### PR TITLE
chore(atw): remove debug artifacts and consolidate test setup boilerplate

### DIFF
--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -203,18 +203,7 @@ class AirToWaterUnit:
 
         This method parses the settings array and handles type conversions.
         """
-        # DEBUG: Log raw API data for ATW unit
-        import json
-
         settings_list = data.get("settings", [])
-        unit_id = data.get("id", "unknown")
-        unit_name = data.get("givenDisplayName", "Unknown")
-        _LOGGER.debug(
-            "[ATW %s '%s'] Raw API settings: %s",
-            unit_id[:8],
-            unit_name,
-            json.dumps(settings_list, indent=2),
-        )
 
         # Parse capabilities
         capabilities_data = data.get("capabilities", {})
@@ -255,18 +244,6 @@ class AirToWaterUnit:
         )
         operation_mode_zone2 = settings.get("OperationModeZone2") if has_zone2 else None
         power = _parse_bool(settings.get("Power"))
-
-        # DEBUG: Log operation status vs zone modes when system is active
-        # This helps us understand if OperationMode contains generic values ("Heating")
-        # or zone-specific values ("HeatFlowTemperature")
-        if power and operation_status != ATW_STATUS_STOP:
-            _LOGGER.debug(
-                "[ATW %s] OperationMode='%s' | Zone1Mode='%s' | Zone2Mode='%s'",
-                data.get("id", "unknown")[:8],
-                operation_status,
-                operation_mode_zone1,
-                operation_mode_zone2,
-            )
 
         return cls(
             # Identity

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,8 @@
 These fixtures require pytest-homeassistant-custom-component.
 """
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -232,6 +233,44 @@ async def setup_atw_integration(hass: "HomeAssistant") -> "MockConfigEntry":
         mock_client.atw.set_mode_zone1 = AsyncMock()
         mock_client.atw.set_dhw_temperature = AsyncMock()
         mock_client.atw.set_forced_hot_water = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        return entry
+
+
+async def setup_atw_integration_custom(
+    hass: "HomeAssistant",
+    mock_context: Any,
+    *,
+    configure_client: Callable[..., None] | None = None,
+) -> "MockConfigEntry":
+    """Set up ATW integration with a custom mock context.
+
+    Use this when tests need specific unit data. Pass configure_client to
+    add mock methods (e.g., energy API) before setup completes.
+    """
+    from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.melcloudhome.const import DOMAIN
+
+    with patch(MOCK_CLIENT_PATH) as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        if configure_client is not None:
+            configure_client(mock_client)
 
         entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/integration/test_sensor_atw.py
