### PR TITLE
docs: Add MAC-577 and MAC-567 as confirmed compatible adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ Home Assistant custom integration for **MELCloud Home** - Control Mitsubishi Ele
 
 This integration works with Mitsubishi Electric air conditioning units connected to **MELCloud Home** via compatible Wi-Fi adapters.
 
-**Confirmed Compatible Hardware:**
-- **Wi-Fi Adapter**: MAC-597 (4th-generation, MELCloud Home)
-- **Indoor Units**: MSZ-AY25VGK2 (single-split and multi-split configurations)
+**Confirmed Compatible Wi-Fi Adapters:**
 
-**Not Supported:**
-- Legacy MELCloud adapters (MAC-567, MAC-577, MAC-587) - use the official Home Assistant MELCloud integration instead
+- **MAC-597** (4th-generation, MELCloud Home)
+- **MAC-577** (confirmed working with dual-split systems)
+- **MAC-567** (confirmed working with dual-split systems)
+
+**Confirmed Compatible Indoor Units:**
+
+- **MSZ-AY25VGK2** (single-split and multi-split configurations)
+
+> **Note:** If your adapter appears in the classic **MELCloud** app (not MELCloud Home), use the official Home Assistant MELCloud integration instead.
 
 For a complete list of tested hardware, compatibility notes, and to contribute your device information, see [SUPPORTED_DEVICES.md](SUPPORTED_DEVICES.md).
 
@@ -185,6 +190,7 @@ These intervals balance update frequency with API rate limits.
 [![Coverage Sunburst](https://codecov.io/gh/andrew-blake/melcloudhome/graphs/sunburst.svg?token=WW97CHORNS)](https://codecov.io/gh/andrew-blake/melcloudhome)
 
 **Test Coverage:**
+
 - Integration tests: Climate control, sensors, config flow, diagnostics
 - API tests: Authentication, device control, data parsing
 - Quality gates: All PRs require passing tests and coverage checks

--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -20,15 +20,28 @@ These adapters have been tested with this integration and are known to work with
   - Uses the **MELCloud Home** app / API
   - Tested and working with this integration
 
-### Not supported by this integration
-
-These adapters use the *legacy* MELCloud API, which is handled by the official Home Assistant `melcloud` integration, **not** this one:
+- **MAC‑577**
+  - Wi‑Fi adapter compatible with MELCloud Home
+  - Confirmed working with dual‑split systems
+  - Full model designation: MAC‑577IF‑E
 
 - **MAC‑567**
-- **MAC‑577**
-- **MAC‑587**
+  - Wi‑Fi adapter with Bluetooth variant (MAC‑567IFB‑E)
+  - Confirmed working with dual‑split systems
+  - Full model designations: MAC‑567IF‑E, MAC‑567IFB‑E
 
-If your system uses one of these adapters and appears in the classic MELCloud app, you should use the built‑in Home Assistant **MELCloud** integration instead of this custom integration.
+> **Note:** Model numbers shown are shortened for readability. Full designations include regional suffixes like ‑IF‑E or ‑IFB‑E (Interface Bluetooth).
+
+### Not yet tested
+
+- **MAC‑587** (MAC‑587IF‑E)
+  - Appears to be compatible with MELCloud Home based on product specifications
+  - Not yet confirmed by users of this integration
+  - If you have this adapter and it works, please let us know!
+
+### Legacy MELCloud (not supported)
+
+If your system appears in the **classic MELCloud app** (not MELCloud Home), you should use the built‑in Home Assistant **MELCloud** integration instead of this custom integration.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates supported devices documentation based on user feedback confirming MAC-577 and MAC-567 adapters work with MELCloud Home.

## User Feedback

> Hi Andrew, great work. Thanks a lot. I recently moved my two dualsplit A/C Systems to the new MELCloudHome Servers and can confirm that your integration also works with MAC-577IF-E and MAC-567IFB-E.

## Changes

### SUPPORTED_DEVICES.md
- ✅ Moved **MAC-567** and **MAC-577** to "Confirmed compatible" section
- ✅ Added full model designations (MAC-577IF-E, MAC-567IF-E, MAC-567IFB-E)
- ✅ Added note explaining shortened model numbers for readability
- ✅ Changed **MAC-587** status from "not supported" to "not yet tested"
- ✅ Clarified that only classic MELCloud (not MELCloud Home) is unsupported

### README.md
- ✅ Updated supported adapters list to include MAC-577 and MAC-567
- ✅ Simplified messaging about legacy MELCloud distinction

## Impact

This significantly expands the known compatible hardware and corrects previous misinformation. The adapters were incorrectly listed as "not supported" when they actually work with MELCloud Home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)