### PR TITLE
ci: enable codecov upload for Dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,6 @@ jobs:
         run: make test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: github.actor != 'dependabot[bot]'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}  # zizmor: ignore[secrets-outside-env]
           files: ./coverage.xml


### PR DESCRIPTION
Removes the `if: github.actor != 'dependabot[bot]'` guard from the codecov upload step. This was blocking auto-merge on workflow-only Dependabot PRs because `codecov/patch` (a required check) never posted — codecov only posts when it receives an upload.

`CODECOV_TOKEN` has been added to the Dependabot secrets store so the token resolves correctly during Dependabot-triggered runs. This is the [approach recommended by Codecov](https://github.com/codecov/codecov-action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)