### PR TITLE
chore: release v2.3.2 (Greek translation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.3.2] - 2026-04-22
+
+### Added
+
+- Greek (el) translations (thanks @h-ram)
+
+
 ## [2.3.1] - 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 Home Assistant custom integration for **MELCloud Home**.
 
-## What's New in v2.3.1
+## What's New in v2.3.2
 
-Fixed vertical swing mode "Swing" being silently ignored on A/C units without horizontal vanes. See [CHANGELOG.md](CHANGELOG.md) for full history.
+Added Greek (el) translations (thanks @h-ram). See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 ## Features
 

--- a/custom_components/melcloudhome/manifest.json
+++ b/custom_components/melcloudhome/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.melcloudhome"
   ],
   "requirements": [],
-  "version": "2.3.1"
+  "version": "2.3.2"
 }


### PR DESCRIPTION
## Summary

- Bumps manifest version 2.3.1 → 2.3.2
- CHANGELOG entry for Greek (el) translations (#106)
- README "What's New" updated to v2.3.2

Patch bump — translation-only release, follows v2.2.5 (Swedish-only) precedent.

## Test plan

- [x] pre-commit green
- [ ] release workflow validates README + CHANGELOG
- [ ] CI green