### PR TITLE
docs: add new MSZ-HR models to SUPPORTED_DEVICES.md

### DIFF
--- a/SUPPORTED_DEVICES.md
+++ b/SUPPORTED_DEVICES.md
@@ -41,6 +41,8 @@ Air-to-Air systems are air conditioning units (wall-mounted, ducted, or console)
 | MSZ-AY35VKGP | MAC-577 | Wall split | |
 | MSZ-AY42VKGP | MAC-577 | Wall split | |
 | MSZ-AY50VGK | MAC-587 | Wall split | Energy tracking works |
+| MSZ-HR25VFK2 | MAC-597 | Wall split | |
+| MSZ-HR35VFK | MAC-577 | Wall split | |
 | MSZ-LN25VGWRAC | MAC-587 | Wall split | Multi-split |
 | MSZ-LN35VG2B | MAC-597 | Wall split | |
 | MFZ-KT50VG | MAC-587 | Console | |


### PR DESCRIPTION
## Summary

Updates supported devices documentation with new hardware that I just verified myself.

## New Confirmations (Apr 29, 2026)

### Indoor Units  
✅ **MSZ-HR25VFK2**
- Adapter: MAC-597

✅ **MSZ-HR35VFK**
- Reported by: HansOtten
- Adapter: MAC-577

## Changes

**SUPPORTED_DEVICES.md:**
- Added MSZ-HR25VFK2 and MSZ-HR35VFK to tested indoor units