### PR TITLE
fix: Skip Codecov upload for Dependabot PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Upload combined coverage to Codecov
         uses: codecov/codecov-action@v5
+        # Don't fail on Dependabot PRs where secrets aren't available
+        if: github.actor != 'dependabot[bot]'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml


### PR DESCRIPTION
## Summary

Fixes the Codecov upload failure on Dependabot PRs (like #16) that was causing CI to fail with:
```
error - Upload failed: {"message":"Token required because branch is protected"}
```

## Problem

Dependabot PRs don't have access to repository secrets by default for security reasons. This causes the coverage workflow to fail when trying to upload to Codecov, even though the CODECOV_TOKEN secret is configured in the repository.

## Solution

Added a conditional check to skip the Codecov upload step for Dependabot PRs:
```yaml
if: github.actor != 'dependabot[bot]'
```

## Impact

- All tests still run for Dependabot PRs
- Coverage uploads work normally for regular PRs and main branch  
- CI no longer fails due to missing secrets on Dependabot PRs
- Dependabot PRs can now be merged without manual intervention

## Testing

This will fix the failing coverage check on all open Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)