### PR TITLE
chore: Prepare v2.2.5 release

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.2.5] - 2026-04-04
+
+### Added
+
+- Swedish (sv) translations (thanks @MHultman)
+- HACS default repository preparation: render_readme, workflow_dispatch validation trigger (thanks @sginestrini)
+
+
 ## [2.2.4] - 2026-04-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 Home Assistant custom integration for **MELCloud Home**.
 
-## What's New in v2.2.4
+## What's New in v2.2.5
 
-Now available in Spanish — bringing MELCloud Home to 7 languages. See [CHANGELOG.md](CHANGELOG.md) for full history.
+Now available in 8 languages with Swedish added. Prepared for HACS default repository submission. See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 ## Features
 

--- a/custom_components/melcloudhome/manifest.json
+++ b/custom_components/melcloudhome/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.melcloudhome"
   ],
   "requirements": [],
-  "version": "2.2.4"
+  "version": "2.2.5"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "MELCloud Home",
+  "render_readme": true,
   "homeassistant": "2024.11.0"
 }


### PR DESCRIPTION
## Summary

- Swedish (sv) translations (thanks @MHultman, PR #79)
- HACS default repository preparation (thanks @sginestrini, PR #80 -- badge change deferred until accepted)
- Bump version to 2.2.5

Incorporates changes from #80 (minus the premature badge update). Closes #80.