+++ b/tests/integration/test_sensor_atw.py
@@ -7,14 +7,11 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, PropertyMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.melcloudhome.const import DOMAIN
 
 from .conftest import (
     TEST_SENSOR_COP,
@@ -24,10 +21,9 @@ from .conftest import (
     create_mock_atw_energy_response,
     create_mock_atw_unit,
     create_mock_atw_user_context,
+    setup_atw_integration_custom,
 )
 
-# Mock at API boundary (NOT coordinator or sensor classes)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
 MOCK_STORE_PATH = "custom_components.melcloudhome.energy_tracker_base.Store"
 
 
@@ -38,27 +34,11 @@ async def test_atw_zone_1_temperature_sensor_created(hass: HomeAssistant) -> Non
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check Zone 1 temperature sensor exists
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
-        assert state is not None
-        assert float(state.state) == 20.5
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
+    assert state is not None
+    assert float(state.state) == 20.5
 
 
 @pytest.mark.asyncio
@@ -68,27 +48,11 @@ async def test_atw_tank_temperature_sensor_created(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check tank temperature sensor exists
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
-        assert state is not None
-        assert float(state.state) == 48.5
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
+    assert state is not None
+    assert float(state.state) == 48.5
 
 
 @pytest.mark.asyncio
@@ -98,27 +62,11 @@ async def test_atw_operation_status_sensor_created(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check operation status sensor exists
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
-        assert state is not None
-        assert state.state == "HotWater"
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
+    assert state is not None
+    assert state.state == "HotWater"
 
 
 @pytest.mark.asyncio
@@ -128,26 +76,11 @@ async def test_atw_operation_status_shows_raw_api_value(hass: HomeAssistant) -> 
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
-        # Raw API value, not mapped
-        assert state.state == "Heating"
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
+    # Raw API value, not mapped
+    assert state.state == "Heating"
 
 
 @pytest.mark.asyncio
@@ -159,29 +92,13 @@ async def test_atw_sensor_unavailable_when_temp_none(hass: HomeAssistant) -> Non
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    zone_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
+    tank_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Temperature sensors should be unavailable when data is None
-        zone_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
-        tank_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
-
-        assert zone_temp.state == "unavailable"
-        assert tank_temp.state == "unavailable"
+    assert zone_temp.state == "unavailable"
+    assert tank_temp.state == "unavailable"
 
 
 @pytest.mark.asyncio
@@ -193,31 +110,15 @@ async def test_atw_sensors_unavailable_when_device_in_error(
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    zone_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
+    tank_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
+    operation = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # All ATW sensors should be unavailable
-        zone_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
-        tank_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
-        operation = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
-
-        assert zone_temp.state == "unavailable"
-        assert tank_temp.state == "unavailable"
-        assert operation.state == "unavailable"
+    assert zone_temp.state == "unavailable"
+    assert tank_temp.state == "unavailable"
+    assert operation.state == "unavailable"
 
 
 # =============================================================================
@@ -230,51 +131,28 @@ async def test_atw_energy_sensors_created_when_capability_present(
     hass: HomeAssistant,
 ) -> None:
     """Test energy sensors are created when device has energy meter capability."""
-    mock_unit = create_mock_atw_unit(
-        has_energy_meter=True,
-    )
+    mock_unit = create_mock_atw_unit(has_energy_meter=True)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
 
-    # Mock energy responses (in watt-hours)
-    mock_consumed = create_mock_atw_energy_response(
-        10000.0, "intervalEnergyConsumed"
-    )  # 10 kWh
-    mock_produced = create_mock_atw_energy_response(
-        40000.0, "intervalEnergyProduced"
-    )  # 40 kWh
+    mock_consumed = create_mock_atw_energy_response(10000.0, "intervalEnergyConsumed")
+    mock_produced = create_mock_atw_energy_response(40000.0, "intervalEnergyProduced")
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    def configure(client: Any) -> None:
+        client.atw = AsyncMock()
+        client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
+        client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
 
-        # Mock ATW energy API methods
-        mock_client.atw = AsyncMock()
-        mock_client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
-        mock_client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
-
-        # Mock storage (both ATA and ATW trackers use the same Store class)
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_atw_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
-        # Check all 3 energy sensors exist
         consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
         produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
         cop = hass.states.get(TEST_SENSOR_COP)
@@ -296,37 +174,15 @@ async def test_atw_energy_sensors_not_created_without_capability(
     hass: HomeAssistant,
 ) -> None:
     """Test energy sensors are NOT created when device lacks energy capability."""
-    mock_unit = create_mock_atw_unit(
-        has_energy_meter=False,  # No energy meter
-    )
+    mock_unit = create_mock_atw_unit(has_energy_meter=False)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Energy sensors should NOT exist
-        consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
-        produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
-        cop = hass.states.get(TEST_SENSOR_COP)
-
-        assert consumed is None
-        assert produced is None
-        assert cop is None
+    assert hass.states.get(TEST_SENSOR_ENERGY_CONSUMED) is None
+    assert hass.states.get(TEST_SENSOR_ENERGY_PRODUCED) is None
+    assert hass.states.get(TEST_SENSOR_COP) is None
 
 
 @pytest.mark.asyncio
@@ -335,43 +191,27 @@ async def test_atw_energy_sensors_unavailable_when_values_none(
 ) -> None:
     """Test energy sensors unavailable when energy values are None."""
     mock_unit = create_mock_atw_unit(
-        has_energy_meter=True,  # Has capability
-        energy_consumed=None,  # But no data yet
+        has_energy_meter=True,
+        energy_consumed=None,
         energy_produced=None,
         cop=None,
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
+    produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
+    cop = hass.states.get(TEST_SENSOR_COP)
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert consumed is not None
+    assert produced is not None
+    assert cop is not None
 
-        # Sensors created but unavailable (no data yet)
-        consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
-        produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
-        cop = hass.states.get(TEST_SENSOR_COP)
-
-        assert consumed is not None
-        assert produced is not None
-        assert cop is not None
-
-        assert consumed.state == "unavailable"
-        assert produced.state == "unavailable"
-        assert cop.state == "unavailable"
+    assert consumed.state == "unavailable"
+    assert produced.state == "unavailable"
+    assert cop.state == "unavailable"
 
 
 @pytest.mark.asyncio
@@ -381,48 +221,28 @@ async def test_atw_cop_calculation_correct(hass: HomeAssistant) -> None:
     On first init, energy values start at 0.0, so COP is unavailable (divide by zero).
     This test verifies the COP sensor is created and becomes unavailable when consumed=0.
     """
-    mock_unit = create_mock_atw_unit(
-        has_energy_meter=True,
-    )
+    mock_unit = create_mock_atw_unit(has_energy_meter=True)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
 
-    # Mock energy responses (first init)
     mock_consumed = create_mock_atw_energy_response(1000.0, "intervalEnergyConsumed")
     mock_produced = create_mock_atw_energy_response(4000.0, "intervalEnergyProduced")
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    def configure(client: Any) -> None:
+        client.atw = AsyncMock()
+        client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
+        client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
 
-        # Mock ATW energy API
-        mock_client.atw = AsyncMock()
-        mock_client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
-        mock_client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
-
-        # Mock storage (no stored data - first init)
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_atw_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
-        # After first init, consumed and produced start at 0.0
-        # COP is unavailable (cannot divide by zero)
         consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
         produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
         cop = hass.states.get(TEST_SENSOR_COP)
@@ -443,65 +263,44 @@ async def test_atw_energy_sensors_have_correct_device_class(
     hass: HomeAssistant,
 ) -> None:
     """Test energy sensors have correct device classes for Energy Dashboard."""
-    mock_unit = create_mock_atw_unit(
-        has_energy_meter=True,
-    )
+    mock_unit = create_mock_atw_unit(has_energy_meter=True)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
 
-    # Mock energy responses
     mock_consumed = create_mock_atw_energy_response(10000.0, "intervalEnergyConsumed")
     mock_produced = create_mock_atw_energy_response(40000.0, "intervalEnergyProduced")
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    def configure(client: Any) -> None:
+        client.atw = AsyncMock()
+        client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
+        client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
 
-        # Mock ATW energy API
-        mock_client.atw = AsyncMock()
-        mock_client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
-        mock_client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
-
-        # Mock storage (both ATA and ATW trackers use the same Store class)
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_atw_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
         consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
         produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
         cop = hass.states.get(TEST_SENSOR_COP)
 
-        # Energy sensors should have energy device class
         assert consumed.attributes.get("device_class") == "energy"
         assert produced.attributes.get("device_class") == "energy"
 
         # COP is dimensionless, no device class
         assert cop.attributes.get("device_class") is None
 
-        # Energy sensors should have TOTAL_INCREASING state class
         assert consumed.attributes.get("state_class") == "total_increasing"
         assert produced.attributes.get("state_class") == "total_increasing"
 
         # COP should have MEASUREMENT state class
         assert cop.attributes.get("state_class") == "measurement"
 
-        # Check units
         assert consumed.attributes.get("unit_of_measurement") == "kWh"
         assert produced.attributes.get("unit_of_measurement") == "kWh"
         assert cop.attributes.get("unit_of_measurement") is None
@@ -514,28 +313,13 @@ async def test_atw_outdoor_temperature_sensor_created(hass: HomeAssistant) -> No
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
-        assert state is not None
-        assert float(state.state) == 12.5
-        assert state.attributes["unit_of_measurement"] == "°C"
-        assert state.attributes["device_class"] == "temperature"
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
+    assert state is not None
+    assert float(state.state) == 12.5
+    assert state.attributes["unit_of_measurement"] == "°C"
+    assert state.attributes["device_class"] == "temperature"
 
 
 @pytest.mark.asyncio
@@ -547,26 +331,11 @@ async def test_atw_outdoor_temperature_not_created_when_none(
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Entity should not exist at all — not permanently unavailable
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
-        assert state is None
+    # Entity should not exist at all — not permanently unavailable
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
+    assert state is None
 
 
 @pytest.mark.asyncio
@@ -576,27 +345,11 @@ async def test_atw_rssi_sensor_created(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check WiFi signal sensor exists with correct attributes
-        wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
-        assert wifi_state is not None
-        # Sensor starts unavailable (no telemetry fetched yet - that happens on schedule)
-        assert wifi_state.state == "unavailable"
-        assert wifi_state.attributes["unit_of_measurement"] == "dBm"
-        assert wifi_state.attributes["device_class"] == "signal_strength"
+    wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
+    assert wifi_state is not None
+    # Sensor starts unavailable (no telemetry fetched yet - that happens on schedule)
+    assert wifi_state.state == "unavailable"
+    assert wifi_state.attributes["unit_of_measurement"] == "dBm"
+    assert wifi_state.attributes["device_class"] == "signal_strength"


### PR DESCRIPTION
## Summary

- Remove two `# DEBUG:` logging blocks from `AirToWaterUnit.from_dict()` — one dumped all raw API settings as formatted JSON on every coordinator poll, the other logged operation mode values on every active unit poll. Both were temporary investigation code.
- Add `setup_atw_integration_custom()` helper to `conftest.py` — eliminates ~12 lines of repeated mock/setup boilerplate per test in `test_sensor_atw.py`.
- Remove duplicate `MOCK_CLIENT_PATH` constant from `test_sensor_atw.py` (it was already defined in `conftest.py`).

## Test Plan

- [x] All 168 integration tests pass (`make test-integration`)
- [x] Pre-commit hooks pass (ruff, mypy, codespell, secrets)