### PR TITLE
chore: Prepare v2.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.2.3] - 2026-04-02
+
+### Added
+
+- German (de) and Thai (th) translations (thanks @thaikolja)
+- Finnish (fi) translations (thanks @zrajna)
+- Portuguese (pt) translations (thanks @tixastronauta)
+
+
 ## [2.2.2] - 2026-04-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 Home Assistant custom integration for **MELCloud Home**.
 
-## What's New in v2.2.2
+## What's New in v2.2.3
 
-Italian (it) translations now available. See [CHANGELOG.md](CHANGELOG.md) for full history.
+Now available in German, Thai, Finnish, and Portuguese — alongside Italian. See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 ## Features
 

--- a/custom_components/melcloudhome/manifest.json
+++ b/custom_components/melcloudhome/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.melcloudhome"
   ],
   "requirements": [],
-  "version": "2.2.2"
+  "version": "2.2.3"
 }


### PR DESCRIPTION
Bump version to v2.2.3, update CHANGELOG and README for German, Thai, Finnish, and Portuguese translations.