### PR TITLE
Prepare for HACS default repository submission

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MELCloud Home
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
+[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
 [![GitHub Release](https://img.shields.io/github/release/andrew-blake/melcloudhome.svg)](https://github.com/andrew-blake/melcloudhome/releases)
 ![License](https://img.shields.io/github/license/andrew-blake/melcloudhome.svg)
 [![Test](https://github.com/andrew-blake/melcloudhome/workflows/Test/badge.svg)](https://github.com/andrew-blake/melcloudhome/actions/workflows/test.yml)

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "MELCloud Home",
+  "render_readme": true,
   "homeassistant": "2024.11.0"
 }


### PR DESCRIPTION
## Summary

Prepares the repository for submission to the [HACS default repository](https://github.com/hacs/default).

## Changes

- **hacs.json**: Add \
ender_readme: true\ so HACS renders the README in the store page
- **validate.yml**: Add \workflow_dispatch\ trigger (recommended by HACS for on-demand validation)
- **README.md**: Update HACS badge from Custom to Default

## Context

All HACS submission requirements are already met:
- [x] Repository structure (\custom_components/melcloudhome/\)
- [x] \manifest.json\ with all required keys
- [x] \hacs.json\ with name
- [x] HACS validation action passing (no \ignore\ keys)
- [x] Hassfest validation action passing
- [x] GitHub releases (v2.2.4)
- [x] Brands in \home-assistant/brands\ repo
- [x] Description, topics, issues enabled

After this is merged and a new release is cut, a PR will be submitted to [hacs/default](https://github.com/hacs/default) to add \ndrew-blake/melcloudhome\ to the \integration\ file.

I already tried to create the hacs PR https://github.com/hacs/default/pull/6728 but it failes because I'm not a major contributor to this repo.