### PR TITLE
Release v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [2.3.1] - 2026-04-19
+## [2.3.1] - 2026-04-20
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ These intervals balance update frequency with API rate limits.
 
 - [Architecture Overview](docs/architecture.md) - Visual system architecture with mermaid diagrams
 - [Testing Best Practices](docs/testing-best-practices.md) - Development setup and testing guidelines
-- [Architecture Decision Records](docs/README.md#architecture-decision-records-adrs) - Key architectural decisions (ADR-001 through ADR-016)
+- [Architecture Decision Records](docs/README.md#architecture-decision-records-adrs) - Key architectural decisions
 
 ## Support
 


### PR DESCRIPTION
Graduates v2.3.1-beta.1 → stable. Fixes #100 (vertical swing "Swing" silently dropped on ATA units without horizontal vanes).

Reporter confirmed the beta fix works; no regressions in prod testing.

Diff: CHANGELOG date bump + stale ADR range removed from README.