### PR TITLE
Fix: Remove unnecessary 3-second session initialization delay

### DIFF
--- a/custom_components/melcloudhome/api/auth.py
+++ b/custom_components/melcloudhome/api/auth.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import os
 import re
 from typing import Any
 from urllib.parse import urlparse
@@ -23,13 +22,10 @@ from .exceptions import AuthenticationError
 _LOGGER = logging.getLogger(__name__)
 
 # Authentication session initialization delay
-# After OAuth completes, Blazor WASM needs time to initialize the session
-# before API endpoints will work. In production this is ~3 seconds.
-# In tests (pytest), we disable this delay because:
-# - VCR cassettes have pre-recorded sessions
-# - Mock server doesn't need Blazor initialization
-# - Reduces test time by ~84 seconds (28 tests x 3s)
-AUTH_SESSION_INIT_DELAY = 0 if os.getenv("PYTEST_CURRENT_TEST") else 3
+# Testing revealed via Chrome DevTools that the session is ready immediately
+# after OAuth redirect. The Blazor WASM app successfully calls /api/user/context
+# without any delay. The original 3-second sleep was unnecessary.
+AUTH_SESSION_INIT_DELAY = 0
 
 
 class MELCloudHomeAuth:


### PR DESCRIPTION
## Summary

Removes the 3-second sleep after OAuth login that was never actually needed. Testing with Chrome DevTools and local dev environment proves the session is ready immediately after OAuth redirect.

## Problem

Every user experienced a mandatory 3-second delay after OAuth completion:
- **100% of users affected** on every login, setup, and reconfiguration
- Assumed to be needed for Blazor WASM session initialization
- No evidence it was actually required - just cargo cult programming

## Investigation

### Chrome DevTools Testing (Production API)

After OAuth redirect to /dashboard, Blazor immediately calls API endpoints with zero delay:
- GET /api/configuration [200] - Success
- GET /bff/user [200] - Success  
- GET /api/user/context [200] - Success (full device data)
- GET /api/user/systeminvites [200] - Success

**Result:** Session works immediately, no initialization delay needed.

### Dev Environment Testing (AUTH_SESSION_INIT_DELAY = 0)

Performed fresh integration setup with delay disabled:
- Integration setup completed successfully
- 7 devices created (6 ATA + 1 ATW)
- 55 entities registered
- First coordinator poll succeeded in 0.309s
- No authentication errors
- No session failures

**Result:** Delay was never necessary.

## Changes

- Set AUTH_SESSION_INIT_DELAY = 0 (was: 0 for tests, 3 for production)
- Update comment to reflect testing findings
- Remove obsolete comments about Blazor initialization delays

## Testing Done

All existing tests continue to pass (already used delay=0).
Verified with production MELCloud API via Chrome DevTools.
Verified with local dev environment (fresh setup with delay=0).

## User Impact

**Before:** Every login took 3+ seconds (3s mandatory delay + OAuth flow)
**After:** Login completes as soon as OAuth finishes (no artificial delay)

Users will experience:
- Faster initial setup (3s faster)
- Faster reauth after credential expiration (3s faster)
- Faster reconfiguration (3s faster)
- No breaking changes or behavioral differences beyond speed improvement

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>