### PR TITLE
chore: release v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Vietnamese (vi) translations (thanks @0jar)
+- Confirmed support for MSZ-HR25VFK2 and MSZ-HR35VFK indoor units (thanks @FerranMartin and @HansOtten)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [2.3.3] - 2026-04-28
+## [2.3.3] - 2026-06-04
+
+### Added
+
+- Vietnamese (vi) translations (thanks @0jar)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Home Assistant custom integration for **MELCloud Home**.
 
 ## What's New in v2.3.3
 
-Fixed outdoor temperature sensor stuck `unavailable` for mostly-idle units. See [CHANGELOG.md](CHANGELOG.md) for full history.
+Fixed outdoor temperature sensor stuck `unavailable` for mostly-idle units. Vietnamese translations added. See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 ## Features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "aiohttp>=3.13.2",
+    "aiohttp>=3.13.2,<3.14",  # TODO: remove upper bound once vcrpy >8.1.1 released (see issue #124)
     "aiohttp-cors>=0.8.1",
     "playwright>=1.56.0",
 ]


### PR DESCRIPTION
## Summary

- Vietnamese (vi) translations (@0jar, #121)
- Outdoor temperature sensor fix (promoted from beta v2.3.3-beta.1)
- Pins `aiohttp<3.14` temporarily — aiohttp 3.14.0 breaks vcrpy's stubs; tracked in #124

## Pre-release checklist

- [x] `manifest.json` version: `2.3.3`
- [x] `CHANGELOG.md` entry with date
- [x] `README.md` "What's New" updated

## After merge

```bash
git checkout main && git pull
git tag -a v2.3.3 -m "v2.3.3 - Vietnamese translations, outdoor temperature fix"
git push origin v2.3.3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)