### PR TITLE
fix(ata): send power and mode atomically to prevent multi-zone fault

### DIFF
--- a/custom_components/melcloudhome/api/client.py
+++ b/custom_components/melcloudhome/api/client.py
@@ -184,6 +184,8 @@ class MELCloudHomeClient:
                 url = f"{self._base_url}{endpoint}"
 
                 _LOGGER.debug("API Request: %s %s", method, endpoint)
+                if kwargs.get("json") is not None:
+                    _LOGGER.debug("API Request payload: %s", kwargs["json"])
 
                 async with session.request(
                     method, url, headers=headers, **kwargs

--- a/custom_components/melcloudhome/api/client_ata.py
+++ b/custom_components/melcloudhome/api/client_ata.py
@@ -79,6 +79,36 @@ class ATAControlClient:
             json=payload,
         )
 
+    async def set_power_and_mode(self, unit_id: str, power: bool, mode: str) -> None:
+        """
+        Turn device on/off and set operation mode in a single atomic API call.
+
+        Sending power and mode together avoids the window where a power-on with
+        operationMode=null can be misinterpreted by the outdoor unit as a mode
+        conflict, which causes fault/flashing on multi-zone systems.
+
+        Args:
+            unit_id: Device ID (UUID)
+            power: True to turn on, False to turn off
+            mode: Operation mode - "Heat", "Cool", "Automatic", "Dry", or "Fan"
+
+        Raises:
+            AuthenticationError: If not authenticated
+            ApiError: If API request fails
+            ValueError: If mode is invalid
+        """
+        valid_modes = set(OPERATION_MODES)
+        if mode not in valid_modes:
+            raise ValueError(f"Invalid mode: {mode}. Must be one of {valid_modes}")
+
+        payload = self._build_ata_control_payload(power=power, operationMode=mode)
+
+        await self._client._api_request(
+            "PUT",
+            API_CONTROL_UNIT.format(unit_id=unit_id),
+            json=payload,
+        )
+
     async def set_temperature(self, unit_id: str, temperature: float) -> None:
         """
         Set target temperature.

--- a/custom_components/melcloudhome/api/client_ata.py
+++ b/custom_components/melcloudhome/api/client_ata.py
@@ -59,6 +59,12 @@ class ATAControlClient:
         payload.update(updates)
         return payload
 
+    def _validate_mode(self, mode: str) -> None:
+        """Raise ValueError if mode is not a valid OPERATION_MODES entry."""
+        valid_modes = set(OPERATION_MODES)
+        if mode not in valid_modes:
+            raise ValueError(f"Invalid mode: {mode}. Must be one of {valid_modes}")
+
     async def set_power(self, unit_id: str, power: bool) -> None:
         """
         Turn device on or off.
@@ -97,9 +103,7 @@ class ATAControlClient:
             ApiError: If API request fails
             ValueError: If mode is invalid
         """
-        valid_modes = set(OPERATION_MODES)
-        if mode not in valid_modes:
-            raise ValueError(f"Invalid mode: {mode}. Must be one of {valid_modes}")
+        self._validate_mode(mode)
 
         payload = self._build_ata_control_payload(power=power, operationMode=mode)
 
@@ -152,9 +156,7 @@ class ATAControlClient:
             ApiError: If API request fails
             ValueError: If mode is invalid
         """
-        valid_modes = set(OPERATION_MODES)
-        if mode not in valid_modes:
-            raise ValueError(f"Invalid mode: {mode}. Must be one of {valid_modes}")
+        self._validate_mode(mode)
 
         payload = self._build_ata_control_payload(operationMode=mode)
 

