### PR TITLE
fix: Remove invalid update-types from dependabot allow block

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,12 +41,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # Only allow security updates for major versions to prevent breaking changes
-    allow:
-      - dependency-type: "direct"
-      - dependency-type: "indirect"
-        update-types: ["security"]
-    # Ignore pre-release versions
+    # Ignore major version updates to prevent breaking changes
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Fixes the Dependabot configuration validation error that was preventing Dependabot from running.

## Changes

- Removed the invalid `allow` block that contained `update-types` property
- The `update-types` property is only valid in `groups` and `ignore` blocks, not in `allow` blocks

## Error Fixed

```
The property '#/updates/1/allow/1' contains additional properties ["update-types"] 
outside of the schema when none are allowed
```

## Testing

- Configuration now passes Dependabot schema validation
- Dependabot will still:
  - Group minor and patch updates together to reduce PR noise
  - Ignore major version updates to prevent breaking changes
  - Update GitHub Actions weekly
  - Update Python dependencies weekly

🤖 Generated with [Claude Code](https://claude.com/claude-code)