### PR TITLE
security: harden CI workflows with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    cooldown:
+      default-days: 7
 
   # Python dependencies (pyproject.toml)
   - package-ecosystem: "pip"
@@ -47,3 +49,5 @@ updates:
         update-types: ["version-update:semver-major"]
     # Keep development tools up to date more aggressively
     versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       - 'v*.*.*-*'  # Match pre-release tags (e.g., v2.0.0-beta.1)
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   validate:
@@ -18,7 +18,9 @@ jobs:
       base_version: ${{ steps.base-version.outputs.base }}
       prerelease: ${{ steps.detect-prerelease.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Get version from tag
         id: get-version
@@ -30,15 +32,17 @@ jobs:
       - name: Get base version (strip pre-release suffix)
         id: base-version
         run: |
-          TAG_VERSION="${{ steps.get-version.outputs.version }}"
+          TAG_VERSION="${STEPS_GET_VERSION_OUTPUTS_VERSION}"
           BASE_VERSION=$(echo "$TAG_VERSION" | sed 's/-.*//')
           echo "base=$BASE_VERSION" >> $GITHUB_OUTPUT
           echo "Base version: $BASE_VERSION (from tag: $TAG_VERSION)"
+        env:
+          STEPS_GET_VERSION_OUTPUTS_VERSION: ${{ steps.get-version.outputs.version }}
 
       - name: Validate manifest version
         run: |
           MANIFEST_VERSION=$(jq -r '.version' custom_components/melcloudhome/manifest.json)
-          BASE_VERSION="${{ steps.base-version.outputs.base }}"
+          BASE_VERSION="${STEPS_BASE_VERSION_OUTPUTS_BASE}"
           echo "Manifest version: $MANIFEST_VERSION"
           echo "Expected version: $BASE_VERSION"
           if [ "$MANIFEST_VERSION" != "$BASE_VERSION" ]; then
@@ -47,19 +51,23 @@ jobs:
             exit 1
           fi
           echo "✅ Versions match!"
+        env:
+          STEPS_BASE_VERSION_OUTPUTS_BASE: ${{ steps.base-version.outputs.base }}
 
       - name: Validate CHANGELOG entry
         run: |
-          BASE_VERSION="${{ steps.base-version.outputs.base }}"
+          BASE_VERSION="${STEPS_BASE_VERSION_OUTPUTS_BASE}"
           if ! grep -q "\[$BASE_VERSION\]" CHANGELOG.md; then
             echo "❌ No CHANGELOG entry found for version $BASE_VERSION"
             exit 1
           fi
           echo "✅ CHANGELOG entry found!"
+        env:
+          STEPS_BASE_VERSION_OUTPUTS_BASE: ${{ steps.base-version.outputs.base }}
 
       - name: Validate README "What's New" version
         run: |
-          BASE_VERSION="${{ steps.base-version.outputs.base }}"
+          BASE_VERSION="${STEPS_BASE_VERSION_OUTPUTS_BASE}"
           README_VERSION=$(grep "## What's New in v" README.md | sed -n 's/## What'\''s New in v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p')
           echo "README 'What's New' version: $README_VERSION"
           echo "Expected version: $BASE_VERSION"
@@ -73,11 +81,13 @@ jobs:
             exit 1
           fi
           echo "✅ README version matches!"
+        env:
+          STEPS_BASE_VERSION_OUTPUTS_BASE: ${{ steps.base-version.outputs.base }}
 
       - name: Detect pre-release
         id: detect-prerelease
         run: |
-          TAG_VERSION="${{ steps.get-version.outputs.version }}"
+          TAG_VERSION="${STEPS_GET_VERSION_OUTPUTS_VERSION}"
           if echo "$TAG_VERSION" | grep -qE '\-(alpha|beta|rc)\.'; then
             echo "prerelease=true" >> $GITHUB_OUTPUT
             echo "✅ Pre-release detected: $TAG_VERSION"
@@ -85,16 +95,22 @@ jobs:
             echo "prerelease=false" >> $GITHUB_OUTPUT
             echo "✅ Stable release detected: $TAG_VERSION"
           fi
+        env:
+          STEPS_GET_VERSION_OUTPUTS_VERSION: ${{ steps.get-version.outputs.version }}
 
   test:
     name: Run Full Test Suite
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -118,13 +134,17 @@ jobs:
     name: Create GitHub Release
     needs: [validate, test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Extract release notes
         id: extract-notes
         run: |
-          VERSION="${{ needs.validate.outputs.base_version }}"
+          VERSION="${NEEDS_VALIDATE_OUTPUTS_BASE_VERSION}"
 
           # Extract section between current version and next version heading
           # Using sed for better portability across awk implementations
@@ -140,9 +160,11 @@ jobs:
 
           echo "Release notes extracted:"
           cat release_notes.txt
+        env:
+          NEEDS_VALIDATE_OUTPUTS_BASE_VERSION: ${{ needs.validate.outputs.base_version }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3.0.0
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           body_path: release_notes.txt
           draft: false
@@ -153,12 +175,15 @@ jobs:
 
       - name: Release summary
         run: |
-          if [ "${{ needs.validate.outputs.prerelease }}" == "true" ]; then
+          if [ "${NEEDS_VALIDATE_OUTPUTS_PRERELEASE}" == "true" ]; then
             RELEASE_TYPE="Pre-release"
           else
             RELEASE_TYPE="Stable Release"
           fi
-          echo "## 🚀 $RELEASE_TYPE ${{ needs.validate.outputs.version }} Published!" >> $GITHUB_STEP_SUMMARY
+          echo "## 🚀 $RELEASE_TYPE ${NEEDS_VALIDATE_OUTPUTS_VERSION} Published!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Release Notes" >> $GITHUB_STEP_SUMMARY
           cat release_notes.txt >> $GITHUB_STEP_SUMMARY
+        env:
+          NEEDS_VALIDATE_OUTPUTS_PRERELEASE: ${{ needs.validate.outputs.prerelease }}
+          NEEDS_VALIDATE_OUTPUTS_VERSION: ${{ needs.validate.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,11 @@ jobs:
     name: Lint & Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - name: Set up Python
         run: uv python install 3.13
       - name: Install dependencies
@@ -32,9 +34,11 @@ jobs:
     name: Run All Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       - name: Set up Python
         run: uv python install 3.13
       - name: Install dependencies
@@ -42,7 +46,7 @@ jobs:
       - name: Run all tests
         run: make test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         if: github.actor != 'dependabot[bot]'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,12 +17,14 @@ jobs:
     runs-on: "ubuntu-latest"
     name: Validate
     steps:
-      - uses: "actions/checkout@v6"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: HACS validation
-        uses: "hacs/action@main"
+        uses: "hacs/action@dcb30e72781db3f207d5236b861172774ab0b485" # main
         with:
           category: "integration"
 
       - name: Hassfest validation
-        uses: "home-assistant/actions/hassfest@master"
+        uses: "home-assistant/actions/hassfest@f6f29a7ee3fa0eccadf3620a7b9ee00ab54ec03b" # master

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 1"  # Weekly on Monday
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions references to commit SHAs to prevent supply chain attacks
- Scope `contents: write` in `release.yml` to the `release` job only (was workflow-wide)
- Move `steps.outputs` and `needs.outputs` expansions into `env:` vars to eliminate template injection surface
- Add `persist-credentials: false` to all `actions/checkout` steps
- Add 7-day cooldown to both Dependabot ecosystems
- Add `zizmor.yml` workflow for ongoing GitHub Actions security scanning (SARIF → Code Scanning tab)

Identified and fixed using [zizmor](https://github.com/zizmorcore/zizmor) — 0 high-severity findings after changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)