--- a/custom_components/melcloudhome/climate_ata.py
+++ b/custom_components/melcloudhome/climate_ata.py
@@ -203,13 +203,12 @@ class ATAClimate(ATAEntityBase, ClimateEntity):  # type: ignore[misc]
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new HVAC mode."""
         if hvac_mode == HVACMode.OFF:
-            # Turn off the device
             await self.coordinator.async_set_power(self._unit_id, False)
         else:
-            # Turn on and set mode
-            await self.coordinator.async_set_power(self._unit_id, True)
             melcloud_mode = HA_HVAC_MODE_TO_ATA[hvac_mode]
-            await self.coordinator.async_set_mode(self._unit_id, melcloud_mode)
+            await self.coordinator.async_set_power_and_mode(
+                self._unit_id, True, melcloud_mode
+            )
 
     @with_debounced_refresh()
     async def async_set_temperature(self, **kwargs: Any) -> None:

--- a/custom_components/melcloudhome/climate_ata.py
+++ b/custom_components/melcloudhome/climate_ata.py
@@ -254,7 +254,13 @@ class ATAClimate(ATAEntityBase, ClimateEntity):  # type: ignore[misc]
     @with_debounced_refresh()
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
-        await self.coordinator.async_set_power(self._unit_id, True)
+        device = self.get_device()
+        if device and device.operation_mode:
+            await self.coordinator.async_set_power_and_mode(
+                self._unit_id, True, device.operation_mode
+            )
+        else:
+            await self.coordinator.async_set_power(self._unit_id, True)
 
     @with_debounced_refresh()
     async def async_turn_off(self) -> None:

--- a/custom_components/melcloudhome/control_client_ata.py
+++ b/custom_components/melcloudhome/control_client_ata.py
@@ -57,6 +57,16 @@ class ATAControlClient(ControlClientBase):
         a unit on to a specific mode, to avoid the operationMode=null window that
         can trigger a mode-conflict fault on multi-zone outdoor units.
         """
+        device = self._get_device(unit_id)
+        if device and device.power == power and device.operation_mode == mode:
+            _LOGGER.debug(
+                "Power already %s and mode already %s for %s, skipping API call",
+                power,
+                mode,
+                unit_id[-8:],
+            )
+            return
+
         _LOGGER.info(
             "Setting power+mode for %s to power=%s mode=%s", unit_id[-8:], power, mode
         )

--- a/custom_components/melcloudhome/control_client_ata.py
+++ b/custom_components/melcloudhome/control_client_ata.py
@@ -48,6 +48,23 @@ class ATAControlClient(ControlClientBase):
         self._get_device = get_device
         self._async_request_refresh = async_request_refresh
 
+    async def async_set_power_and_mode(
+        self, unit_id: str, power: bool, mode: str
+    ) -> None:
+        """Set power state and operation mode atomically in a single API call.
+
+        Use this instead of separate async_set_power + async_set_mode when turning
+        a unit on to a specific mode, to avoid the operationMode=null window that
+        can trigger a mode-conflict fault on multi-zone outdoor units.
+        """
+        _LOGGER.info(
+            "Setting power+mode for %s to power=%s mode=%s", unit_id[-8:], power, mode
+        )
+        await self._execute_with_retry(
+            lambda: self._client.ata.set_power_and_mode(unit_id, power, mode),
+            f"set_power_and_mode({unit_id}, {power}, {mode})",
+        )
+
     async def async_set_power(self, unit_id: str, power: bool) -> None:
         """Set power state with automatic session recovery.
 

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -552,6 +552,14 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
     # Air-to-Air (A2A) Control Methods - Delegate to ATAControlClient
     # =================================================================
 
+    async def async_set_power_and_mode(
+        self, unit_id: str, power: bool, mode: str
+    ) -> None:
+        """Set power state and operation mode atomically."""
+        return await self.control_client_ata.async_set_power_and_mode(
+            unit_id, power, mode
+        )
+
     async def async_set_power(self, unit_id: str, power: bool) -> None:
         """Set power state with automatic session recovery."""
         return await self.control_client_ata.async_set_power(unit_id, power)

--- a/custom_components/melcloudhome/protocols.py
+++ b/custom_components/melcloudhome/protocols.py
@@ -106,6 +106,18 @@ class CoordinatorProtocol(Protocol):
         """
         ...
 
