### PR TITLE
security: replace softprops/action-gh-release with gh CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,14 +164,15 @@ jobs:
           NEEDS_VALIDATE_OUTPUTS_BASE_VERSION: ${{ needs.validate.outputs.base_version }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          body_path: release_notes.txt
-          draft: false
-          prerelease: ${{ needs.validate.outputs.prerelease == 'true' }}
-          generate_release_notes: false
+        run: |
+          if [ "${NEEDS_VALIDATE_OUTPUTS_PRERELEASE}" == "true" ]; then
+            gh release create "${GITHUB_REF_NAME}" --notes-file release_notes.txt --prerelease
+          else
+            gh release create "${GITHUB_REF_NAME}" --notes-file release_notes.txt
+          fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEEDS_VALIDATE_OUTPUTS_PRERELEASE: ${{ needs.validate.outputs.prerelease }}
 
       - name: Release summary
         run: |


### PR DESCRIPTION
Closes the open Code Scanning alert (#16).

`gh` is pre-installed on all GitHub Actions runners, so there's no need for a third-party action to create releases. This removes the `softprops/action-gh-release` dependency entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
