### PR TITLE
fix: correct SECURITY.md credential storage description

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ Security updates are provided for the current stable release:
 | Version | Supported          |
 | ------- | ------------------ |
 | Latest  | :white_check_mark: |
-| < 1.3   | :x:                |
+| Older   | :x:                |
 
 Please ensure you're running the latest version before reporting vulnerabilities.
 
@@ -79,7 +79,7 @@ When using this integration:
 
 - This integration uses cloud polling and does not expose local network services
 - All API communication uses HTTPS
-- Credentials are stored securely by Home Assistant's credential storage system
+- Credentials are stored in Home Assistant's config entry storage on the local filesystem — securing the host machine is important
 - No user data is collected or transmitted beyond what's required for MELCloud API communication
 
 ## Questions?


### PR DESCRIPTION
## Summary

- Fix inaccurate claim that credentials use HA's "secure credential storage system" — they're stored as plain JSON in config entry storage, same as every other integration
- Fix stale version table (`< 1.3` → `Older`)

## Context

Investigated #91 (migrate to HA credential store) and found HA doesn't offer an encrypted store for user passwords or rotating OAuth tokens. The `entry.data` pattern is standard across all integrations. Closing #91 as won't-do.

## Test plan

- [ ] Review SECURITY.md reads accurately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