+    async def async_set_power_and_mode(
+        self, unit_id: str, power: bool, mode: str
+    ) -> None:
+        """Set power state and operation mode atomically for ATA unit.
+
+        Args:
+            unit_id: ATA unit ID
+            power: True to turn on, False to turn off
+            mode: Operation mode (e.g., "Heat", "Cool", "Automatic", "Dry", "Fan")
+        """
+        ...
+
     async def async_set_temperature(self, unit_id: str, temperature: float) -> None:
         """Set target temperature for ATA unit.
 

--- a/tests/api/test_client_validation.py
+++ b/tests/api/test_client_validation.py
@@ -167,6 +167,50 @@ class TestModeValidation:
             await client.ata.set_mode("unit-id", "Fan")
 
 
+class TestPowerAndModeValidation:
+    """Test set_power_and_mode parameter validation."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_mode_raises(self) -> None:
+        """Invalid mode should raise ValueError before hitting the API."""
+        client = MELCloudHomeClient()
+
+        with pytest.raises(ValueError, match=r"Invalid mode.*Must be one of"):
+            await client.ata.set_power_and_mode("unit-id", True, "InvalidMode")
+
+    @pytest.mark.asyncio
+    async def test_lowercase_mode_raises(self) -> None:
+        """Lowercase mode should raise ValueError (case-sensitive)."""
+        client = MELCloudHomeClient()
+
+        with pytest.raises(ValueError, match="Invalid mode"):
+            await client.ata.set_power_and_mode("unit-id", True, "heat")
+
+    @pytest.mark.asyncio
+    async def test_valid_mode_heat_passes_validation(self) -> None:
+        """Valid mode 'Heat' should pass validation (fail on auth, not ValueError)."""
+        client = MELCloudHomeClient()
+
+        with pytest.raises(AuthenticationError, match="Not authenticated"):
+            await client.ata.set_power_and_mode("unit-id", True, "Heat")
+
+    @pytest.mark.asyncio
+    async def test_valid_mode_cool_passes_validation(self) -> None:
+        """Valid mode 'Cool' should pass validation."""
+        client = MELCloudHomeClient()
+
+        with pytest.raises(AuthenticationError, match="Not authenticated"):
+            await client.ata.set_power_and_mode("unit-id", True, "Cool")
+
+    @pytest.mark.asyncio
+    async def test_power_off_with_valid_mode(self) -> None:
+        """Power=False with valid mode should pass validation."""
+        client = MELCloudHomeClient()
+
+        with pytest.raises(AuthenticationError, match="Not authenticated"):
+            await client.ata.set_power_and_mode("unit-id", False, "Heat")
+
+
 class TestFanSpeedValidation:
     """Test fan speed parameter validation."""
 

--- a/tests/integration/test_climate_ata.py
+++ b/tests/integration/test_climate_ata.py
@@ -103,6 +103,7 @@ async def setup_integration(hass: HomeAssistant) -> MockConfigEntry:
         mock_client.ata = MagicMock()
         mock_client.ata.set_power = AsyncMock()
         mock_client.ata.set_mode = AsyncMock()
+        mock_client.ata.set_power_and_mode = AsyncMock()
         mock_client.ata.set_temperature = AsyncMock()
         mock_client.ata.set_fan_speed = AsyncMock()
         mock_client.ata.set_vane_vertical = AsyncMock()

--- a/tests/integration/test_climate_ata.py
+++ b/tests/integration/test_climate_ata.py
@@ -166,6 +166,59 @@ async def test_set_hvac_mode_to_cool(
 
 
 @pytest.mark.asyncio
+async def test_set_hvac_mode_noop_when_already_matches(
+    hass: HomeAssistant,
+) -> None:
+    """Test that set_hvac_mode is a no-op when power+mode already match device state.
+
+    The unit starts: power=True, operation_mode="Heat".
+    HA_HVAC_MODE_TO_ATA[HVACMode.HEAT] == "Heat", so the guard fires and no
+    API call is made.
+    """
+    mock_unit = create_mock_unit(power=True, operation_mode="Heat")
+    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
+
+    with patch(MOCK_CLIENT_PATH) as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_client.ata = MagicMock()
+        mock_client.ata.set_power = AsyncMock()
+        mock_client.ata.set_mode = AsyncMock()
+        mock_client.ata.set_power_and_mode = AsyncMock()
+        mock_client.ata.set_temperature = AsyncMock()
+        mock_client.ata.set_fan_speed = AsyncMock()
+        mock_client.ata.set_vane_vertical = AsyncMock()
+        mock_client.ata.set_vane_horizontal = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            "climate",
+            "set_hvac_mode",
+            {
+                "entity_id": "climate.melcloudhome_0efc_9abc_climate",
+                "hvac_mode": HVACMode.HEAT,
+            },
+            blocking=True,
+        )
+
+        # Guard should fire — no API write made
+        mock_client.ata.set_power_and_mode.assert_not_called()
+        mock_client.ata.set_power.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_set_hvac_mode_off_turns_device_off(
     hass: HomeAssistant, setup_integration: MockConfigEntry
 ) -> None:

--- a/tests/integration/test_climate_ata.py
+++ b/tests/integration/test_climate_ata.py
@@ -219,6 +219,55 @@ async def test_set_hvac_mode_noop_when_already_matches(
 
 
 @pytest.mark.asyncio
+async def test_turn_on_uses_atomic_power_and_mode(
+    hass: HomeAssistant,
+) -> None:
+    """Test that turn_on sends power+mode atomically, not power alone.
+
+    Sending power=True without operationMode triggers the multi-zone outdoor
+    unit fault. async_turn_on must use set_power_and_mode with the current mode.
+    """
+    mock_unit = create_mock_unit(power=False, operation_mode="Heat")
+    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
+
+    with patch(MOCK_CLIENT_PATH) as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_client.ata = MagicMock()
+        mock_client.ata.set_power = AsyncMock()
+        mock_client.ata.set_mode = AsyncMock()
+        mock_client.ata.set_power_and_mode = AsyncMock()
+        mock_client.ata.set_temperature = AsyncMock()
+        mock_client.ata.set_fan_speed = AsyncMock()
+        mock_client.ata.set_vane_vertical = AsyncMock()
+        mock_client.ata.set_vane_horizontal = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            "climate",
+            "turn_on",
+            {"entity_id": "climate.melcloudhome_0efc_9abc_climate"},
+            blocking=True,
+        )
+
+        # Must use set_power_and_mode, not bare set_power
+        mock_client.ata.set_power_and_mode.assert_called_once()
+        mock_client.ata.set_power.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_set_hvac_mode_off_turns_device_off(
     hass: HomeAssistant, setup_integration: MockConfigEntry
 ) -> None:


### PR DESCRIPTION
Closes #132

## Summary

- Fixes intermittent fault/flashing on multi-zone mini-split systems (one outdoor unit, multiple indoor units) when turning on via HA
- `async_set_hvac_mode` and `async_turn_on` both send power and mode in a single atomic API call — closing the bypass where the `turn_on` service (automations, dashboard power button) could still trigger the fault
- Adds payload debug logging to `_api_request` for diagnosing API call contents

## Root Cause

When setting HVAC mode on a powered-off unit, the previous code sent two separate API calls:

1. `{power: true, operationMode: null}` — power-on with no mode
2. `{power: null, operationMode: 'Cool'}` — mode set ~0.5s later

On a multi-zone system, this created a window where the outdoor unit had already committed to Cool mode for the first indoor unit, then received a null-mode power-on signal from the second unit. The outdoor unit interpreted this as a mode conflict and tripped its protection logic, causing the second unit to flash.

## Changes

**`api/client_ata.py`** — new `set_power_and_mode()` method sending `{power, operationMode}` atomically

**`control_client_ata.py`** — new `async_set_power_and_mode()` wiring it through with retry/logging

**`coordinator.py`** — delegation method

**`climate_ata.py`** — `async_set_hvac_mode` and `async_turn_on` both use the atomic call

**`api/client.py`** — debug log for request payload body (only fires for PUT/POST, not GET)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)