### PR TITLE
chore: consolidate integration test setup boilerplate

### DIFF
--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -203,18 +203,7 @@ class AirToWaterUnit:
 
         This method parses the settings array and handles type conversions.
         """
-        # DEBUG: Log raw API data for ATW unit
-        import json
-
         settings_list = data.get("settings", [])
-        unit_id = data.get("id", "unknown")
-        unit_name = data.get("givenDisplayName", "Unknown")
-        _LOGGER.debug(
-            "[ATW %s '%s'] Raw API settings: %s",
-            unit_id[:8],
-            unit_name,
-            json.dumps(settings_list, indent=2),
-        )
 
         # Parse capabilities
         capabilities_data = data.get("capabilities", {})
@@ -255,18 +244,6 @@ class AirToWaterUnit:
         )
         operation_mode_zone2 = settings.get("OperationModeZone2") if has_zone2 else None
         power = _parse_bool(settings.get("Power"))
-
-        # DEBUG: Log operation status vs zone modes when system is active
-        # This helps us understand if OperationMode contains generic values ("Heating")
-        # or zone-specific values ("HeatFlowTemperature")
-        if power and operation_status != ATW_STATUS_STOP:
-            _LOGGER.debug(
-                "[ATW %s] OperationMode='%s' | Zone1Mode='%s' | Zone2Mode='%s'",
-                data.get("id", "unknown")[:8],
-                operation_status,
-                operation_mode_zone1,
-                operation_mode_zone2,
-            )
 
         return cls(
             # Identity

--- a/docs/testing-best-practices.md
+++ b/docs/testing-best-practices.md
@@ -197,21 +197,25 @@ See `docker-compose.test.yml` for implementation details.
 
 **Study these test files for correct patterns:**
 
-- **ATA (Air-to-Air) devices:** `tests/integration/test_climate_ata.py`
-  - Complete fixture setup with shared helpers
-  - ATA-specific device mocking (`mock_client.ata.*`)
+- **ATA (Air-to-Air) devices:** `tests/integration/test_climate_ata.py`, `tests/integration/test_sensor_ata.py`
+  - Uses `setup_ata_integration_custom()` from conftest — no inline boilerplate
+  - ATA-specific device mocking (`mock_client.ata.*`) captured from return value
   - Entity state validation through `hass.states`
   - Service call testing through `hass.services`
 
-- **ATW (Air-to-Water) devices:** `tests/integration/test_climate_atw.py`
-  - ATW-specific device mocking (`mock_client.atw.*`)
+- **ATW (Air-to-Water) devices:** `tests/integration/test_climate_atw.py`, `tests/integration/test_sensor_atw.py`
+  - Uses `setup_atw_integration_custom()` from conftest
+  - ATW-specific device mocking (`mock_client.atw.*`) captured from return value
   - Multi-zone climate entity patterns
   - Water heater entity integration
 
 - **Shared fixtures:** `tests/integration/conftest.py`
-  - Helper functions: `create_mock_atw_unit()`, `create_mock_user_context()`
-  - Reusable test constants
-  - Common mocking patterns
+  - **ATA helpers:** `create_mock_ata_unit()`, `create_mock_ata_building()`, `create_mock_ata_user_context()`, `setup_ata_integration_custom()`
+  - **ATW helpers:** `create_mock_atw_unit()`, `create_mock_atw_building()`, `create_mock_atw_user_context()`, `setup_atw_integration_custom()`
+  - Both `setup_*_integration_custom()` helpers return `(entry, mock_client)` — capture `mock_client` when you need to assert on calls or reconfigure mocks after setup
+  - Reusable test constants (`TEST_ATA_UNIT_ID`, `TEST_ATW_UNIT_ID`, entity IDs, etc.)
+
+**Critical rule:** Always check conftest for existing helpers before writing local `create_mock_*` functions or copying the `MockConfigEntry` setup block. If helpers are missing for your use case, add them to conftest rather than duplicating inline.
 
 ### Key Pattern Summary
 
@@ -509,11 +513,11 @@ When publishing to HACS, ensure:
 
 **Integration Tests:**
 
-- `tests/integration/test_climate_ata.py` - ATA device testing patterns
-- `tests/integration/test_climate_atw.py` - ATW device testing patterns
+- `tests/integration/conftest.py` - **Start here.** All shared helpers and setup factories live here.
+- `tests/integration/test_climate_ata.py` - ATA device testing patterns (uses conftest helpers)
+- `tests/integration/test_sensor_atw.py` - ATW sensor patterns (uses conftest helpers, no inline boilerplate)
 - `tests/integration/test_config_flow.py` - Config flow validation
 - `tests/integration/test_init.py` - Integration setup/teardown
-- `tests/integration/conftest.py` - Shared fixtures and helpers
 
 **API Tests:**
 
@@ -536,6 +540,9 @@ Before submitting a PR with new tests:
 - [ ] Integration tests use `hass.states` and `hass.services` exclusively
 - [ ] No assertions on internal coordinator/entity method calls
 - [ ] No direct imports of internal classes (coordinator, entity classes)
+- [ ] No local `create_mock_*` functions — use or extend conftest helpers instead
+- [ ] No local `MOCK_CLIENT_PATH` constant — import from conftest
+- [ ] No inline `MockConfigEntry` + `async_setup` block — use `setup_ata/atw_integration_custom()`
 - [ ] API tests use VCR cassettes or appropriate mocks
 - [ ] Tests follow naming convention: `test_<feature>_<scenario>`
 - [ ] Tests include docstrings explaining what's being tested

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,8 @@
 These fixtures require pytest-homeassistant-custom-component.
 """
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
@@ -232,6 +233,44 @@ async def setup_atw_integration(hass: "HomeAssistant") -> "MockConfigEntry":
         mock_client.atw.set_mode_zone1 = AsyncMock()
         mock_client.atw.set_dhw_temperature = AsyncMock()
         mock_client.atw.set_forced_hot_water = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        return entry
+
+
+async def setup_atw_integration_custom(
+    hass: "HomeAssistant",
+    mock_context: Any,
+    *,
+    configure_client: Callable[..., None] | None = None,
+) -> "MockConfigEntry":
+    """Set up ATW integration with a custom mock context.
+
+    Use this when tests need specific unit data. Pass configure_client to
+    add mock methods (e.g., energy API) before setup completes.
+    """
+    from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.melcloudhome.const import DOMAIN
+
+    with patch(MOCK_CLIENT_PATH) as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        if configure_client is not None:
+            configure_client(mock_client)
 
         entry = MockConfigEntry(
             domain=DOMAIN,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -300,9 +300,8 @@ async def setup_atw_integration_custom(
 # ATA (Air-to-Air) test helpers
 # =============================================================================
 
-# Same UUID as ATW constants — safe because each test loads only one device type
-TEST_ATA_UNIT_ID = "0efc1234-5678-9abc-def0-123456789abc"
-TEST_ATA_BUILDING_ID = "building-test-id"
+TEST_ATA_UNIT_ID = "a1b2c3d4-5678-9abc-def0-123456789abc"
+TEST_ATA_BUILDING_ID = "building-ata-test-id"
 
 
 def create_mock_ata_unit(
@@ -369,6 +368,16 @@ def create_mock_ata_user_context(buildings: list | None = None) -> "UserContext"
     if buildings is None:
         buildings = [create_mock_ata_building()]
     return UserContext(buildings=buildings)
+
+
+def create_mock_ata_energy_context() -> "UserContext":
+    """Create a mock UserContext with one energy-capable ATA unit.
+
+    Convenience wrapper for the common energy coordinator test setup.
+    """
+    return create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
 
 async def setup_ata_integration_custom(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from pytest_homeassistant_custom_component.common import MockConfigEntry
 
     from custom_components.melcloudhome.api.models import Building, UserContext
+    from custom_components.melcloudhome.api.models_ata import AirToAirUnit
     from custom_components.melcloudhome.api.models_atw import AirToWaterUnit
 
 # Import fixtures from pytest-homeassistant-custom-component
@@ -251,11 +252,11 @@ async def setup_atw_integration_custom(
     mock_context: Any,
     *,
     configure_client: Callable[..., None] | None = None,
-) -> "MockConfigEntry":
+) -> "tuple[MockConfigEntry, Any]":
     """Set up ATW integration with a custom mock context.
 
-    Use this when tests need specific unit data. Pass configure_client to
-    add mock methods (e.g., energy API) before setup completes.
+    Returns (entry, mock_client). Capture mock_client to configure mocks or
+    assert on calls after setup. Use configure_client for pre-setup mock wiring.
     """
     from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
     from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -281,4 +282,117 @@ async def setup_atw_integration_custom(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        return entry
+        return entry, mock_client
+
+
+# =============================================================================
+# ATA (Air-to-Air) test helpers
+# =============================================================================
+
+# Same UUID as ATW constants — safe because each test loads only one device type
+TEST_ATA_UNIT_ID = "0efc1234-5678-9abc-def0-123456789abc"
+TEST_ATA_BUILDING_ID = "building-test-id"
+
+
+def create_mock_ata_unit(
+    unit_id: str = TEST_ATA_UNIT_ID,
+    name: str = "Test Unit",
+    power: bool = True,
+    operation_mode: str = "Heat",
+    set_temperature: float | None = 21.0,
+    room_temperature: float | None = 20.0,
+    set_fan_speed: str | None = "Auto",
+    vane_vertical: str | None = "Auto",
+    vane_horizontal: str | None = "Auto",
+    in_standby_mode: bool = False,
+    is_in_error: bool = False,
+    rssi: int | None = -50,
+    has_energy_meter: bool = False,
+    energy_consumed: float | None = None,
+    has_outdoor_sensor: bool = False,
+    outdoor_temperature: float | None = None,
+) -> "AirToAirUnit":
+    """Create a mock AirToAirUnit for testing."""
+    from custom_components.melcloudhome.api.models_ata import (
+        AirToAirCapabilities,
+        AirToAirUnit,
+    )
+
+    return AirToAirUnit(
+        id=unit_id,
+        name=name,
+        power=power,
+        operation_mode=operation_mode,
+        set_temperature=set_temperature,
+        room_temperature=room_temperature,
+        set_fan_speed=set_fan_speed,
+        vane_vertical_direction=vane_vertical,
+        vane_horizontal_direction=vane_horizontal,
+        in_standby_mode=in_standby_mode,
+        is_in_error=is_in_error,
+        rssi=rssi,
+        capabilities=AirToAirCapabilities(has_energy_consumed_meter=has_energy_meter),
+        energy_consumed=energy_consumed,
+        has_outdoor_temp_sensor=has_outdoor_sensor,
+        outdoor_temperature=outdoor_temperature,
+    )
+
+
+def create_mock_ata_building(
+    building_id: str = TEST_ATA_BUILDING_ID,
+    name: str = "Test Building",
+    units: list | None = None,
+) -> "Building":
+    """Create a mock Building with ATA units for testing."""
+    from custom_components.melcloudhome.api.models import Building
+
+    if units is None:
+        units = [create_mock_ata_unit()]
+    return Building(id=building_id, name=name, air_to_air_units=units)
+
+
+def create_mock_ata_user_context(buildings: list | None = None) -> "UserContext":
+    """Create a mock UserContext with ATA buildings for testing."""
+    from custom_components.melcloudhome.api.models import UserContext
+
+    if buildings is None:
+        buildings = [create_mock_ata_building()]
+    return UserContext(buildings=buildings)
+
+
+async def setup_ata_integration_custom(
+    hass: "HomeAssistant",
+    mock_context: Any,
+    *,
+    configure_client: Callable[..., None] | None = None,
+) -> "tuple[MockConfigEntry, Any]":
+    """Set up ATA integration with a custom mock context.
+
+    Returns (entry, mock_client). Capture mock_client to configure mocks or
+    assert on calls after setup. Use configure_client for pre-setup mock wiring.
+    """
+    from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.melcloudhome.const import DOMAIN
+
+    with patch(MOCK_CLIENT_PATH) as mock_client_class:
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        if configure_client is not None:
+            configure_client(mock_client)
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        return entry, mock_client

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -247,17 +247,12 @@ async def setup_atw_integration(hass: "HomeAssistant") -> "MockConfigEntry":
         return entry
 
 
-async def setup_atw_integration_custom(
+async def _setup_integration_custom(
     hass: "HomeAssistant",
     mock_context: Any,
     *,
     configure_client: Callable[..., None] | None = None,
 ) -> "tuple[MockConfigEntry, Any]":
-    """Set up ATW integration with a custom mock context.
-
-    Returns (entry, mock_client). Capture mock_client to configure mocks or
-    assert on calls after setup. Use configure_client for pre-setup mock wiring.
-    """
     from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
     from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -283,6 +278,22 @@ async def setup_atw_integration_custom(
         await hass.async_block_till_done()
 
         return entry, mock_client
+
+
+async def setup_atw_integration_custom(
+    hass: "HomeAssistant",
+    mock_context: Any,
+    *,
+    configure_client: Callable[..., None] | None = None,
+) -> "tuple[MockConfigEntry, Any]":
+    """Set up ATW integration with a custom mock context.
+
+    Returns (entry, mock_client). Capture mock_client to configure mocks or
+    assert on calls after setup. Use configure_client for pre-setup mock wiring.
+    """
+    return await _setup_integration_custom(
+        hass, mock_context, configure_client=configure_client
+    )
 
 
 # =============================================================================
@@ -371,28 +382,6 @@ async def setup_ata_integration_custom(
     Returns (entry, mock_client). Capture mock_client to configure mocks or
     assert on calls after setup. Use configure_client for pre-setup mock wiring.
     """
-    from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-    from custom_components.melcloudhome.const import DOMAIN
-
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        if configure_client is not None:
-            configure_client(mock_client)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        return entry, mock_client
+    return await _setup_integration_custom(
+        hass, mock_context, configure_client=configure_client
+    )

--- a/tests/integration/test_binary_sensor_ata.py
+++ b/tests/integration/test_binary_sensor_ata.py
@@ -7,160 +7,63 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.api.models import Building, UserContext
-from custom_components.melcloudhome.api.models_ata import (
-    AirToAirCapabilities,
-    AirToAirUnit,
+from .conftest import (
+    create_mock_ata_building,
+    create_mock_ata_unit,
+    create_mock_ata_user_context,
+    setup_ata_integration_custom,
 )
-from custom_components.melcloudhome.const import DOMAIN
-
-# Mock at API boundary (NOT coordinator or sensor classes)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
-
-# Test device identifiers
-TEST_UNIT_ID = "0efc1234-5678-9abc-def0-123456789abc"
-TEST_BUILDING_ID = "building-test-id"
-
-
-def create_mock_unit(
-    unit_id: str = TEST_UNIT_ID,
-    name: str = "Test Unit",
-    is_in_error: bool = False,
-) -> AirToAirUnit:
-    """Create a mock AirToAirUnit for binary sensor testing."""
-    capabilities = AirToAirCapabilities(has_energy_consumed_meter=False)
-
-    return AirToAirUnit(
-        id=unit_id,
-        name=name,
-        power=True,
-        operation_mode="Heat",
-        set_temperature=21.0,
-        room_temperature=20.0,
-        set_fan_speed="Auto",
-        vane_vertical_direction="Auto",
-        vane_horizontal_direction="Auto",
-        in_standby_mode=False,
-        is_in_error=is_in_error,
-        rssi=-50,
-        capabilities=capabilities,
-        energy_consumed=None,
-    )
-
-
-def create_mock_building(
-    building_id: str = TEST_BUILDING_ID,
-    name: str = "Test Building",
-    units: list[AirToAirUnit] | None = None,
-) -> Building:
-    """Create a mock Building for binary sensor testing."""
-    if units is None:
-        units = [create_mock_unit()]
-    return Building(id=building_id, name=name, air_to_air_units=units)
-
-
-def create_mock_user_context(buildings: list[Building] | None = None) -> UserContext:
-    """Create a mock UserContext for binary sensor testing."""
-    if buildings is None:
-        buildings = [create_mock_building()]
-    return UserContext(buildings=buildings)
 
 
 @pytest.mark.asyncio
 async def test_binary_sensor_entity_creation(hass: HomeAssistant) -> None:
     """Test that binary sensor entities are created for each unit."""
-    mock_context = create_mock_user_context()
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Setup mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    error_state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_error_state")
+    connection_state = hass.states.get(
+        "binary_sensor.melcloudhome_0efc_9abc_connection_state"
+    )
 
-        # Create and setup config entry
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert error_state is not None
+    assert error_state.attributes["device_class"] == "problem"
 
-        # Verify binary sensors created (entity ID from UUID: 0efc1234-...9abc)
-        error_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_error_state"
-        connection_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_connection_state"
-
-        # Check error state sensor exists
-        error_state = hass.states.get(error_sensor_id)
-        assert error_state is not None
-        assert error_state.attributes["device_class"] == "problem"
-
-        # Check connection state sensor exists
-        connection_state = hass.states.get(connection_sensor_id)
-        assert connection_state is not None
-        assert connection_state.attributes["device_class"] == "connectivity"
+    assert connection_state is not None
+    assert connection_state.attributes["device_class"] == "connectivity"
 
 
 @pytest.mark.asyncio
 async def test_error_state_sensor_reflects_unit_status(hass: HomeAssistant) -> None:
     """Test that error state sensor reflects unit error status."""
-    # Create unit with error
-    unit_with_error = create_mock_unit(is_in_error=True)
-    building = create_mock_building(units=[unit_with_error])
-    mock_context = create_mock_user_context(buildings=[building])
+    unit_with_error = create_mock_ata_unit(is_in_error=True)
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[unit_with_error])]
+    )
+    _, mock_client = await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Setup mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    error_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_error_state"
+    assert hass.states.get(error_sensor_id).state == STATE_ON  # ON = problem exists
 
-        # Create and setup config entry
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    # Update to no-error state and refresh
+    unit_no_error = create_mock_ata_unit(is_in_error=False)
+    mock_context_updated = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[unit_no_error])]
+    )
+    mock_client.get_user_context = AsyncMock(return_value=mock_context_updated)
 
-        # Check error state sensor shows error (ON = problem)
-        error_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_error_state"
-        error_state = hass.states.get(error_sensor_id)
-        assert error_state is not None
-        assert error_state.state == STATE_ON  # ON = problem exists
+    from custom_components.melcloudhome.const import DOMAIN
 
-        # Now create unit without error and update
-        unit_no_error = create_mock_unit(is_in_error=False)
-        building_updated = create_mock_building(units=[unit_no_error])
-        mock_context_updated = create_mock_user_context(buildings=[building_updated])
-        mock_client.get_user_context = AsyncMock(return_value=mock_context_updated)
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+    await hass.async_block_till_done()
 
-        # Trigger coordinator refresh
-        await hass.services.async_call(
-            DOMAIN,
-            "force_refresh",
-            {},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-
-        # Check error state sensor now shows no error (OFF = no problem)
-        error_state = hass.states.get(error_sensor_id)
-        assert error_state.state == STATE_OFF  # OFF = no problem
+    assert hass.states.get(error_sensor_id).state == STATE_OFF
 
 
 @pytest.mark.asyncio
@@ -168,51 +71,20 @@ async def test_connection_state_sensor_reflects_coordinator_status(
     hass: HomeAssistant,
 ) -> None:
     """Test that connection state sensor reflects coordinator update success."""
-    mock_context = create_mock_user_context()
+    mock_context = create_mock_ata_user_context()
+    _, mock_client = await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Setup mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    connection_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_connection_state"
+    assert hass.states.get(connection_sensor_id).state == STATE_ON  # Connected
 
-        # Create and setup config entry
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    from custom_components.melcloudhome.api.exceptions import ApiError
+    from custom_components.melcloudhome.const import DOMAIN
 
-        # Check connection state sensor shows connected (ON = connected)
-        connection_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_connection_state"
-        connection_state = hass.states.get(connection_sensor_id)
-        assert connection_state is not None
-        assert connection_state.state == STATE_ON  # ON = connected
+    mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+    await hass.async_block_till_done()
 
-        # Simulate coordinator update failure
-        from custom_components.melcloudhome.api.exceptions import ApiError
-
-        mock_client.get_user_context = AsyncMock(
-            side_effect=ApiError("Connection failed")
-        )
-
-        # Trigger coordinator refresh (will fail)
-        await hass.services.async_call(
-            DOMAIN,
-            "force_refresh",
-            {},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-
-        # Check connection state sensor now shows disconnected (OFF = disconnected)
-        connection_state = hass.states.get(connection_sensor_id)
-        assert connection_state.state == STATE_OFF  # OFF = disconnected
+    assert hass.states.get(connection_sensor_id).state == STATE_OFF
 
 
 @pytest.mark.asyncio
@@ -220,96 +92,36 @@ async def test_error_sensor_unavailable_when_coordinator_fails(
     hass: HomeAssistant,
 ) -> None:
     """Test that error state sensor becomes unavailable when coordinator fails."""
-    mock_context = create_mock_user_context()
+    mock_context = create_mock_ata_user_context()
+    _, mock_client = await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Setup mock client - initially working
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    error_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_error_state"
+    assert hass.states.get(error_sensor_id).state != "unavailable"
 
-        # Create and setup config entry
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    from custom_components.melcloudhome.api.exceptions import ApiError
+    from custom_components.melcloudhome.const import DOMAIN
 
-        # Error sensor should be available initially
-        error_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_error_state"
-        error_state = hass.states.get(error_sensor_id)
-        assert error_state is not None
-        assert error_state.state != "unavailable"
+    mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+    await hass.async_block_till_done()
 
-        # Simulate coordinator failure
-        from custom_components.melcloudhome.api.exceptions import ApiError
-
-        mock_client.get_user_context = AsyncMock(
-            side_effect=ApiError("Connection failed")
-        )
-
-        # Trigger coordinator refresh (will fail)
-        await hass.services.async_call(
-            DOMAIN,
-            "force_refresh",
-            {},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-
-        # Error sensor should become unavailable
-        error_state = hass.states.get(error_sensor_id)
-        assert error_state.state == "unavailable"
+    assert hass.states.get(error_sensor_id).state == "unavailable"
 
 
 @pytest.mark.asyncio
 async def test_connection_sensor_always_available(hass: HomeAssistant) -> None:
     """Test that connection state sensor is always available, even when coordinator fails."""
-    mock_context = create_mock_user_context()
+    mock_context = create_mock_ata_user_context()
+    _, mock_client = await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Setup mock client that will fail
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    from custom_components.melcloudhome.api.exceptions import ApiError
+    from custom_components.melcloudhome.const import DOMAIN
 
-        # Create and setup config entry
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+    await hass.async_block_till_done()
 
-        # Simulate coordinator failure
-        from custom_components.melcloudhome.api.exceptions import ApiError
-
-        mock_client.get_user_context = AsyncMock(
-            side_effect=ApiError("Connection failed")
-        )
-
-        # Trigger coordinator refresh (will fail)
-        await hass.services.async_call(
-            DOMAIN,
-            "force_refresh",
-            {},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-
-        # Connection sensor should still be available (not "unavailable")
-        # It should be OFF (indicating connection failure), but not unavailable
-        connection_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_connection_state"
-        connection_state = hass.states.get(connection_sensor_id)
-        assert connection_state is not None
-        assert connection_state.state == STATE_OFF  # Shows disconnection
-        # Not checking != "unavailable" because that's implicit in state == STATE_OFF
+    connection_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_connection_state"
+    connection_state = hass.states.get(connection_sensor_id)
+    assert connection_state is not None
+    assert connection_state.state == STATE_OFF  # Shows disconnection, not unavailable

--- a/tests/integration/test_binary_sensor_ata.py
+++ b/tests/integration/test_binary_sensor_ata.py
@@ -27,9 +27,9 @@ async def test_binary_sensor_entity_creation(hass: HomeAssistant) -> None:
     mock_context = create_mock_ata_user_context()
     await setup_ata_integration_custom(hass, mock_context)
 
-    error_state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_error_state")
+    error_state = hass.states.get("binary_sensor.melcloudhome_a1b2_9abc_error_state")
     connection_state = hass.states.get(
-        "binary_sensor.melcloudhome_0efc_9abc_connection_state"
+        "binary_sensor.melcloudhome_a1b2_9abc_connection_state"
     )
 
     assert error_state is not None
@@ -48,7 +48,7 @@ async def test_error_state_sensor_reflects_unit_status(hass: HomeAssistant) -> N
     )
     _, mock_client = await setup_ata_integration_custom(hass, mock_context)
 
-    error_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_error_state"
+    error_sensor_id = "binary_sensor.melcloudhome_a1b2_9abc_error_state"
     assert hass.states.get(error_sensor_id).state == STATE_ON  # ON = problem exists
 
     # Update to no-error state and refresh
@@ -74,7 +74,7 @@ async def test_connection_state_sensor_reflects_coordinator_status(
     mock_context = create_mock_ata_user_context()
     _, mock_client = await setup_ata_integration_custom(hass, mock_context)
 
-    connection_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_connection_state"
+    connection_sensor_id = "binary_sensor.melcloudhome_a1b2_9abc_connection_state"
     assert hass.states.get(connection_sensor_id).state == STATE_ON  # Connected
 
     from custom_components.melcloudhome.api.exceptions import ApiError
@@ -95,7 +95,7 @@ async def test_error_sensor_unavailable_when_coordinator_fails(
     mock_context = create_mock_ata_user_context()
     _, mock_client = await setup_ata_integration_custom(hass, mock_context)
 
-    error_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_error_state"
+    error_sensor_id = "binary_sensor.melcloudhome_a1b2_9abc_error_state"
     assert hass.states.get(error_sensor_id).state != "unavailable"
 
     from custom_components.melcloudhome.api.exceptions import ApiError
@@ -121,7 +121,7 @@ async def test_connection_sensor_always_available(hass: HomeAssistant) -> None:
     await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
     await hass.async_block_till_done()
 
-    connection_sensor_id = "binary_sensor.melcloudhome_0efc_9abc_connection_state"
+    connection_sensor_id = "binary_sensor.melcloudhome_a1b2_9abc_connection_state"
     connection_state = hass.states.get(connection_sensor_id)
     assert connection_state is not None
     assert connection_state.state == STATE_OFF  # Shows disconnection, not unavailable

--- a/tests/integration/test_binary_sensor_atw.py
+++ b/tests/integration/test_binary_sensor_atw.py
@@ -7,23 +7,16 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, PropertyMock, patch
-
 import pytest
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, STATE_OFF, STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.melcloudhome.const import DOMAIN
 
 from .conftest import (
     create_mock_atw_building,
     create_mock_atw_unit,
     create_mock_atw_user_context,
+    setup_atw_integration_custom,
 )
-
-# Mock at API boundary (NOT coordinator or sensor classes)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
 
 
 @pytest.mark.asyncio
@@ -33,27 +26,11 @@ async def test_atw_error_state_sensor_created(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check error state sensor exists
-        state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_error_state")
-        assert state is not None
-        assert state.state == STATE_OFF  # No error
+    state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_error_state")
+    assert state is not None
+    assert state.state == STATE_OFF  # No error
 
 
 @pytest.mark.asyncio
@@ -63,27 +40,11 @@ async def test_atw_connection_state_sensor_created(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check connection state sensor exists
-        state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_connection_state")
-        assert state is not None
-        assert state.state == STATE_ON  # Connected
+    state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_connection_state")
+    assert state is not None
+    assert state.state == STATE_ON  # Connected
 
 
 @pytest.mark.asyncio
@@ -93,29 +54,11 @@ async def test_atw_forced_dhw_active_sensor_created(hass: HomeAssistant) -> None
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check forced DHW active sensor exists
-        state = hass.states.get(
-            "binary_sensor.melcloudhome_0efc_9abc_forced_dhw_active"
-        )
-        assert state is not None
-        assert state.state == STATE_ON  # Forced DHW is active
+    state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_forced_dhw_active")
+    assert state is not None
+    assert state.state == STATE_ON  # Forced DHW is active
 
 
 @pytest.mark.asyncio
@@ -125,58 +68,25 @@ async def test_atw_error_state_on_when_device_in_error(hass: HomeAssistant) -> N
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_error_state")
-        assert state is not None
-        assert state.state == STATE_ON  # Device in error
+    state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_error_state")
+    assert state is not None
+    assert state.state == STATE_ON  # Device in error
 
 
 @pytest.mark.asyncio
 async def test_atw_forced_dhw_reflects_device_mode(hass: HomeAssistant) -> None:
     """Test forced DHW sensor reflects device forced_hot_water_mode."""
-    # Test with forced DHW OFF
     mock_unit = create_mock_atw_unit(forced_hot_water_mode=False)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(
-            "binary_sensor.melcloudhome_0efc_9abc_forced_dhw_active"
-        )
-        assert state is not None
-        assert state.state == STATE_OFF  # Forced DHW not active
+    state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_forced_dhw_active")
+    assert state is not None
+    assert state.state == STATE_OFF  # Forced DHW not active
 
 
 @pytest.mark.asyncio
@@ -186,24 +96,8 @@ async def test_atw_connection_always_available(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Connection sensor should always be available
-        state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_connection_state")
-        assert state is not None
-        assert state.state == STATE_ON  # Connected
+    state = hass.states.get("binary_sensor.melcloudhome_0efc_9abc_connection_state")
+    assert state is not None
+    assert state.state == STATE_ON  # Connected

--- a/tests/integration/test_climate_ata.py
+++ b/tests/integration/test_climate_ata.py
@@ -21,7 +21,7 @@ from .conftest import (
     setup_ata_integration_custom,
 )
 
-_CLIMATE_ENTITY = "climate.melcloudhome_0efc_9abc_climate"
+_CLIMATE_ENTITY = "climate.melcloudhome_a1b2_9abc_climate"
 
 
 def _configure_ata_controls(client: Any) -> None:

--- a/tests/integration/test_climate_ata.py
+++ b/tests/integration/test_climate_ata.py
@@ -7,132 +7,43 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.components.climate import HVACAction, HVACMode
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.api.models import Building, UserContext
-from custom_components.melcloudhome.api.models_ata import (
-    AirToAirCapabilities,
-    AirToAirUnit,
+from .conftest import (
+    create_mock_ata_building,
+    create_mock_ata_unit,
+    create_mock_ata_user_context,
+    setup_ata_integration_custom,
 )
-from custom_components.melcloudhome.const import DOMAIN
 
-# Mock at API boundary (NOT coordinator)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
-
-# Test device UUID - generates entity_id: climate.melcloudhome_0efc_9abc
-TEST_UNIT_ID = "0efc1234-5678-9abc-def0-123456789abc"
-TEST_BUILDING_ID = "building-test-id"
+_CLIMATE_ENTITY = "climate.melcloudhome_0efc_9abc_climate"
 
 
-def create_mock_unit(
-    unit_id: str = TEST_UNIT_ID,
-    name: str = "Test Unit",
-    power: bool = True,
-    operation_mode: str = "Heat",
-    set_temperature: float = 21.0,
-    room_temperature: float = 20.0,
-    set_fan_speed: str = "Auto",
-    vane_vertical: str = "Auto",
-    vane_horizontal: str = "Auto",
-    is_in_error: bool = False,
-) -> AirToAirUnit:
-    """Create a mock AirToAirUnit for testing.
-
-    Uses real model class with realistic data.
-    """
-    return AirToAirUnit(
-        id=unit_id,
-        name=name,
-        power=power,
-        operation_mode=operation_mode,
-        set_temperature=set_temperature,
-        room_temperature=room_temperature,
-        set_fan_speed=set_fan_speed,
-        vane_vertical_direction=vane_vertical,
-        vane_horizontal_direction=vane_horizontal,
-        in_standby_mode=False,
-        is_in_error=is_in_error,
-        rssi=-50,
-        capabilities=AirToAirCapabilities(),
-    )
-
-
-def create_mock_building(
-    building_id: str = TEST_BUILDING_ID,
-    name: str = "Test Building",
-    units: list[AirToAirUnit] | None = None,
-) -> Building:
-    """Create a mock Building for testing."""
-    if units is None:
-        units = [create_mock_unit()]
-    return Building(id=building_id, name=name, air_to_air_units=units)
-
-
-def create_mock_user_context(buildings: list[Building] | None = None) -> UserContext:
-    """Create a mock UserContext for testing."""
-    if buildings is None:
-        buildings = [create_mock_building()]
-    return UserContext(buildings=buildings)
-
-
-@pytest.fixture
-async def setup_integration(hass: HomeAssistant) -> MockConfigEntry:
-    """Set up the integration with mocked API client.
-
-    Follows HA best practices:
-    - Mocks at API boundary (MELCloudHomeClient)
-    - Sets up through core interface (hass.config_entries.async_setup)
-    - Returns config entry for test use
-    """
-    mock_context = create_mock_user_context()
-
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        # Mock API control methods (called by service calls)
-        mock_client.ata = MagicMock()
-        mock_client.ata.set_power = AsyncMock()
-        mock_client.ata.set_mode = AsyncMock()
-        mock_client.ata.set_power_and_mode = AsyncMock()
-        mock_client.ata.set_temperature = AsyncMock()
-        mock_client.ata.set_fan_speed = AsyncMock()
-        mock_client.ata.set_vane_vertical = AsyncMock()
-        mock_client.ata.set_vane_horizontal = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        return entry
+def _configure_ata_controls(client: Any) -> None:
+    client.ata = MagicMock()
+    client.ata.set_power = AsyncMock()
+    client.ata.set_mode = AsyncMock()
+    client.ata.set_power_and_mode = AsyncMock()
+    client.ata.set_temperature = AsyncMock()
+    client.ata.set_fan_speed = AsyncMock()
+    client.ata.set_vane_vertical = AsyncMock()
+    client.ata.set_vane_horizontal = AsyncMock()
 
 
 @pytest.mark.asyncio
-async def test_climate_entity_state_reflects_device_data(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test that climate entity state correctly reflects device data.
+async def test_climate_entity_state_reflects_device_data(hass: HomeAssistant) -> None:
+    """Test that climate entity state correctly reflects device data."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
 
-    Validates: Entity state matches mock device configuration
-    Tests through: hass.states (core interface)
-    """
-    # ✅ CORRECT: Assert through state machine
-    state = hass.states.get("climate.melcloudhome_0efc_9abc_climate")
-
+    state = hass.states.get(_CLIMATE_ENTITY)
     assert state is not None
     assert state.state == HVACMode.HEAT
     assert state.attributes["current_temperature"] == 20.0
@@ -142,504 +53,272 @@ async def test_climate_entity_state_reflects_device_data(
 
 
 @pytest.mark.asyncio
-async def test_set_hvac_mode_to_cool(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test changing HVAC mode to COOL via service call.
+async def test_set_hvac_mode_to_cool(hass: HomeAssistant) -> None:
+    """Test changing HVAC mode to COOL via service call."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
 
-    Validates: Service accepts mode change without error
-    Tests through: hass.services (core interface)
-    """
-    # ✅ CORRECT: Call service through core registry
     await hass.services.async_call(
         "climate",
         "set_hvac_mode",
-        {
-            "entity_id": "climate.melcloudhome_0efc_9abc_climate",
-            "hvac_mode": HVACMode.COOL,
-        },
+        {"entity_id": _CLIMATE_ENTITY, "hvac_mode": HVACMode.COOL},
         blocking=True,
     )
 
-    # Service call succeeded (no exception raised)
-    # Note: State change depends on coordinator refresh, not tested here
-
 
 @pytest.mark.asyncio
-async def test_set_hvac_mode_noop_when_already_matches(
-    hass: HomeAssistant,
-) -> None:
-    """Test that set_hvac_mode is a no-op when power+mode already match device state.
+async def test_set_hvac_mode_noop_when_already_matches(hass: HomeAssistant) -> None:
+    """Test that set_hvac_mode is a no-op when power+mode already match device state."""
+    mock_unit = create_mock_ata_unit(power=True, operation_mode="Heat")
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[mock_unit])]
+    )
+    _, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
 
-    The unit starts: power=True, operation_mode="Heat".
-    HA_HVAC_MODE_TO_ATA[HVACMode.HEAT] == "Heat", so the guard fires and no
-    API call is made.
-    """
-    mock_unit = create_mock_unit(power=True, operation_mode="Heat")
-    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
-
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        mock_client.ata = MagicMock()
-        mock_client.ata.set_power = AsyncMock()
-        mock_client.ata.set_mode = AsyncMock()
-        mock_client.ata.set_power_and_mode = AsyncMock()
-        mock_client.ata.set_temperature = AsyncMock()
-        mock_client.ata.set_fan_speed = AsyncMock()
-        mock_client.ata.set_vane_vertical = AsyncMock()
-        mock_client.ata.set_vane_horizontal = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        await hass.services.async_call(
-            "climate",
-            "set_hvac_mode",
-            {
-                "entity_id": "climate.melcloudhome_0efc_9abc_climate",
-                "hvac_mode": HVACMode.HEAT,
-            },
-            blocking=True,
-        )
-
-        # Guard should fire — no API write made
-        mock_client.ata.set_power_and_mode.assert_not_called()
-        mock_client.ata.set_power.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_turn_on_uses_atomic_power_and_mode(
-    hass: HomeAssistant,
-) -> None:
-    """Test that turn_on sends power+mode atomically, not power alone.
-
-    Sending power=True without operationMode triggers the multi-zone outdoor
-    unit fault. async_turn_on must use set_power_and_mode with the current mode.
-    """
-    mock_unit = create_mock_unit(power=False, operation_mode="Heat")
-    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
-
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        mock_client.ata = MagicMock()
-        mock_client.ata.set_power = AsyncMock()
-        mock_client.ata.set_mode = AsyncMock()
-        mock_client.ata.set_power_and_mode = AsyncMock()
-        mock_client.ata.set_temperature = AsyncMock()
-        mock_client.ata.set_fan_speed = AsyncMock()
-        mock_client.ata.set_vane_vertical = AsyncMock()
-        mock_client.ata.set_vane_horizontal = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        await hass.services.async_call(
-            "climate",
-            "turn_on",
-            {"entity_id": "climate.melcloudhome_0efc_9abc_climate"},
-            blocking=True,
-        )
-
-        # Must use set_power_and_mode, not bare set_power
-        mock_client.ata.set_power_and_mode.assert_called_once()
-        mock_client.ata.set_power.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_set_hvac_mode_off_turns_device_off(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test that setting HVAC mode to OFF powers down device.
-
-    Validates: OFF mode service call accepted
-    Tests through: hass.services (core interface)
-    """
     await hass.services.async_call(
         "climate",
         "set_hvac_mode",
-        {
-            "entity_id": "climate.melcloudhome_0efc_9abc_climate",
-            "hvac_mode": HVACMode.OFF,
-        },
+        {"entity_id": _CLIMATE_ENTITY, "hvac_mode": HVACMode.HEAT},
         blocking=True,
     )
 
-    # Service call succeeded (no exception raised)
+    mock_client.ata.set_power_and_mode.assert_not_called()
+    mock_client.ata.set_power.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_set_temperature_within_valid_range(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test setting temperature within valid range.
+async def test_turn_on_uses_atomic_power_and_mode(hass: HomeAssistant) -> None:
+    """Test that turn_on sends power+mode atomically, not power alone."""
+    mock_unit = create_mock_ata_unit(power=False, operation_mode="Heat")
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[mock_unit])]
+    )
+    _, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
 
-    Validates: Temperature change service call accepted
-    Tests through: hass.services (core interface)
-    """
+    await hass.services.async_call(
+        "climate",
+        "turn_on",
+        {"entity_id": _CLIMATE_ENTITY},
+        blocking=True,
+    )
+
+    mock_client.ata.set_power_and_mode.assert_called_once()
+    mock_client.ata.set_power.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_hvac_mode_off_turns_device_off(hass: HomeAssistant) -> None:
+    """Test that setting HVAC mode to OFF powers down device."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": _CLIMATE_ENTITY, "hvac_mode": HVACMode.OFF},
+        blocking=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_temperature_within_valid_range(hass: HomeAssistant) -> None:
+    """Test setting temperature within valid range."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
     await hass.services.async_call(
         "climate",
         "set_temperature",
-        {"entity_id": "climate.melcloudhome_0efc_9abc_climate", "temperature": 22.5},
+        {"entity_id": _CLIMATE_ENTITY, "temperature": 22.5},
         blocking=True,
     )
 
-    # Service call succeeded (no exception raised)
-
 
 @pytest.mark.asyncio
-async def test_set_temperature_out_of_range_rejected(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test that temperature out of range is rejected gracefully.
-
-    Validates: Out-of-range temps are logged but don't crash integration
-    Tests through: hass.services (core interface)
-
-    Note: Home Assistant's climate component may validate ranges before
-    calling entity methods. Our entity also validates in async_set_temperature.
-    """
+async def test_set_temperature_out_of_range_rejected(hass: HomeAssistant) -> None:
+    """Test that temperature out of range is rejected gracefully."""
     from contextlib import suppress
 
     from homeassistant.exceptions import ServiceValidationError
 
-    # Below minimum (10°C for heat mode)
-    # May be rejected by HA or logged by entity
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
     with suppress(ServiceValidationError):
         await hass.services.async_call(
             "climate",
             "set_temperature",
-            {"entity_id": "climate.melcloudhome_0efc_9abc_climate", "temperature": 5.0},
+            {"entity_id": _CLIMATE_ENTITY, "temperature": 5.0},
             blocking=True,
         )
 
-    # Above maximum (31°C)
     with suppress(ServiceValidationError):
         await hass.services.async_call(
             "climate",
             "set_temperature",
-            {
-                "entity_id": "climate.melcloudhome_0efc_9abc_climate",
-                "temperature": 35.0,
-            },
+            {"entity_id": _CLIMATE_ENTITY, "temperature": 35.0},
             blocking=True,
         )
-
-    # Test passes - out of range temps handled without crash
 
 
 @pytest.mark.asyncio
-async def test_set_fan_mode(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test setting fan mode via service call.
+async def test_set_fan_mode(hass: HomeAssistant) -> None:
+    """Test setting fan mode via service call."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
 
-    Validates: Fan mode change service call accepted
-    Tests through: hass.services (core interface)
-    """
     await hass.services.async_call(
         "climate",
         "set_fan_mode",
-        {"entity_id": "climate.melcloudhome_0efc_9abc_climate", "fan_mode": "three"},
+        {"entity_id": _CLIMATE_ENTITY, "fan_mode": "three"},
         blocking=True,
     )
 
-    # Service call succeeded (no exception raised)
-
 
 @pytest.mark.asyncio
-async def test_set_swing_mode_vertical_vanes(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test setting vertical vane position via swing mode.
+async def test_set_swing_mode_vertical_vanes(hass: HomeAssistant) -> None:
+    """Test setting vertical vane position via swing mode."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
 
-    Validates: Swing mode change service call accepted
-    Tests through: hass.services (core interface)
-    """
     await hass.services.async_call(
         "climate",
         "set_swing_mode",
-        {"entity_id": "climate.melcloudhome_0efc_9abc_climate", "swing_mode": "swing"},
+        {"entity_id": _CLIMATE_ENTITY, "swing_mode": "swing"},
         blocking=True,
     )
-
-    # Service call succeeded (no exception raised)
 
 
 @pytest.mark.asyncio
-async def test_set_swing_horizontal_mode(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test setting horizontal vane position.
+async def test_set_swing_horizontal_mode(hass: HomeAssistant) -> None:
+    """Test setting horizontal vane position."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
 
-    Validates: Horizontal swing mode change service call accepted
-    Tests through: hass.services (core interface)
-    """
     await hass.services.async_call(
         "climate",
         "set_swing_horizontal_mode",
-        {
-            "entity_id": "climate.melcloudhome_0efc_9abc_climate",
-            "swing_horizontal_mode": "centre",
-        },
+        {"entity_id": _CLIMATE_ENTITY, "swing_horizontal_mode": "centre"},
         blocking=True,
     )
-
-    # Service call succeeded (no exception raised)
 
 
 @pytest.mark.asyncio
 async def test_hvac_action_heating_when_temp_below_target(hass: HomeAssistant) -> None:
-    """Test HVAC action inference: HEATING when temp below target.
-
-    Validates: hvac_action attribute shows HEATING with hysteresis
-    Tests through: hass.states (core interface)
-    Scenario: Heat mode, current 19°C, target 21°C (> 0.5°C threshold)
-    """
-    # Create unit with temp below target
-    mock_unit = create_mock_unit(
-        operation_mode="Heat",
-        set_temperature=21.0,
-        room_temperature=19.0,  # 2°C below target (exceeds 0.5°C hysteresis)
+    """Test HVAC action inference: HEATING when temp below target."""
+    mock_unit = create_mock_ata_unit(
+        operation_mode="Heat", set_temperature=21.0, room_temperature=19.0
     )
-    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # ✅ CORRECT: Assert through state machine
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_climate")
-        assert state is not None
-        assert state.attributes["hvac_action"] == HVACAction.HEATING
+    state = hass.states.get(_CLIMATE_ENTITY)
+    assert state is not None
+    assert state.attributes["hvac_action"] == HVACAction.HEATING
 
 
 @pytest.mark.asyncio
 async def test_hvac_action_idle_when_temp_at_target(hass: HomeAssistant) -> None:
-    """Test HVAC action inference: IDLE when temp at target.
-
-    Validates: hvac_action attribute shows IDLE
-    Tests through: hass.states (core interface)
-    Scenario: Heat mode, current 21°C, target 21°C (within hysteresis)
-    """
-    mock_unit = create_mock_unit(
-        operation_mode="Heat",
-        set_temperature=21.0,
-        room_temperature=21.0,  # At target
+    """Test HVAC action inference: IDLE when temp at target."""
+    mock_unit = create_mock_ata_unit(
+        operation_mode="Heat", set_temperature=21.0, room_temperature=21.0
     )
-    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_climate")
-        assert state is not None
-        assert state.attributes["hvac_action"] == HVACAction.IDLE
+    state = hass.states.get(_CLIMATE_ENTITY)
+    assert state is not None
+    assert state.attributes["hvac_action"] == HVACAction.IDLE
 
 
 @pytest.mark.asyncio
 async def test_hvac_action_cooling_when_temp_above_target(hass: HomeAssistant) -> None:
-    """Test HVAC action inference: COOLING when temp above target.
-
-    Validates: hvac_action attribute shows COOLING with hysteresis
-    Tests through: hass.states (core interface)
-    Scenario: Cool mode, current 22°C, target 20°C (> 0.5°C threshold)
-    """
-    mock_unit = create_mock_unit(
-        operation_mode="Cool",
-        set_temperature=20.0,
-        room_temperature=22.0,  # 2°C above target (exceeds 0.5°C hysteresis)
+    """Test HVAC action inference: COOLING when temp above target."""
+    mock_unit = create_mock_ata_unit(
+        operation_mode="Cool", set_temperature=20.0, room_temperature=22.0
     )
-    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_climate")
-        assert state is not None
-        assert state.attributes["hvac_action"] == HVACAction.COOLING
+    state = hass.states.get(_CLIMATE_ENTITY)
+    assert state is not None
+    assert state.attributes["hvac_action"] == HVACAction.COOLING
 
 
 @pytest.mark.asyncio
 async def test_device_unavailable_when_in_error_state(hass: HomeAssistant) -> None:
-    """Test that device shows as unavailable when in error state.
+    """Test that device shows as unavailable when in error state."""
+    mock_unit = create_mock_ata_unit(is_in_error=True)
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(hass, mock_context)
 
-    Validates: Entity availability reflects device error state
-    Tests through: hass.states (core interface)
-    Scenario: Device with is_in_error=True
-    """
-    mock_unit = create_mock_unit(is_in_error=True)
-    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
-
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_climate")
-        assert state is not None
-        assert state.state == "unavailable"
+    state = hass.states.get(_CLIMATE_ENTITY)
+    assert state is not None
+    assert state.state == "unavailable"
 
 
 @pytest.mark.asyncio
 async def test_device_power_off_shows_hvac_mode_off(hass: HomeAssistant) -> None:
-    """Test that device power OFF maps to HVACMode.OFF.
+    """Test that device power OFF maps to HVACMode.OFF."""
+    mock_unit = create_mock_ata_unit(power=False, operation_mode="Heat")
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(hass, mock_context)
 
-    Validates: Powered off device shows OFF state regardless of mode
-    Tests through: hass.states (core interface)
-    Scenario: Device with power=False, operation_mode="Heat"
-    """
-    mock_unit = create_mock_unit(power=False, operation_mode="Heat")
-    mock_context = create_mock_user_context([create_mock_building(units=[mock_unit])])
-
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_climate")
-        assert state is not None
-        assert state.state == HVACMode.OFF
-        assert state.attributes["hvac_action"] == HVACAction.OFF
+    state = hass.states.get(_CLIMATE_ENTITY)
+    assert state is not None
+    assert state.state == HVACMode.OFF
+    assert state.attributes["hvac_action"] == HVACAction.OFF
 
 
 @pytest.mark.asyncio
-async def test_turn_on_and_turn_off_services(
-    hass: HomeAssistant, setup_integration: MockConfigEntry
-) -> None:
-    """Test turn_on and turn_off service calls.
-
-    Validates: Turn on/off services accepted without error
-    Tests through: hass.services (core interface)
-    """
-    # Turn off
-    await hass.services.async_call(
-        "climate",
-        "turn_off",
-        {"entity_id": "climate.melcloudhome_0efc_9abc_climate"},
-        blocking=True,
+async def test_turn_on_and_turn_off_services(hass: HomeAssistant) -> None:
+    """Test turn_on and turn_off service calls."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
     )
 
-    # Turn on
     await hass.services.async_call(
-        "climate",
-        "turn_on",
-        {"entity_id": "climate.melcloudhome_0efc_9abc_climate"},
-        blocking=True,
+        "climate", "turn_off", {"entity_id": _CLIMATE_ENTITY}, blocking=True
     )
-
-    # Both calls succeeded (no exception raised)
+    await hass.services.async_call(
+        "climate", "turn_on", {"entity_id": _CLIMATE_ENTITY}, blocking=True
+    )
 
 
 @pytest.mark.asyncio
 async def test_device_removal_entity_becomes_unavailable(hass: HomeAssistant) -> None:
-    """Test that entity becomes unavailable when device is removed.
+    """Test that entity becomes unavailable when device is removed."""
+    mock_context = create_mock_ata_user_context([create_mock_ata_building(units=[])])
+    await setup_ata_integration_custom(hass, mock_context)
 
-    Validates: Entity handles device removal gracefully
-    Tests through: hass.states (core interface)
-    Scenario: Building with no units (device removed from account)
-    """
-    # Setup with empty units list
-    mock_context = create_mock_user_context([create_mock_building(units=[])])
-
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Entity won't be created if no units at setup
-        # This tests that setup doesn't crash with empty units
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_climate")
-        assert state is None  # Entity not created
+    state = hass.states.get(_CLIMATE_ENTITY)
+    assert state is None  # Entity not created when no units

--- a/tests/integration/test_climate_atw.py
+++ b/tests/integration/test_climate_atw.py
@@ -7,15 +7,11 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.components.climate import HVACAction, HVACMode
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.melcloudhome.const import DOMAIN
 
 from .conftest import (
     TEST_ATW_UNIT_ID,
@@ -23,131 +19,69 @@ from .conftest import (
     create_mock_atw_building,
     create_mock_atw_unit,
     create_mock_atw_user_context,
+    setup_atw_integration_custom,
 )
-
-# Mock at API boundary (NOT coordinator)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
 
 
 @pytest.mark.asyncio
 async def test_atw_climate_zone1_created(hass: HomeAssistant) -> None:
     """Test ATW Zone 1 climate entity is created."""
-    mock_unit = create_mock_atw_unit()
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit()])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check Zone 1 entity exists with correct naming
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-        assert state is not None
-        assert state.state == HVACMode.HEAT
-        assert state.attributes["current_temperature"] == 20.0
-        assert state.attributes["temperature"] == 21.0
+    state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
+    assert state is not None
+    assert state.state == HVACMode.HEAT
+    assert state.attributes["current_temperature"] == 20.0
+    assert state.attributes["temperature"] == 21.0
 
 
 @pytest.mark.asyncio
 async def test_atw_set_temperature_zone1(hass: HomeAssistant) -> None:
     """Test setting Zone 1 temperature via service."""
-    mock_unit = create_mock_atw_unit()
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit()])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_temperature_zone1 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw.set_temperature_zone1 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": TEST_CLIMATE_ZONE1_ENTITY_ID, "temperature": 22.5},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_temperature service
-        await hass.services.async_call(
-            "climate",
-            "set_temperature",
-            {
-                "entity_id": TEST_CLIMATE_ZONE1_ENTITY_ID,
-                "temperature": 22.5,
-            },
-            blocking=True,
-        )
-
-        # Verify API was called correctly
-        await hass.async_block_till_done()
-        mock_client.atw.set_temperature_zone1.assert_called_once_with(
-            TEST_ATW_UNIT_ID, 22.5
-        )
+    mock_client.atw.set_temperature_zone1.assert_called_once_with(
+        TEST_ATW_UNIT_ID, 22.5
+    )
 
 
 @pytest.mark.asyncio
 async def test_atw_hvac_mode_heat_powers_up_system(hass: HomeAssistant) -> None:
     """Test setting HVAC mode to HEAT powers up ATW system."""
-    mock_unit = create_mock_atw_unit(power=False)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(power=False)])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_power = AsyncMock()
+    mock_client.atw.set_mode_zone1 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
-        mock_client.atw.set_power = AsyncMock()
-        mock_client.atw.set_mode_zone1 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": TEST_CLIMATE_ZONE1_ENTITY_ID, "hvac_mode": HVACMode.HEAT},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_hvac_mode service
-        await hass.services.async_call(
-            "climate",
-            "set_hvac_mode",
-            {
-                "entity_id": TEST_CLIMATE_ZONE1_ENTITY_ID,
-                "hvac_mode": HVACMode.HEAT,
-            },
-            blocking=True,
-        )
-
-        # Verify API was called correctly (power on + set heat mode)
-        await hass.async_block_till_done()
-        mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, True)
-        mock_client.atw.set_mode_zone1.assert_called_once_with(
-            TEST_ATW_UNIT_ID, "HeatRoomTemperature"
-        )
+    mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, True)
+    mock_client.atw.set_mode_zone1.assert_called_once_with(
+        TEST_ATW_UNIT_ID, "HeatRoomTemperature"
+    )
 
 
 @pytest.mark.asyncio
@@ -155,107 +89,59 @@ async def test_atw_preset_mode_reflects_zone_operation_mode(
     hass: HomeAssistant,
 ) -> None:
     """Test preset mode reflects Zone 1 operation mode."""
-    mock_unit = create_mock_atw_unit(operation_mode_zone1="HeatRoomTemperature")
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [
+            create_mock_atw_building(
+                units=[create_mock_atw_unit(operation_mode_zone1="HeatRoomTemperature")]
+            )
+        ]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-        assert state.attributes["preset_mode"] == "room"
+    state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
+    assert state.attributes["preset_mode"] == "room"
 
 
 @pytest.mark.asyncio
 async def test_atw_set_preset_mode_room_to_flow(hass: HomeAssistant) -> None:
     """Test changing preset mode from room to flow."""
-    mock_unit = create_mock_atw_unit(operation_mode_zone1="HeatRoomTemperature")
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [
+            create_mock_atw_building(
+                units=[create_mock_atw_unit(operation_mode_zone1="HeatRoomTemperature")]
+            )
+        ]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_mode_zone1 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw.set_mode_zone1 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_preset_mode service
-        await hass.services.async_call(
-            "climate",
-            "set_preset_mode",
-            {
-                "entity_id": "climate.melcloudhome_0efc_9abc_zone_1",
-                "preset_mode": "flow",
-            },
-            blocking=True,
-        )
-
-        # Service succeeded without errors
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": "climate.melcloudhome_0efc_9abc_zone_1", "preset_mode": "flow"},
+        blocking=True,
+    )
 
 
 @pytest.mark.asyncio
 async def test_atw_set_preset_mode_flow_to_curve(hass: HomeAssistant) -> None:
     """Test changing preset mode from flow to curve."""
-    mock_unit = create_mock_atw_unit(operation_mode_zone1="HeatFlowTemperature")
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [
+            create_mock_atw_building(
+                units=[create_mock_atw_unit(operation_mode_zone1="HeatFlowTemperature")]
+            )
+        ]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_mode_zone1 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw.set_mode_zone1 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_preset_mode service
-        await hass.services.async_call(
-            "climate",
-            "set_preset_mode",
-            {
-                "entity_id": "climate.melcloudhome_0efc_9abc_zone_1",
-                "preset_mode": "curve",
-            },
-            blocking=True,
-        )
-
-        # Service succeeded without errors
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": "climate.melcloudhome_0efc_9abc_zone_1", "preset_mode": "curve"},
+        blocking=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -263,34 +149,18 @@ async def test_atw_hvac_action_idle_when_valve_on_dhw(hass: HomeAssistant) -> No
     """Test HVAC action is IDLE when 3-way valve is on DHW (ATW-specific)."""
     mock_unit = create_mock_atw_unit(
         power=True,
-        room_temperature_zone1=18.0,  # Below target
+        room_temperature_zone1=18.0,
         set_temperature_zone1=21.0,
         operation_mode_zone1="HeatRoomTemperature",
-        operation_status="HotWater",  # Valve on DHW, not Zone 1
+        operation_status="HotWater",
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-        # Even though temp is below target, hvac_action is IDLE because valve is on DHW
-        assert state.attributes["hvac_action"] == HVACAction.IDLE
+    state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
+    assert state.attributes["hvac_action"] == HVACAction.IDLE
 
 
 @pytest.mark.asyncio
@@ -300,34 +170,18 @@ async def test_atw_hvac_action_heating_when_valve_on_zone1_and_below_target(
     """Test HVAC action is HEATING when valve on Zone 1 and below target."""
     mock_unit = create_mock_atw_unit(
         power=True,
-        room_temperature_zone1=18.0,  # Below target
+        room_temperature_zone1=18.0,
         set_temperature_zone1=21.0,
         operation_mode_zone1="HeatRoomTemperature",
-        operation_status="Heating",  # Real API returns simplified status
+        operation_status="Heating",
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-        # Valve is on Zone 1 and temp below target, so HEATING
-        assert state.attributes["hvac_action"] == HVACAction.HEATING
+    state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
+    assert state.attributes["hvac_action"] == HVACAction.HEATING
 
 
 @pytest.mark.asyncio
@@ -336,33 +190,17 @@ async def test_atw_extra_state_attributes_include_valve_status(
 ) -> None:
     """Test extra state attributes include operation_status and valve info."""
     mock_unit = create_mock_atw_unit(
-        operation_status="Heating",
-        forced_hot_water_mode=False,
+        operation_status="Heating", forced_hot_water_mode=False
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-        assert state.attributes["operation_status"] == "Heating"
-        assert "forced_dhw_active" in state.attributes
-        assert "zone_heating_available" in state.attributes
+    state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
+    assert state.attributes["operation_status"] == "Heating"
+    assert "forced_dhw_active" in state.attributes
+    assert "zone_heating_available" in state.attributes
 
 
 @pytest.mark.asyncio
@@ -370,29 +208,14 @@ async def test_atw_climate_unavailable_when_device_in_error(
     hass: HomeAssistant,
 ) -> None:
     """Test ATW climate entity unavailable when device in error."""
-    mock_unit = create_mock_atw_unit(is_in_error=True)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(is_in_error=True)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-        assert state.state == "unavailable"
+    assert (
+        hass.states.get("climate.melcloudhome_0efc_9abc_zone_1").state == "unavailable"
+    )
 
 
 @pytest.mark.asyncio
@@ -400,59 +223,27 @@ async def test_atw_climate_zone_naming_includes_zone_1_suffix(
     hass: HomeAssistant,
 ) -> None:
     """Test ATW climate entity ID includes zone_1 suffix."""
-    mock_unit = create_mock_atw_unit()
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit()])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Entity ID should include _zone_1 suffix
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-        assert state is not None
-        assert "_zone_1" in state.entity_id
+    state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
+    assert state is not None
+    assert "_zone_1" in state.entity_id
 
 
 @pytest.mark.asyncio
 async def test_atw_climate_off_when_power_false(hass: HomeAssistant) -> None:
     """Test ATW climate state is OFF when power is false."""
-    mock_unit = create_mock_atw_unit(power=False)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(power=False)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-        assert state.state == HVACMode.OFF
+    assert (
+        hass.states.get("climate.melcloudhome_0efc_9abc_zone_1").state == HVACMode.OFF
+    )
 
 
 # ==============================================================================
@@ -465,31 +256,15 @@ async def test_atw_cooling_hvac_mode_available_when_capability_enabled(
     hass: HomeAssistant,
 ) -> None:
     """Test COOL hvac_mode available when has_cooling_mode=True."""
-    mock_unit = create_mock_atw_unit(has_cooling_mode=True)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(has_cooling_mode=True)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
-        assert HVACMode.COOL in state.attributes["hvac_modes"]
-        assert HVACMode.HEAT in state.attributes["hvac_modes"]
-        assert HVACMode.OFF in state.attributes["hvac_modes"]
+    state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
+    assert HVACMode.COOL in state.attributes["hvac_modes"]
+    assert HVACMode.HEAT in state.attributes["hvac_modes"]
+    assert HVACMode.OFF in state.attributes["hvac_modes"]
 
 
 @pytest.mark.asyncio
@@ -497,30 +272,14 @@ async def test_atw_cooling_hvac_mode_unavailable_without_capability(
     hass: HomeAssistant,
 ) -> None:
     """Test COOL hvac_mode unavailable when has_cooling_mode=False."""
-    mock_unit = create_mock_atw_unit(has_cooling_mode=False)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(has_cooling_mode=False)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
-        assert HVACMode.COOL not in state.attributes["hvac_modes"]
-        assert HVACMode.HEAT in state.attributes["hvac_modes"]
+    state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
+    assert HVACMode.COOL not in state.attributes["hvac_modes"]
+    assert HVACMode.HEAT in state.attributes["hvac_modes"]
 
 
 @pytest.mark.asyncio
@@ -529,32 +288,16 @@ async def test_atw_cooling_mode_detected_from_operation_mode(
 ) -> None:
     """Test cooling mode detected from CoolRoomTemperature operation mode."""
     mock_unit = create_mock_atw_unit(
-        has_cooling_mode=True,
-        operation_mode_zone1="CoolRoomTemperature",
+        has_cooling_mode=True, operation_mode_zone1="CoolRoomTemperature"
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
-        assert state.state == HVACMode.COOL
-        assert state.attributes["preset_mode"] == "room"
+    state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
+    assert state.state == HVACMode.COOL
+    assert state.attributes["preset_mode"] == "room"
 
 
 @pytest.mark.asyncio
@@ -563,70 +306,38 @@ async def test_atw_cooling_preset_modes_only_room_and_flow(
 ) -> None:
     """Test cooling mode shows only room and flow presets (no curve)."""
     mock_unit = create_mock_atw_unit(
-        has_cooling_mode=True,
-        operation_mode_zone1="CoolRoomTemperature",
+        has_cooling_mode=True, operation_mode_zone1="CoolRoomTemperature"
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
-        preset_modes = state.attributes["preset_modes"]
-        assert "room" in preset_modes
-        assert "flow" in preset_modes
-        assert "curve" not in preset_modes  # Curve not available in cooling
-        assert len(preset_modes) == 2
+    state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
+    preset_modes = state.attributes["preset_modes"]
+    assert "room" in preset_modes
+    assert "flow" in preset_modes
+    assert "curve" not in preset_modes
+    assert len(preset_modes) == 2
 
 
 @pytest.mark.asyncio
 async def test_atw_heating_preset_modes_all_three(hass: HomeAssistant) -> None:
     """Test heating mode shows all three presets (room, flow, curve)."""
     mock_unit = create_mock_atw_unit(
-        has_cooling_mode=True,
-        operation_mode_zone1="HeatRoomTemperature",
+        has_cooling_mode=True, operation_mode_zone1="HeatRoomTemperature"
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
-        preset_modes = state.attributes["preset_modes"]
-        assert "room" in preset_modes
-        assert "flow" in preset_modes
-        assert "curve" in preset_modes
-        assert len(preset_modes) == 3
+    state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
+    preset_modes = state.attributes["preset_modes"]
+    assert "room" in preset_modes
+    assert "flow" in preset_modes
+    assert "curve" in preset_modes
+    assert len(preset_modes) == 3
 
 
 @pytest.mark.asyncio
@@ -635,78 +346,42 @@ async def test_atw_cooling_temperature_step_always_one_degree(
 ) -> None:
     """Test cooling mode always uses 1.0°C temperature step."""
     mock_unit = create_mock_atw_unit(
-        has_cooling_mode=True,
-        operation_mode_zone1="CoolRoomTemperature",
+        has_cooling_mode=True, operation_mode_zone1="CoolRoomTemperature"
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID)
-        assert state.attributes["target_temp_step"] == 1.0
+    assert (
+        hass.states.get(TEST_CLIMATE_ZONE1_ENTITY_ID).attributes["target_temp_step"]
+        == 1.0
+    )
 
 
 @pytest.mark.asyncio
 async def test_atw_set_preset_mode_in_cooling(hass: HomeAssistant) -> None:
     """Test setting preset mode from room to flow in cooling mode."""
     mock_unit = create_mock_atw_unit(
-        has_cooling_mode=True,
-        operation_mode_zone1="CoolRoomTemperature",
+        has_cooling_mode=True, operation_mode_zone1="CoolRoomTemperature"
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_mode_zone1 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
-        mock_client.atw.set_mode_zone1 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": TEST_CLIMATE_ZONE1_ENTITY_ID, "preset_mode": "flow"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_preset_mode service
-        await hass.services.async_call(
-            "climate",
-            "set_preset_mode",
-            {
-                "entity_id": TEST_CLIMATE_ZONE1_ENTITY_ID,
-                "preset_mode": "flow",
-            },
-            blocking=True,
-        )
-
-        # Verify API called with cooling flow mode
-        await hass.async_block_till_done()
-        mock_client.atw.set_mode_zone1.assert_called_once_with(
-            TEST_ATW_UNIT_ID, "CoolFlowTemperature"
-        )
+    mock_client.atw.set_mode_zone1.assert_called_once_with(
+        TEST_ATW_UNIT_ID, "CoolFlowTemperature"
+    )
 
 
 @pytest.mark.asyncio
@@ -714,46 +389,25 @@ async def test_atw_set_hvac_mode_to_cool(hass: HomeAssistant) -> None:
     """Test setting HVAC mode to COOL."""
     mock_unit = create_mock_atw_unit(
         has_cooling_mode=True,
-        power=False,  # Start with power off so set_power(True) is actually called
+        power=False,
         operation_mode_zone1="HeatRoomTemperature",
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_power = AsyncMock()
+    mock_client.atw.set_mode_zone1 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
-        mock_client.atw.set_power = AsyncMock()
-        mock_client.atw.set_mode_zone1 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": TEST_CLIMATE_ZONE1_ENTITY_ID, "hvac_mode": HVACMode.COOL},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_hvac_mode service
-        await hass.services.async_call(
-            "climate",
-            "set_hvac_mode",
-            {
-                "entity_id": TEST_CLIMATE_ZONE1_ENTITY_ID,
-                "hvac_mode": HVACMode.COOL,
-            },
-            blocking=True,
-        )
-
-        # Verify API calls (power on + set cool mode)
-        await hass.async_block_till_done()
-        mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, True)
-        mock_client.atw.set_mode_zone1.assert_called_once_with(
-            TEST_ATW_UNIT_ID, "CoolRoomTemperature"
-        )
+    mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, True)
+    mock_client.atw.set_mode_zone1.assert_called_once_with(
+        TEST_ATW_UNIT_ID, "CoolRoomTemperature"
+    )

--- a/tests/integration/test_climate_atw_zone2.py
+++ b/tests/integration/test_climate_atw_zone2.py
@@ -7,15 +7,11 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.components.climate import HVACAction, HVACMode
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.melcloudhome.const import DOMAIN
 
 from .conftest import (
     TEST_ATW_UNIT_ID,
@@ -24,10 +20,8 @@ from .conftest import (
     create_mock_atw_building,
     create_mock_atw_unit,
     create_mock_atw_user_context,
+    setup_atw_integration_custom,
 )
-
-# Mock at API boundary (NOT coordinator)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
 
 
 @pytest.mark.asyncio
@@ -42,29 +36,14 @@ async def test_atw_climate_zone2_created_when_has_zone2(hass: HomeAssistant) -> 
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
-        assert state is not None
-        assert state.state == HVACMode.HEAT
-        assert state.attributes["current_temperature"] == 20.0
-        assert state.attributes["temperature"] == 21.0
-        assert state.attributes["preset_mode"] == "flow"
+    state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
+    assert state is not None
+    assert state.state == HVACMode.HEAT
+    assert state.attributes["current_temperature"] == 20.0
+    assert state.attributes["temperature"] == 21.0
+    assert state.attributes["preset_mode"] == "flow"
 
 
 @pytest.mark.asyncio
@@ -72,119 +51,59 @@ async def test_atw_climate_zone2_not_created_when_no_zone2(
     hass: HomeAssistant,
 ) -> None:
     """Test ATW Zone 2 climate entity is not created when device lacks Zone 2."""
-    mock_unit = create_mock_atw_unit(has_zone2=False)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(has_zone2=False)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
-        assert state is None
+    assert hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID) is None
 
 
 @pytest.mark.asyncio
 async def test_atw_set_temperature_zone2(hass: HomeAssistant) -> None:
     """Test setting Zone 2 temperature via service."""
-    mock_unit = create_mock_atw_unit(has_zone2=True)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(has_zone2=True)])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_temperature_zone2 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw.set_temperature_zone2 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        {"entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID, "temperature": 22.5},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_temperature service
-        await hass.services.async_call(
-            "climate",
-            "set_temperature",
-            {
-                "entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID,
-                "temperature": 22.5,
-            },
-            blocking=True,
-        )
-
-        # Verify API was called correctly
-        await hass.async_block_till_done()
-        mock_client.atw.set_temperature_zone2.assert_called_once_with(
-            TEST_ATW_UNIT_ID, 22.5
-        )
+    mock_client.atw.set_temperature_zone2.assert_called_once_with(
+        TEST_ATW_UNIT_ID, 22.5
+    )
 
 
 @pytest.mark.asyncio
 async def test_atw_set_preset_mode_zone2(hass: HomeAssistant) -> None:
     """Test changing Zone 2 preset mode to flow."""
     mock_unit = create_mock_atw_unit(
-        has_zone2=True,
-        operation_mode_zone2="HeatRoomTemperature",
+        has_zone2=True, operation_mode_zone2="HeatRoomTemperature"
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_mode_zone2 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
-        mock_client.atw.set_mode_zone2 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID, "preset_mode": "flow"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_preset_mode service
-        await hass.services.async_call(
-            "climate",
-            "set_preset_mode",
-            {
-                "entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID,
-                "preset_mode": "flow",
-            },
-            blocking=True,
-        )
-
-        # Verify API was called with correct ATW mode
-        await hass.async_block_till_done()
-        mock_client.atw.set_mode_zone2.assert_called_once_with(
-            TEST_ATW_UNIT_ID, "HeatFlowTemperature"
-        )
+    mock_client.atw.set_mode_zone2.assert_called_once_with(
+        TEST_ATW_UNIT_ID, "HeatFlowTemperature"
+    )
 
 
 @pytest.mark.asyncio
@@ -201,25 +120,10 @@ async def test_atw_zone2_hvac_action_heating(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
-        assert state.attributes["hvac_action"] == HVACAction.HEATING
+    state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
+    assert state.attributes["hvac_action"] == HVACAction.HEATING
 
 
 @pytest.mark.asyncio
@@ -234,26 +138,11 @@ async def test_atw_zone2_temperature_sensor_created(hass: HomeAssistant) -> None
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_SENSOR_ZONE2_TEMP)
-        assert state is not None
-        assert float(state.state) == 20.0
+    state = hass.states.get(TEST_SENSOR_ZONE2_TEMP)
+    assert state is not None
+    assert float(state.state) == 20.0
 
 
 @pytest.mark.asyncio
@@ -261,74 +150,35 @@ async def test_atw_zone2_temperature_sensor_not_created_without_zone2(
     hass: HomeAssistant,
 ) -> None:
     """Test Zone 2 temperature sensor NOT created without Zone 2."""
-    mock_unit = create_mock_atw_unit(has_zone2=False)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(has_zone2=False)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_SENSOR_ZONE2_TEMP)
-        assert state is None
+    assert hass.states.get(TEST_SENSOR_ZONE2_TEMP) is None
 
 
 @pytest.mark.asyncio
 async def test_atw_zone2_hvac_mode_off(hass: HomeAssistant) -> None:
     """Test setting Zone 2 HVAC mode to OFF powers down the system."""
     mock_unit = create_mock_atw_unit(
-        has_zone2=True,
-        power=True,
-        operation_mode_zone2="HeatRoomTemperature",
+        has_zone2=True, power=True, operation_mode_zone2="HeatRoomTemperature"
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_power = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw.set_power = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID, "hvac_mode": HVACMode.OFF},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Set HVAC mode to OFF
-        await hass.services.async_call(
-            "climate",
-            "set_hvac_mode",
-            {
-                "entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID,
-                "hvac_mode": HVACMode.OFF,
-            },
-            blocking=True,
-        )
-
-        # Verify power off was called
-        await hass.async_block_till_done()
-        mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, False)
+    mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, False)
 
 
 @pytest.mark.asyncio
@@ -345,32 +195,14 @@ async def test_atw_zone2_extra_state_attributes(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
-        assert state is not None
-
-        # Verify extra state attributes (system-wide)
-        assert state.attributes["operation_status"] == "Heating"
-        assert state.attributes["forced_dhw_active"] is False
-        assert state.attributes["ftc_model"] == 3
-        # Note: zone_heating_available is True for both zones when system is heating
-        assert state.attributes["zone_heating_available"] is True
+    state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
+    assert state is not None
+    assert state.attributes["operation_status"] == "Heating"
+    assert state.attributes["forced_dhw_active"] is False
+    assert state.attributes["ftc_model"] == 3
+    assert state.attributes["zone_heating_available"] is True
 
 
 @pytest.mark.asyncio
@@ -382,90 +214,50 @@ async def test_atw_zone2_zone_heating_not_available_when_stopped(
         has_zone2=True,
         power=True,
         operation_mode_zone2="HeatRoomTemperature",
-        operation_status="Stop",  # System idle
+        operation_status="Stop",
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
-        assert state is not None
-        assert state.attributes["zone_heating_available"] is False
+    state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
+    assert state is not None
+    assert state.attributes["zone_heating_available"] is False
 
 
 @pytest.mark.asyncio
 async def test_atw_zone2_preset_mode_transitions(hass: HomeAssistant) -> None:
     """Test Zone 2 preset mode transitions (flow to curve, curve to room)."""
     mock_unit = create_mock_atw_unit(
-        has_zone2=True,
-        operation_mode_zone2="HeatFlowTemperature",
+        has_zone2=True, operation_mode_zone2="HeatFlowTemperature"
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_mode_zone2 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
-        mock_client.atw.set_mode_zone2 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID, "preset_mode": "curve"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mock_client.atw.set_mode_zone2.assert_called_with(TEST_ATW_UNIT_ID, "HeatCurve")
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Test flow -> curve
-        await hass.services.async_call(
-            "climate",
-            "set_preset_mode",
-            {
-                "entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID,
-                "preset_mode": "curve",
-            },
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        mock_client.atw.set_mode_zone2.assert_called_with(TEST_ATW_UNIT_ID, "HeatCurve")
-
-        # Test curve -> room
-        mock_client.atw.set_mode_zone2.reset_mock()
-        await hass.services.async_call(
-            "climate",
-            "set_preset_mode",
-            {
-                "entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID,
-                "preset_mode": "room",
-            },
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        mock_client.atw.set_mode_zone2.assert_called_with(
-            TEST_ATW_UNIT_ID, "HeatRoomTemperature"
-        )
+    mock_client.atw.set_mode_zone2.reset_mock()
+    await hass.services.async_call(
+        "climate",
+        "set_preset_mode",
+        {"entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID, "preset_mode": "room"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mock_client.atw.set_mode_zone2.assert_called_with(
+        TEST_ATW_UNIT_ID, "HeatRoomTemperature"
+    )
 
 
 @pytest.mark.asyncio
@@ -479,26 +271,11 @@ async def test_atw_zone2_cooling_mode_available(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
-        assert state is not None
-        assert HVACMode.COOL in state.attributes["hvac_modes"]
+    state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
+    assert state is not None
+    assert HVACMode.COOL in state.attributes["hvac_modes"]
 
 
 @pytest.mark.asyncio
@@ -514,26 +291,11 @@ async def test_atw_zone2_cooling_mode_detected(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
-        assert state.state == HVACMode.COOL
-        assert state.attributes["hvac_action"] == HVACAction.COOLING
+    state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
+    assert state.state == HVACMode.COOL
+    assert state.attributes["hvac_action"] == HVACAction.COOLING
 
 
 @pytest.mark.asyncio
@@ -548,40 +310,20 @@ async def test_atw_zone2_set_cooling_mode(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_mode_zone2 = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
-        mock_client.atw.set_mode_zone2 = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID, "hvac_mode": HVACMode.COOL},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Set HVAC mode to COOL
-        await hass.services.async_call(
-            "climate",
-            "set_hvac_mode",
-            {
-                "entity_id": TEST_CLIMATE_ZONE2_ENTITY_ID,
-                "hvac_mode": HVACMode.COOL,
-            },
-            blocking=True,
-        )
-
-        await hass.async_block_till_done()
-        mock_client.atw.set_mode_zone2.assert_called_once_with(
-            TEST_ATW_UNIT_ID, "CoolRoomTemperature"
-        )
+    mock_client.atw.set_mode_zone2.assert_called_once_with(
+        TEST_ATW_UNIT_ID, "CoolRoomTemperature"
+    )
 
 
 @pytest.mark.asyncio
@@ -596,28 +338,11 @@ async def test_atw_zone2_cooling_preset_modes(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
-        assert state is not None
-
-        # In cooling mode, only room and flow presets available (no curve)
-        preset_modes = state.attributes["preset_modes"]
-        assert "room" in preset_modes
-        assert "flow" in preset_modes
-        assert "curve" not in preset_modes
+    state = hass.states.get(TEST_CLIMATE_ZONE2_ENTITY_ID)
+    assert state is not None
+    preset_modes = state.attributes["preset_modes"]
+    assert "room" in preset_modes
+    assert "flow" in preset_modes
+    assert "curve" not in preset_modes

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -21,8 +21,8 @@ from custom_components.melcloudhome.api.models_ata import (
 )
 from custom_components.melcloudhome.const import DOMAIN
 
-# Mock at API boundary (NOT coordinator)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
+from .conftest import MOCK_CLIENT_PATH
+
 MOCK_STORE_PATH = "custom_components.melcloudhome.energy_tracker_base.Store"
 
 # Test device UUID - generates entity_id: sensor.melcloudhome_0efc_9abc_energy

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -20,9 +20,7 @@ from .conftest import (
     MOCK_CLIENT_PATH,
     TEST_ATA_BUILDING_ID,
     TEST_ATA_UNIT_ID,
-    create_mock_ata_building,
-    create_mock_ata_unit,
-    create_mock_ata_user_context,
+    create_mock_ata_energy_context,
 )
 
 MOCK_STORE_PATH = "custom_components.melcloudhome.energy_tracker_base.Store"
@@ -70,9 +68,7 @@ async def test_initial_energy_fetch_with_first_init(hass: HomeAssistant) -> None
     Validates: First initialization behavior prevents inflating totals
     Tests through: hass.states (sensor entity state)
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # Mock energy response with 2 hours of historical data (should be skipped)
     mock_energy_data = create_mock_energy_response(
@@ -113,7 +109,7 @@ async def test_initial_energy_fetch_with_first_init(hass: HomeAssistant) -> None
         await hass.async_block_till_done()
 
         # ✅ CORRECT: Assert through state machine
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
         assert state.state == "0.0"  # Should start at 0, not include historical data
         assert state.attributes["unit_of_measurement"] == "kWh"
@@ -135,9 +131,7 @@ async def test_energy_accumulation_cumulative_totals(hass: HomeAssistant) -> Non
     Validates: Energy accumulation logic works correctly
     Tests through: hass.states (sensor shows accumulated total)
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # Initial state: 1 hour already processed
     initial_storage = {
@@ -186,7 +180,7 @@ async def test_energy_accumulation_cumulative_totals(hass: HomeAssistant) -> Non
         await hass.async_block_till_done()
 
         # ✅ CORRECT: Assert through state machine
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
         # Expected: 0.5 (initial) + 0.6 (11:00) + 0.7 (12:00) = 1.8 kWh
@@ -219,9 +213,7 @@ async def test_double_hour_prevention(hass: HomeAssistant) -> None:
     Validates: Double-counting prevention works correctly
     Tests through: hass.states (total doesn't increase on duplicate)
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # Initial state: 2 hours already processed
     initial_storage = {
@@ -270,7 +262,7 @@ async def test_double_hour_prevention(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         # ✅ CORRECT: Assert through state machine
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
         # Should still be 1.1 kWh (no new hours added)
@@ -314,9 +306,7 @@ async def test_energy_topping_up_progressive_updates(hass: HomeAssistant) -> Non
     Validates: GitHub issue #23 - Wrong amount of consumed energy
     Tests through: hass.states (sensor shows correct accumulated total)
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # Initial state: 10.0 kWh already accumulated, no hour tracking yet
     initial_storage = {
@@ -358,7 +348,7 @@ async def test_energy_topping_up_progressive_updates(hass: HomeAssistant) -> Non
         await hass.async_block_till_done()
 
         # ✅ Should be 10.0 + 0.1 = 10.1 kWh
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
         assert float(state.state) == pytest.approx(10.1, rel=0.01)
 
@@ -375,7 +365,7 @@ async def test_energy_topping_up_progressive_updates(hass: HomeAssistant) -> Non
         await hass.async_block_till_done()
 
         # ✅ Should add delta: 0.3 - 0.1 = 0.2 kWh → 10.1 + 0.2 = 10.3 kWh
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert float(state.state) == pytest.approx(10.3, rel=0.01)
         # ❌ WILL FAIL with current code: stays at 10.1 (skips "old" hour)
 
@@ -395,7 +385,7 @@ async def test_energy_topping_up_progressive_updates(hass: HomeAssistant) -> Non
 
         # ✅ Should add: delta 09:00 (0.1) + new 10:00 (0.1) = 0.2 kWh
         # 10.3 + 0.2 = 10.5 kWh
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert float(state.state) == pytest.approx(10.5, rel=0.01)
         # ❌ WILL FAIL with current code: would be 10.2 (skips 09:00 delta, adds 10:00)
 
@@ -428,9 +418,7 @@ async def test_energy_persistence_across_restarts(hass: HomeAssistant) -> None:
     Validates: Storage persistence works correctly
     Tests through: hass.states (sensor shows persisted value)
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # Simulated persisted data from previous session
     persisted_storage = {
@@ -478,7 +466,7 @@ async def test_energy_persistence_across_restarts(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         # ✅ CORRECT: Assert through state machine
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
         # Expected: 25.7 (persisted) + 0.9 (new hour) = 26.6 kWh
@@ -515,9 +503,7 @@ async def test_storage_migration_from_v1_3_4_to_v2_0(hass: HomeAssistant) -> Non
     Validates: Backward compatibility migration works correctly
     Tests through: Storage format conversion and functionality
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # v1.3.4 storage format (single-measure)
     v1_3_4_storage = {
@@ -569,7 +555,7 @@ async def test_storage_migration_from_v1_3_4_to_v2_0(hass: HomeAssistant) -> Non
         await hass.async_block_till_done()
 
         # ✅ Verify sensor exists and shows migrated value + new accumulation
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
         # Expected: 15.3 (migrated from v1.3.4) + 0.7 (new hour) = 16.0 kWh
         assert float(state.state) == pytest.approx(16.0, rel=0.01)
@@ -608,9 +594,7 @@ async def test_storage_no_migration_for_v2_0_format(hass: HomeAssistant) -> None
     Validates: v2.0 → v2.0 upgrade path works correctly
     Tests through: Storage format detection and loading
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # v2.0 storage format (multi-measure)
     v2_0_storage = {
@@ -670,7 +654,7 @@ async def test_storage_no_migration_for_v2_0_format(hass: HomeAssistant) -> None
         await hass.async_block_till_done()
 
         # ✅ Verify sensor exists and shows restored value + new accumulation
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
         # Expected: 20.5 (restored from v2.0) + 0.7 (new hour) = 21.2 kWh
         assert float(state.state) == pytest.approx(21.2, rel=0.01)
@@ -708,9 +692,7 @@ async def test_energy_update_failure_recovery(hass: HomeAssistant) -> None:
     Validates: Error handling prevents integration crash
     Tests through: hass.states (sensor exists but unavailable)
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # Initial state with some accumulated energy (simulating previous session)
     initial_storage = {
@@ -747,7 +729,7 @@ async def test_energy_update_failure_recovery(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         # ✅ CORRECT: Assert through state machine
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
         # Current behavior: sensor shows unavailable when initial fetch fails
@@ -755,7 +737,7 @@ async def test_energy_update_failure_recovery(hass: HomeAssistant) -> None:
         assert state.state == "unavailable"
 
         # Verify integration didn't crash - other sensors still work
-        climate_state = hass.states.get("climate.melcloudhome_0efc_9abc_climate")
+        climate_state = hass.states.get("climate.melcloudhome_a1b2_9abc_climate")
         assert climate_state is not None
         assert climate_state.state == "heat"  # Climate entity still functional
 
@@ -773,9 +755,7 @@ async def test_energy_polling_cancellation_on_shutdown(hass: HomeAssistant) -> N
     Validates: Clean shutdown prevents resource leaks
     Tests through: Integration setup/teardown
     """
-    mock_context = create_mock_ata_user_context(
-        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
-    )
+    mock_context = create_mock_ata_energy_context()
 
     # Mock energy data (will only be called during initial setup)
     mock_energy_data = create_mock_energy_response([("2025-01-15T10:00:00Z", 500.0)])
@@ -808,7 +788,7 @@ async def test_energy_polling_cancellation_on_shutdown(hass: HomeAssistant) -> N
         await hass.async_block_till_done()
 
         # Verify sensor exists
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
         # Reset call count after setup

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -14,69 +14,22 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.api.models import Building, UserContext
-from custom_components.melcloudhome.api.models_ata import (
-    AirToAirCapabilities,
-    AirToAirUnit,
-)
 from custom_components.melcloudhome.const import DOMAIN
 
-from .conftest import MOCK_CLIENT_PATH
+from .conftest import (
+    MOCK_CLIENT_PATH,
+    TEST_ATA_BUILDING_ID,
+    TEST_ATA_UNIT_ID,
+    create_mock_ata_building,
+    create_mock_ata_unit,
+    create_mock_ata_user_context,
+)
 
 MOCK_STORE_PATH = "custom_components.melcloudhome.energy_tracker_base.Store"
 
-# Test device UUID - generates entity_id: sensor.melcloudhome_0efc_9abc_energy
-TEST_UNIT_ID = "0efc1234-5678-9abc-def0-123456789abc"
-TEST_BUILDING_ID = "building-test-id"
-
-
-def create_mock_unit_with_energy(
-    unit_id: str = TEST_UNIT_ID,
-    name: str = "Test Unit",
-    has_energy_meter: bool = True,
-) -> AirToAirUnit:
-    """Create a mock AirToAirUnit with energy capabilities.
-
-    Uses real model class with realistic data.
-    """
-    capabilities = AirToAirCapabilities(has_energy_consumed_meter=has_energy_meter)
-
-    return AirToAirUnit(
-        id=unit_id,
-        name=name,
-        power=True,
-        operation_mode="Heat",
-        set_temperature=21.0,
-        room_temperature=20.0,
-        set_fan_speed="Auto",
-        vane_vertical_direction="Auto",
-        vane_horizontal_direction="Auto",
-        in_standby_mode=False,
-        is_in_error=False,
-        rssi=-50,
-        capabilities=capabilities,
-        energy_consumed=None,  # Will be populated by coordinator
-    )
-
-
-def create_mock_building_with_energy(
-    building_id: str = TEST_BUILDING_ID,
-    name: str = "Test Building",
-    units: list[AirToAirUnit] | None = None,
-) -> Building:
-    """Create a mock Building with energy-capable units."""
-    if units is None:
-        units = [create_mock_unit_with_energy()]
-    return Building(id=building_id, name=name, air_to_air_units=units)
-
-
-def create_mock_user_context_with_energy(
-    buildings: list[Building] | None = None,
-) -> UserContext:
-    """Create a mock UserContext with energy-capable devices."""
-    if buildings is None:
-        buildings = [create_mock_building_with_energy()]
-    return UserContext(buildings=buildings)
+# Aliases — used as dict keys in energy data assertions throughout this file
+TEST_UNIT_ID = TEST_ATA_UNIT_ID
+TEST_BUILDING_ID = TEST_ATA_BUILDING_ID
 
 
 def create_mock_energy_response(
@@ -117,7 +70,9 @@ async def test_initial_energy_fetch_with_first_init(hass: HomeAssistant) -> None
     Validates: First initialization behavior prevents inflating totals
     Tests through: hass.states (sensor entity state)
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # Mock energy response with 2 hours of historical data (should be skipped)
     mock_energy_data = create_mock_energy_response(
@@ -180,7 +135,9 @@ async def test_energy_accumulation_cumulative_totals(hass: HomeAssistant) -> Non
     Validates: Energy accumulation logic works correctly
     Tests through: hass.states (sensor shows accumulated total)
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # Initial state: 1 hour already processed
     initial_storage = {
@@ -262,7 +219,9 @@ async def test_double_hour_prevention(hass: HomeAssistant) -> None:
     Validates: Double-counting prevention works correctly
     Tests through: hass.states (total doesn't increase on duplicate)
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # Initial state: 2 hours already processed
     initial_storage = {
@@ -355,7 +314,9 @@ async def test_energy_topping_up_progressive_updates(hass: HomeAssistant) -> Non
     Validates: GitHub issue #23 - Wrong amount of consumed energy
     Tests through: hass.states (sensor shows correct accumulated total)
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # Initial state: 10.0 kWh already accumulated, no hour tracking yet
     initial_storage = {
@@ -467,7 +428,9 @@ async def test_energy_persistence_across_restarts(hass: HomeAssistant) -> None:
     Validates: Storage persistence works correctly
     Tests through: hass.states (sensor shows persisted value)
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # Simulated persisted data from previous session
     persisted_storage = {
@@ -552,7 +515,9 @@ async def test_storage_migration_from_v1_3_4_to_v2_0(hass: HomeAssistant) -> Non
     Validates: Backward compatibility migration works correctly
     Tests through: Storage format conversion and functionality
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # v1.3.4 storage format (single-measure)
     v1_3_4_storage = {
@@ -643,7 +608,9 @@ async def test_storage_no_migration_for_v2_0_format(hass: HomeAssistant) -> None
     Validates: v2.0 → v2.0 upgrade path works correctly
     Tests through: Storage format detection and loading
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # v2.0 storage format (multi-measure)
     v2_0_storage = {
@@ -741,7 +708,9 @@ async def test_energy_update_failure_recovery(hass: HomeAssistant) -> None:
     Validates: Error handling prevents integration crash
     Tests through: hass.states (sensor exists but unavailable)
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # Initial state with some accumulated energy (simulating previous session)
     initial_storage = {
@@ -804,7 +773,9 @@ async def test_energy_polling_cancellation_on_shutdown(hass: HomeAssistant) -> N
     Validates: Clean shutdown prevents resource leaks
     Tests through: Integration setup/teardown
     """
-    mock_context = create_mock_user_context_with_energy()
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[create_mock_ata_unit(has_energy_meter=True)])]
+    )
 
     # Mock energy data (will only be called during initial setup)
     mock_energy_data = create_mock_energy_response([("2025-01-15T10:00:00Z", 500.0)])

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -79,12 +79,12 @@ async def test_diagnostics_includes_entity_states(hass: HomeAssistant) -> None:
     assert "entities" in diagnostics
     entities = diagnostics["entities"]
 
-    climate_entity_id = "climate.melcloudhome_0efc_9abc_climate"
+    climate_entity_id = "climate.melcloudhome_a1b2_9abc_climate"
     assert climate_entity_id in entities
     assert entities[climate_entity_id]["state"] == "heat"
     assert "attributes" in entities[climate_entity_id]
 
-    temp_sensor_id = "sensor.melcloudhome_0efc_9abc_room_temperature"
+    temp_sensor_id = "sensor.melcloudhome_a1b2_9abc_room_temperature"
     assert temp_sensor_id in entities
     assert entities[temp_sensor_id]["state"] == "20.0"
 

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -15,92 +15,36 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.api.models import Building, UserContext
-from custom_components.melcloudhome.api.models_ata import (
-    AirToAirCapabilities,
-    AirToAirUnit,
-)
 from custom_components.melcloudhome.const import DOMAIN
 from custom_components.melcloudhome.diagnostics import (
     async_get_config_entry_diagnostics,
 )
 
-# Mock at API boundary (NOT coordinator or diagnostics internals)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
-
-# Test device identifiers
-TEST_UNIT_ID = "0efc1234-5678-9abc-def0-123456789abc"
-TEST_BUILDING_ID = "building-test-id"
-
-
-def create_mock_unit(
-    unit_id: str = TEST_UNIT_ID,
-    name: str = "Test Unit",
-    power: bool = True,
-    operation_mode: str = "Heat",
-    set_temperature: float = 21.0,
-    room_temperature: float = 20.0,
-    has_energy_meter: bool = False,
-) -> AirToAirUnit:
-    """Create a mock AirToAirUnit for diagnostics testing."""
-    capabilities = AirToAirCapabilities(has_energy_consumed_meter=has_energy_meter)
-
-    return AirToAirUnit(
-        id=unit_id,
-        name=name,
-        power=power,
-        operation_mode=operation_mode,
-        set_temperature=set_temperature,
-        room_temperature=room_temperature,
-        set_fan_speed="Auto",
-        vane_vertical_direction="Auto",
-        vane_horizontal_direction="Auto",
-        in_standby_mode=False,
-        is_in_error=False,
-        rssi=-50,
-        capabilities=capabilities,
-        energy_consumed=None,
-    )
-
-
-def create_mock_building(
-    building_id: str = TEST_BUILDING_ID,
-    name: str = "Test Building",
-    units: list[AirToAirUnit] | None = None,
-) -> Building:
-    """Create a mock Building for diagnostics testing."""
-    if units is None:
-        units = [create_mock_unit()]
-    return Building(id=building_id, name=name, air_to_air_units=units)
-
-
-def create_mock_user_context(buildings: list[Building] | None = None) -> UserContext:
-    """Create a mock UserContext for diagnostics testing."""
-    if buildings is None:
-        buildings = [create_mock_building()]
-    return UserContext(buildings=buildings)
+from .conftest import (
+    MOCK_CLIENT_PATH,
+    create_mock_ata_building,
+    create_mock_ata_unit,
+    create_mock_ata_user_context,
+    setup_ata_integration_custom,
+)
 
 
 @pytest.mark.asyncio
 async def test_diagnostics_basic_structure(hass: HomeAssistant) -> None:
     """Test diagnostics returns correct basic structure with redacted credentials."""
-    mock_context = create_mock_user_context()
+    mock_context = create_mock_ata_user_context()
 
+    # Non-standard entry: title + non-default password — keep inline
     with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Setup mock client
         mock_client = mock_client_class.return_value
         mock_client.login = AsyncMock()
         mock_client.close = AsyncMock()
         mock_client.get_user_context = AsyncMock(return_value=mock_context)
         type(mock_client).is_authenticated = PropertyMock(return_value=True)
 
-        # Create and setup config entry
         entry = MockConfigEntry(
             domain=DOMAIN,
-            data={
-                CONF_EMAIL: "test@example.com",
-                CONF_PASSWORD: "secret_password",
-            },
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "secret_password"},
             unique_id="test@example.com",
             title="MELCloud Home",
         )
@@ -108,24 +52,18 @@ async def test_diagnostics_basic_structure(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        # Get diagnostics data
         diagnostics = await async_get_config_entry_diagnostics(hass, entry)
 
-        # Verify basic structure
         assert "entry" in diagnostics
         assert "coordinator" in diagnostics
         assert "entities" in diagnostics
         assert "user_context" in diagnostics
 
-        # Verify entry data
         assert diagnostics["entry"]["title"] == "***REDACTED***"
         assert diagnostics["entry"]["version"] == 2
-
-        # Verify credentials are redacted
         assert diagnostics["entry"]["data"][CONF_EMAIL] == "**REDACTED**"
         assert diagnostics["entry"]["data"][CONF_PASSWORD] == "**REDACTED**"
 
-        # Verify coordinator data
         assert diagnostics["coordinator"]["last_update_success"] is True
         assert diagnostics["coordinator"]["update_interval"] == 60.0
 
@@ -133,50 +71,28 @@ async def test_diagnostics_basic_structure(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_diagnostics_includes_entity_states(hass: HomeAssistant) -> None:
     """Test diagnostics includes entity states for climate and sensors."""
-    mock_context = create_mock_user_context()
+    mock_context = create_mock_ata_user_context()
+    entry, _ = await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Setup mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
 
-        # Create and setup config entry
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert "entities" in diagnostics
+    entities = diagnostics["entities"]
 
-        # Get diagnostics data
-        diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    climate_entity_id = "climate.melcloudhome_0efc_9abc_climate"
+    assert climate_entity_id in entities
+    assert entities[climate_entity_id]["state"] == "heat"
+    assert "attributes" in entities[climate_entity_id]
 
-        # Verify entities section exists and has data
-        assert "entities" in diagnostics
-        entities = diagnostics["entities"]
-
-        # Should have climate entity (entity ID derived from UUID: 0efc1234-...9abc)
-        climate_entity_id = "climate.melcloudhome_0efc_9abc_climate"
-        assert climate_entity_id in entities
-        assert entities[climate_entity_id]["state"] == "heat"
-        assert "attributes" in entities[climate_entity_id]
-
-        # Should have sensor entities
-        temp_sensor_id = "sensor.melcloudhome_0efc_9abc_room_temperature"
-        assert temp_sensor_id in entities
-        assert entities[temp_sensor_id]["state"] == "20.0"
+    temp_sensor_id = "sensor.melcloudhome_0efc_9abc_room_temperature"
+    assert temp_sensor_id in entities
+    assert entities[temp_sensor_id]["state"] == "20.0"
 
 
 @pytest.mark.asyncio
 async def test_diagnostics_includes_user_context_data(hass: HomeAssistant) -> None:
     """Test diagnostics includes detailed user context with buildings and units."""
-    # Create mock data with multiple units
-    unit1 = create_mock_unit(
+    unit1 = create_mock_ata_unit(
         unit_id="unit-1",
         name="Living Room",
         power=True,
@@ -185,7 +101,7 @@ async def test_diagnostics_includes_user_context_data(hass: HomeAssistant) -> No
         room_temperature=20.5,
         has_energy_meter=True,
     )
-    unit2 = create_mock_unit(
+    unit2 = create_mock_ata_unit(
         unit_id="unit-2",
         name="Bedroom",
         power=False,
@@ -194,77 +110,55 @@ async def test_diagnostics_includes_user_context_data(hass: HomeAssistant) -> No
         room_temperature=21.0,
         has_energy_meter=False,
     )
-
-    building = create_mock_building(
-        building_id="building-1",
-        name="Home",
-        units=[unit1, unit2],
+    mock_context = create_mock_ata_user_context(
+        [
+            create_mock_ata_building(
+                building_id="building-1", name="Home", units=[unit1, unit2]
+            )
+        ]
     )
-    mock_context = create_mock_user_context(buildings=[building])
+    entry, _ = await setup_ata_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Setup mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
 
-        # Create and setup config entry
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert "user_context" in diagnostics
+    user_context = diagnostics["user_context"]
 
-        # Get diagnostics data
-        diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    assert "buildings" in user_context
+    assert len(user_context["buildings"]) == 1
 
-        # Verify user_context structure
-        assert "user_context" in diagnostics
-        user_context = diagnostics["user_context"]
+    building_data = user_context["buildings"][0]
+    assert building_data["id"] == "building-1"
+    assert building_data["name"] == "Building-1"
+    assert building_data["ata_unit_count"] == 2
+    assert building_data["atw_unit_count"] == 0
 
-        # Verify buildings
-        assert "buildings" in user_context
-        assert len(user_context["buildings"]) == 1
+    units = building_data["ata_units"]
+    assert len(units) == 2
 
-        building_data = user_context["buildings"][0]
-        assert building_data["id"] == "building-1"
-        assert building_data["name"] == "Building-1"
-        assert building_data["ata_unit_count"] == 2
-        assert building_data["atw_unit_count"] == 0
+    assert units[0]["id"] == "unit-1"
+    assert units[0]["name"] == "***REDACTED***"
+    assert units[0]["power"] is True
+    assert units[0]["operation_mode"] == "Heat"
+    assert units[0]["set_temperature"] == 22.0
+    assert units[0]["room_temperature"] == 20.5
+    assert units[0]["has_energy_consumed_meter"] is True
 
-        # Verify units
-        units = building_data["ata_units"]
-        assert len(units) == 2
-
-        # Check unit 1
-        assert units[0]["id"] == "unit-1"
-        assert units[0]["name"] == "***REDACTED***"
-        assert units[0]["power"] is True
-        assert units[0]["operation_mode"] == "Heat"
-        assert units[0]["set_temperature"] == 22.0
-        assert units[0]["room_temperature"] == 20.5
-        assert units[0]["has_energy_consumed_meter"] is True
-
-        # Check unit 2
-        assert units[1]["id"] == "unit-2"
-        assert units[1]["name"] == "***REDACTED***"
-        assert units[1]["power"] is False
-        assert units[1]["operation_mode"] == "Cool"
-        assert units[1]["set_temperature"] == 19.0
-        assert units[1]["room_temperature"] == 21.0
-        assert units[1]["has_energy_consumed_meter"] is False
+    assert units[1]["id"] == "unit-2"
+    assert units[1]["name"] == "***REDACTED***"
+    assert units[1]["power"] is False
+    assert units[1]["operation_mode"] == "Cool"
+    assert units[1]["set_temperature"] == 19.0
+    assert units[1]["room_temperature"] == 21.0
+    assert units[1]["has_energy_consumed_meter"] is False
 
 
 @pytest.mark.asyncio
 async def test_diagnostics_redacts_tokens(hass: HomeAssistant) -> None:
-    """Regression test: access_token, refresh_token, token_expiry must not appear in diagnostics output."""
-    mock_context = create_mock_user_context()
+    """Regression: access_token, refresh_token, token_expiry must not appear in diagnostics."""
+    mock_context = create_mock_ata_user_context()
 
+    # Non-standard entry: extra config fields — keep inline
     with patch(MOCK_CLIENT_PATH) as mock_client_class:
         mock_client = mock_client_class.return_value
         mock_client.login = AsyncMock()
@@ -291,8 +185,6 @@ async def test_diagnostics_redacts_tokens(hass: HomeAssistant) -> None:
         diagnostics = await async_get_config_entry_diagnostics(hass, entry)
         blob = json.dumps(diagnostics)
 
-        # Token values must not survive redaction
         assert "mock-access-token-abc123" not in blob
         assert "mock-refresh-token-xyz789" not in blob
-        # token_expiry is a float — check its distinctive value is gone
         assert "9999999999.0" not in blob

--- a/tests/integration/test_outdoor_temperature_sensor.py
+++ b/tests/integration/test_outdoor_temperature_sensor.py
@@ -1,22 +1,21 @@
 """Integration tests for outdoor temperature sensor."""
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from freezegun import freeze_time
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.api.models import Building, UserContext
-from custom_components.melcloudhome.api.models_ata import (
-    AirToAirCapabilities,
-    AirToAirUnit,
-)
 from custom_components.melcloudhome.const import DOMAIN
 
-# Mock at API boundary
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
+from .conftest import (
+    create_mock_ata_building,
+    create_mock_ata_unit,
+    create_mock_ata_user_context,
+    setup_ata_integration_custom,
+)
 
 # Test device UUIDs (match mock server IDs)
 LIVING_ROOM_ID = "0efc1234-5678-9abc-def0-123456787db"  # Has outdoor sensor
@@ -25,102 +24,50 @@ STUDY_ID = "a1b2c3d4-e5f6-7890-abcd-ef0123456789"  # Has outdoor sensor (2nd uni
 TEST_BUILDING_ID = "building-test-id"
 
 
-def create_mock_unit(
-    unit_id: str,
-    name: str,
-    has_outdoor_sensor: bool = False,
-) -> AirToAirUnit:
-    """Create a mock AirToAirUnit for testing."""
-    unit = AirToAirUnit(
-        id=unit_id,
-        name=name,
-        power=True,
-        operation_mode="Heat",
-        set_temperature=21.0,
-        room_temperature=20.0,
-        set_fan_speed="Auto",
-        vane_vertical_direction="Auto",
-        vane_horizontal_direction="Auto",
-        in_standby_mode=False,
-        is_in_error=False,
-        rssi=-50,
-        capabilities=AirToAirCapabilities(),
-    )
-    # Set outdoor temp fields based on whether device has sensor
-    if has_outdoor_sensor:
-        unit.has_outdoor_temp_sensor = True
-        unit.outdoor_temperature = 12.0
-    return unit
-
-
-def create_mock_building(units: list[AirToAirUnit]) -> Building:
-    """Create a mock Building for testing."""
-    return Building(id=TEST_BUILDING_ID, name="Test Building", air_to_air_units=units)
-
-
-def create_mock_user_context(buildings: list[Building]) -> UserContext:
-    """Create a mock UserContext for testing."""
-    return UserContext(buildings=buildings)
-
-
 @pytest.fixture
 async def setup_integration_with_outdoor_temp(hass: HomeAssistant) -> MockConfigEntry:
     """Set up integration with two devices - one with outdoor sensor, one without."""
-    # Create two test devices
-    living_room = create_mock_unit(
-        LIVING_ROOM_ID, "Living Room AC", has_outdoor_sensor=True
+    living_room = create_mock_ata_unit(
+        unit_id=LIVING_ROOM_ID,
+        name="Living Room AC",
+        has_outdoor_sensor=True,
+        outdoor_temperature=12.0,
     )
-    bedroom = create_mock_unit(BEDROOM_ID, "Bedroom AC", has_outdoor_sensor=False)
-
-    mock_context = create_mock_user_context(
-        [create_mock_building([living_room, bedroom])]
+    bedroom = create_mock_ata_unit(
+        unit_id=BEDROOM_ID,
+        name="Bedroom AC",
+        has_outdoor_sensor=False,
+    )
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[living_room, bedroom])]
     )
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    async def mock_get_outdoor_temp(unit_id: str) -> float | None:
+        if unit_id == LIVING_ROOM_ID:
+            return 12.0
+        return None
 
-        # Mock get_outdoor_temperature to return 12.0 for Living Room, None for Bedroom
-        async def mock_get_outdoor_temp(unit_id: str) -> float | None:
-            if unit_id == LIVING_ROOM_ID:
-                return 12.0
-            return None
+    def configure(client: Any) -> None:
+        client.get_outdoor_temperature = AsyncMock(side_effect=mock_get_outdoor_temp)
+        client.ata = MagicMock()
+        client.ata.set_power = AsyncMock()
+        client.ata.set_temperature = AsyncMock()
 
-        mock_client.get_outdoor_temperature = AsyncMock(
-            side_effect=mock_get_outdoor_temp
-        )
-
-        # Mock ATA control client
-        mock_client.ata = MagicMock()
-        mock_client.ata.set_power = AsyncMock()
-        mock_client.ata.set_temperature = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        return entry
+    entry, _ = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=configure
+    )
+    return entry
 
 
 async def test_outdoor_temperature_sensor_created_when_device_has_sensor(
     hass: HomeAssistant, setup_integration_with_outdoor_temp
 ):
     """Test outdoor temp sensor created for device with outdoor sensor."""
-    # Living Room AC (0efc..7db) has outdoor sensor in mock
     entity_id = "sensor.melcloudhome_0efc_87db_outdoor_temperature"
-
     state = hass.states.get(entity_id)
 
     assert state is not None
-    assert state.state == "12.0"  # Value from mock
+    assert state.state == "12.0"
     assert state.attributes["unit_of_measurement"] == "°C"
     assert state.attributes["device_class"] == "temperature"
     assert state.attributes["state_class"] == "measurement"
@@ -130,12 +77,8 @@ async def test_outdoor_temperature_sensor_not_created_when_no_sensor(
     hass: HomeAssistant, setup_integration_with_outdoor_temp
 ):
     """Test outdoor temp sensor NOT created for device without outdoor sensor."""
-    # Bedroom AC (5b3e..7a9b) does not have outdoor sensor in mock
     entity_id = "sensor.melcloudhome_5b3e_7a9b_outdoor_temperature"
-
-    state = hass.states.get(entity_id)
-
-    assert state is None  # Entity should not exist
+    assert hass.states.get(entity_id) is None
 
 
 async def test_outdoor_temperature_updates_on_coordinator_refresh(
@@ -144,13 +87,9 @@ async def test_outdoor_temperature_updates_on_coordinator_refresh(
     """Test outdoor temperature value updates when coordinator refreshes."""
     entity_id = "sensor.melcloudhome_0efc_87db_outdoor_temperature"
 
-    # Initial state
     state_before = hass.states.get(entity_id)
     assert state_before is not None
     assert state_before.state == "12.0"
-
-    # Trigger coordinator refresh by calling the coordinator directly
-    from custom_components.melcloudhome.const import DOMAIN
 
     coordinator = hass.data[DOMAIN][setup_integration_with_outdoor_temp.entry_id][
         "coordinator"
@@ -158,7 +97,6 @@ async def test_outdoor_temperature_updates_on_coordinator_refresh(
     await coordinator.async_request_refresh()
     await hass.async_block_till_done()
 
-    # Value should still be 12.0 (mock returns constant)
     state_after = hass.states.get(entity_id)
     assert state_after.state == "12.0"
 
@@ -167,40 +105,24 @@ async def test_outdoor_temperature_unavailable_when_api_fails(
     hass: HomeAssistant,
 ):
     """Test outdoor temp sensor shows unavailable when API fails."""
-    # Create device with outdoor sensor
-    living_room = create_mock_unit(
-        LIVING_ROOM_ID, "Living Room AC", has_outdoor_sensor=False
-    )  # Start as False - discovery will try to enable it
-    mock_context = create_mock_user_context([create_mock_building([living_room])])
+    living_room = create_mock_ata_unit(
+        unit_id=LIVING_ROOM_ID,
+        name="Living Room AC",
+        has_outdoor_sensor=False,
+    )
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[living_room])]
+    )
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    def configure(client: Any) -> None:
+        client.get_outdoor_temperature = AsyncMock(side_effect=Exception("API error"))
+        client.ata = MagicMock()
+        client.ata.set_power = AsyncMock()
 
-        # Mock get_outdoor_temperature to raise exception
-        mock_client.get_outdoor_temperature = AsyncMock(
-            side_effect=Exception("API error")
-        )
+    await setup_ata_integration_custom(hass, mock_context, configure_client=configure)
 
-        mock_client.ata = MagicMock()
-        mock_client.ata.set_power = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Entity should not be created because API call failed during discovery
-        entity_id = "sensor.melcloudhome_0efc_87db_outdoor_temperature"
-        state = hass.states.get(entity_id)
-        assert state is None  # Not created due to discovery failure
+    entity_id = "sensor.melcloudhome_0efc_87db_outdoor_temperature"
+    assert hass.states.get(entity_id) is None
 
 
 @freeze_time("2026-02-07 12:00:00", real_asyncio=True)
@@ -213,158 +135,112 @@ async def test_outdoor_temperature_all_units_polled_on_refresh(
     Regression test: a shared polling timer was consumed by the first unit
     in the loop, starving all subsequent units from ever updating.
     """
-    # Create two units that BOTH have outdoor sensors
-    living_room = create_mock_unit(
-        LIVING_ROOM_ID, "Living Room AC", has_outdoor_sensor=True
+    living_room = create_mock_ata_unit(
+        unit_id=LIVING_ROOM_ID,
+        name="Living Room AC",
+        has_outdoor_sensor=True,
+        outdoor_temperature=8.0,
     )
-    study = create_mock_unit(STUDY_ID, "Study AC", has_outdoor_sensor=True)
-
-    mock_context = create_mock_user_context(
-        [create_mock_building([living_room, study])]
+    study = create_mock_ata_unit(
+        unit_id=STUDY_ID,
+        name="Study AC",
+        has_outdoor_sensor=True,
+        outdoor_temperature=3.0,
+    )
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[living_room, study])]
     )
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    async def mock_get_outdoor_temp(unit_id: str) -> float | None:
+        if unit_id == LIVING_ROOM_ID:
+            return 8.0
+        if unit_id == STUDY_ID:
+            return 3.0
+        return None
 
-        # Return different temperatures per unit to verify both are polled
-        async def mock_get_outdoor_temp(unit_id: str) -> float | None:
-            if unit_id == LIVING_ROOM_ID:
-                return 8.0
-            if unit_id == STUDY_ID:
-                return 3.0
-            return None
+    def configure(client: Any) -> None:
+        client.get_outdoor_temperature = AsyncMock(side_effect=mock_get_outdoor_temp)
+        client.ata = MagicMock()
+        client.ata.set_power = AsyncMock()
+        client.ata.set_temperature = AsyncMock()
 
-        mock_client.get_outdoor_temperature = AsyncMock(
-            side_effect=mock_get_outdoor_temp
-        )
+    entry, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=configure
+    )
 
-        mock_client.ata = MagicMock()
-        mock_client.ata.set_power = AsyncMock()
-        mock_client.ata.set_temperature = AsyncMock()
+    living_room_entity = "sensor.melcloudhome_0efc_87db_outdoor_temperature"
+    study_entity = "sensor.melcloudhome_a1b2_6789_outdoor_temperature"
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    state_lr = hass.states.get(living_room_entity)
+    state_study = hass.states.get(study_entity)
 
-        # Both sensors should exist with their respective values
-        living_room_entity = "sensor.melcloudhome_0efc_87db_outdoor_temperature"
-        # STUDY_ID clean: a1b2c3d4e5f678901234ef0123456789 -> first4=a1b2 last4=6789
-        study_entity = "sensor.melcloudhome_a1b2_6789_outdoor_temperature"
+    assert state_lr is not None, "Living Room outdoor temp sensor not created"
+    assert state_study is not None, "Study outdoor temp sensor not created"
+    assert state_lr.state == "8.0"
+    assert state_study.state == "3.0"
 
-        state_lr = hass.states.get(living_room_entity)
-        state_study = hass.states.get(study_entity)
+    async def mock_get_outdoor_temp_updated(unit_id: str) -> float | None:
+        if unit_id == LIVING_ROOM_ID:
+            return 10.0
+        if unit_id == STUDY_ID:
+            return 1.0
+        return None
 
-        assert state_lr is not None, "Living Room outdoor temp sensor not created"
-        assert state_study is not None, "Study outdoor temp sensor not created"
-        assert state_lr.state == "8.0"
-        assert state_study.state == "3.0"
+    # mock_client is the same instance the coordinator holds — update directly
+    mock_client.get_outdoor_temperature = AsyncMock(
+        side_effect=mock_get_outdoor_temp_updated
+    )
 
-        # Now change the mock to return updated temps and trigger a refresh
-        # after the polling interval has elapsed
-        async def mock_get_outdoor_temp_updated(unit_id: str) -> float | None:
-            if unit_id == LIVING_ROOM_ID:
-                return 10.0
-            if unit_id == STUDY_ID:
-                return 1.0
-            return None
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator._last_outdoor_temp_poll.clear()
 
-        mock_client.get_outdoor_temperature = AsyncMock(
-            side_effect=mock_get_outdoor_temp_updated
-        )
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
 
-        # Simulate the polling interval having elapsed. freezer.move_to does not
-        # reliably affect datetime.now() inside coordinator with real_asyncio=True,
-        # so directly clear the poll records — semantically equivalent to +31 min.
-        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-        coordinator._last_outdoor_temp_poll.clear()
+    state_lr = hass.states.get(living_room_entity)
+    state_study = hass.states.get(study_entity)
 
-        await coordinator.async_request_refresh()
-        await hass.async_block_till_done()
-
-        # BOTH units should have updated values
-        state_lr = hass.states.get(living_room_entity)
-        state_study = hass.states.get(study_entity)
-
-        assert state_lr.state == "10.0", (
-            f"Living Room stuck at {state_lr.state}, expected 10.0"
-        )
-        assert state_study.state == "1.0", (
-            f"Study stuck at {state_study.state}, expected 1.0"
-        )
+    assert state_lr.state == "10.0", f"Living Room stuck at {state_lr.state}"
+    assert state_study.state == "1.0", f"Study stuck at {state_study.state}"
 
 
 async def test_idle_unit_reprobed_after_polling_interval(
     hass: HomeAssistant,
 ):
-    """Test that a unit with no outdoor sensor found is re-probed after 30 min.
-
-    Regression: if the initial probe returns None (unit idle at HA startup),
-    the integration permanently marks the sensor absent for the session with no
-    recovery path. The fix re-probes every 30 min so the sensor recovers the
-    next time the AC runs, without needing an HA restart.
-    """
-    # Unit starts with no outdoor sensor flag (default — matches real coordinator
-    # after HA restart; no pre-seeded capability)
-    living_room = create_mock_unit(
-        LIVING_ROOM_ID, "Living Room AC", has_outdoor_sensor=False
+    """Test that a unit with no outdoor sensor found is re-probed after 30 min."""
+    living_room = create_mock_ata_unit(
+        unit_id=LIVING_ROOM_ID, name="Living Room AC", has_outdoor_sensor=False
     )
-    mock_context = create_mock_user_context([create_mock_building([living_room])])
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[living_room])]
+    )
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    def configure(client: Any) -> None:
+        client.get_outdoor_temperature = AsyncMock(return_value=None)
+        client.ata = MagicMock()
+        client.ata.set_power = AsyncMock()
 
-        # Initial probe returns None — unit was idle at startup
-        mock_client.get_outdoor_temperature = AsyncMock(return_value=None)
+    entry, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=configure
+    )
 
-        mock_client.ata = MagicMock()
-        mock_client.ata.set_power = AsyncMock()
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    unit = coordinator.get_ata_device(LIVING_ROOM_ID)
+    assert unit is not None
+    assert unit.has_outdoor_temp_sensor is False
+    assert unit.outdoor_temperature is None
 
-        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    mock_client.get_outdoor_temperature = AsyncMock(return_value=15.0)
+    coordinator._last_outdoor_temp_poll.clear()
 
-        # Confirm initial state: no outdoor sensor data found
-        unit = coordinator.get_ata_device(LIVING_ROOM_ID)
-        assert unit is not None
-        assert unit.has_outdoor_temp_sensor is False
-        assert unit.outdoor_temperature is None
+    await coordinator.async_request_refresh()
+    await hass.async_block_till_done()
 
-        # Unit becomes active — next probe will return a value
-        mock_client.get_outdoor_temperature = AsyncMock(return_value=15.0)
-
-        # Simulate the polling interval having elapsed. freezer.move_to does not
-        # reliably affect datetime.now() inside coordinator with real_asyncio=True,
-        # so directly clear the poll records — semantically equivalent to +31 min.
-        coordinator._last_outdoor_temp_poll.clear()
-
-        await coordinator.async_request_refresh()
-        await hass.async_block_till_done()
-
-        # After re-probe the unit should now have outdoor sensor data
-        unit = coordinator.get_ata_device(LIVING_ROOM_ID)
-        assert unit.has_outdoor_temp_sensor is True, (
-            "Unit should have outdoor sensor flag set after re-probe"
-        )
-        assert unit.outdoor_temperature == 15.0, (
-            f"Expected 15.0°C after re-probe, got {unit.outdoor_temperature}"
-        )
+    unit = coordinator.get_ata_device(LIVING_ROOM_ID)
+    assert unit.has_outdoor_temp_sensor is True, (
+        "Unit should have outdoor sensor flag set after re-probe"
+    )
+    assert unit.outdoor_temperature == 15.0, (
+        f"Expected 15.0°C after re-probe, got {unit.outdoor_temperature}"
+    )

--- a/tests/integration/test_outdoor_temperature_sensor.py
+++ b/tests/integration/test_outdoor_temperature_sensor.py
@@ -91,10 +91,7 @@ async def test_outdoor_temperature_updates_on_coordinator_refresh(
     assert state_before is not None
     assert state_before.state == "12.0"
 
-    coordinator = hass.data[DOMAIN][setup_integration_with_outdoor_temp.entry_id][
-        "coordinator"
-    ]
-    await coordinator.async_request_refresh()
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
     await hass.async_block_till_done()
 
     state_after = hass.states.get(entity_id)
@@ -191,10 +188,12 @@ async def test_outdoor_temperature_all_units_polled_on_refresh(
         side_effect=mock_get_outdoor_temp_updated
     )
 
+    # _last_outdoor_temp_poll has no public reset interface; direct access is the
+    # only way to simulate the 30-minute polling interval elapsing in tests.
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
     coordinator._last_outdoor_temp_poll.clear()
 
-    await coordinator.async_request_refresh()
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
     await hass.async_block_till_done()
 
     state_lr = hass.states.get(living_room_entity)
@@ -224,6 +223,11 @@ async def test_idle_unit_reprobed_after_polling_interval(
         hass, mock_context, configure_client=configure
     )
 
+    # Outdoor temp entities use should_create_fn at setup time and are not
+    # dynamically added on coordinator updates — the coordinator model is the
+    # only observable outcome of a re-probe short of an entry reload.
+    # _last_outdoor_temp_poll has no public reset API; direct access is the
+    # only way to simulate the 30-minute interval elapsing in tests.
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     unit = coordinator.get_ata_device(LIVING_ROOM_ID)
@@ -234,7 +238,7 @@ async def test_idle_unit_reprobed_after_polling_interval(
     mock_client.get_outdoor_temperature = AsyncMock(return_value=15.0)
     coordinator._last_outdoor_temp_poll.clear()
 
-    await coordinator.async_request_refresh()
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
     await hass.async_block_till_done()
 
     unit = coordinator.get_ata_device(LIVING_ROOM_ID)

--- a/tests/integration/test_sensor_ata.py
+++ b/tests/integration/test_sensor_ata.py
@@ -56,19 +56,19 @@ async def test_sensor_entity_creation(hass: HomeAssistant) -> None:
             hass, mock_context, configure_client=configure
         )
 
-        temp_state = hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature")
+        temp_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_room_temperature")
         assert temp_state is not None
         assert float(temp_state.state) == 20.0
         assert temp_state.attributes["unit_of_measurement"] == "°C"
         assert temp_state.attributes["device_class"] == "temperature"
 
-        wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
+        wifi_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_wifi_signal")
         assert wifi_state is not None
         assert int(wifi_state.state) == -50
         assert wifi_state.attributes["unit_of_measurement"] == "dBm"
         assert wifi_state.attributes["device_class"] == "signal_strength"
 
-        energy_state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        energy_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert energy_state is not None
         assert float(energy_state.state) == 0.0  # First init starts at 0
         assert energy_state.attributes["unit_of_measurement"] == "kWh"
@@ -143,7 +143,7 @@ async def test_sensor_state_updates_on_refresh(hass: HomeAssistant) -> None:
         hass, initial_context, configure_client=configure
     )
 
-    temp_state = hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature")
+    temp_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_room_temperature")
     assert float(temp_state.state) == 20.0
 
     from custom_components.melcloudhome.const import DOMAIN
@@ -152,11 +152,11 @@ async def test_sensor_state_updates_on_refresh(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert (
-        float(hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature").state)
+        float(hass.states.get("sensor.melcloudhome_a1b2_9abc_room_temperature").state)
         == 22.0
     )
     assert (
-        int(hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal").state) == -45
+        int(hass.states.get("sensor.melcloudhome_a1b2_9abc_wifi_signal").state) == -45
     )
 
 
@@ -181,10 +181,10 @@ async def test_energy_sensor_availability(hass: HomeAssistant) -> None:
             hass, mock_context, configure_client=configure
         )
 
-        energy_state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
+        energy_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert energy_state is not None
         assert energy_state.state == "unavailable"
 
-        temp_state = hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature")
+        temp_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_room_temperature")
         assert temp_state is not None
         assert float(temp_state.state) == 20.0

--- a/tests/integration/test_sensor_ata.py
+++ b/tests/integration/test_sensor_ata.py
@@ -7,97 +7,23 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, PropertyMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.api.models import Building, UserContext
-from custom_components.melcloudhome.api.models_ata import (
-    AirToAirCapabilities,
-    AirToAirUnit,
+from .conftest import (
+    create_mock_ata_building,
+    create_mock_ata_unit,
+    create_mock_ata_user_context,
+    setup_ata_integration_custom,
 )
-from custom_components.melcloudhome.const import DOMAIN
 
-# Mock at API boundary (NOT coordinator or sensor classes)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
 MOCK_STORE_PATH = "custom_components.melcloudhome.energy_tracker_base.Store"
 
-# Test device UUID - generates entity_id: sensor.melcloudhome_0efc_9abc_*
-TEST_UNIT_ID = "0efc1234-5678-9abc-def0-123456789abc"
-TEST_BUILDING_ID = "building-test-id"
 
-
-def create_mock_unit(
-    unit_id: str = TEST_UNIT_ID,
-    name: str = "Test Unit",
-    room_temperature: float | None = 20.0,
-    rssi: int | None = -50,
-    has_energy_meter: bool = False,
-    energy_consumed: float | None = None,
-) -> AirToAirUnit:
-    """Create a mock AirToAirUnit for sensor testing.
-
-    Args:
-        unit_id: Unit identifier
-        name: Unit display name
-        room_temperature: Room temperature in Celsius (None = unavailable)
-        rssi: WiFi signal strength in dBm (None = unavailable)
-        has_energy_meter: Whether unit has energy meter capability
-        energy_consumed: Energy consumed in kWh (None = unavailable)
-
-    Returns:
-        Mock AirToAirUnit with sensor-relevant data
-    """
-    capabilities = AirToAirCapabilities(has_energy_consumed_meter=has_energy_meter)
-
-    return AirToAirUnit(
-        id=unit_id,
-        name=name,
-        power=True,
-        operation_mode="Heat",
-        set_temperature=21.0,
-        room_temperature=room_temperature,
-        set_fan_speed="Auto",
-        vane_vertical_direction="Auto",
-        vane_horizontal_direction="Auto",
-        in_standby_mode=False,
-        is_in_error=False,
-        rssi=rssi,
-        capabilities=capabilities,
-        energy_consumed=energy_consumed,
-    )
-
-
-def create_mock_building(
-    building_id: str = TEST_BUILDING_ID,
-    name: str = "Test Building",
-    units: list[AirToAirUnit] | None = None,
-) -> Building:
-    """Create a mock Building for sensor testing."""
-    if units is None:
-        units = [create_mock_unit()]
-    return Building(id=building_id, name=name, air_to_air_units=units)
-
-
-def create_mock_user_context(buildings: list[Building] | None = None) -> UserContext:
-    """Create a mock UserContext for sensor testing."""
-    if buildings is None:
-        buildings = [create_mock_building()]
-    return UserContext(buildings=buildings)
-
-
-def create_mock_energy_response(wh_value: float) -> dict:
-    """Create a mock energy API response.
-
-    Args:
-        wh_value: Energy value in watt-hours
-
-    Returns:
-        Mock API response matching MELCloud format
-    """
+def _create_mock_energy_response(wh_value: float) -> dict:
     return {
         "measureData": [
             {
@@ -111,73 +37,37 @@ def create_mock_energy_response(wh_value: float) -> dict:
 
 @pytest.mark.asyncio
 async def test_sensor_entity_creation(hass: HomeAssistant) -> None:
-    """Test that all sensor entities are created correctly.
-
-    When integration is set up with a unit that has all sensor data:
-    1. Room temperature sensor is created
-    2. WiFi signal sensor is created
-    3. Energy sensor is created (if unit has energy meter capability)
-    4. All sensors show correct initial values
-
-    Validates: Basic sensor entity creation
-    Tests through: hass.states (sensor entity states)
-    """
-    # Create unit with energy meter capability
-    unit_with_energy = create_mock_unit(
-        has_energy_meter=True,
-        energy_consumed=None,  # Will be populated by coordinator
+    """Test that all sensor entities are created correctly."""
+    unit_with_energy = create_mock_ata_unit(has_energy_meter=True)
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[unit_with_energy])]
     )
-    mock_context = create_mock_user_context(
-        buildings=[create_mock_building(units=[unit_with_energy])]
-    )
+    mock_energy_data = _create_mock_energy_response(5500.0)
 
-    # Mock energy response (5500 Wh = 5.5 kWh)
-    mock_energy_data = create_mock_energy_response(5500.0)
+    def configure(client: Any) -> None:
+        client.get_energy_data = AsyncMock(return_value=mock_energy_data)
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        # Set up mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        # Mock storage (no stored data)
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        # Set up integration
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_ata_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
-        # ✅ CORRECT: Assert through state machine
-        # Check room temperature sensor
         temp_state = hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature")
         assert temp_state is not None
         assert float(temp_state.state) == 20.0
         assert temp_state.attributes["unit_of_measurement"] == "°C"
         assert temp_state.attributes["device_class"] == "temperature"
 
-        # Check WiFi signal sensor
         wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
         assert wifi_state is not None
         assert int(wifi_state.state) == -50
         assert wifi_state.attributes["unit_of_measurement"] == "dBm"
         assert wifi_state.attributes["device_class"] == "signal_strength"
 
-        # Check energy sensor (should be created and show initial value of 0.0)
-        # Note: First init skips historical data, starts at 0.0
         energy_state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
         assert energy_state is not None
         assert float(energy_state.state) == 0.0  # First init starts at 0
@@ -187,217 +77,114 @@ async def test_sensor_entity_creation(hass: HomeAssistant) -> None:
 
 @pytest.mark.asyncio
 async def test_energy_sensor_conditional_creation(hass: HomeAssistant) -> None:
-    """Test that energy sensor is only created for units with energy meter capability.
-
-    When integration is set up:
-    1. Units WITH energy meter capability get energy sensor created
-    2. Units WITHOUT energy meter capability do NOT get energy sensor created
-    3. Other sensors (temp, WiFi) are created regardless
-
-    Validates: Conditional sensor creation based on device capabilities
-    Tests through: hass.states (sensor presence/absence)
-    """
-    # Create two units: one with energy meter, one without
-    # Use simple unit IDs that will generate predictable entity IDs
-    unit_with_energy = create_mock_unit(
-        unit_id="aaaa1234-5678-9abc-def0-123456789999",  # → aaaa_9999
+    """Test that energy sensor is only created for units with energy meter capability."""
+    unit_with_energy = create_mock_ata_unit(
+        unit_id="aaaa1234-5678-9abc-def0-123456789999",
         name="Unit With Energy",
         has_energy_meter=True,
-        energy_consumed=None,  # Will be populated by coordinator
     )
-    unit_without_energy = create_mock_unit(
-        unit_id="bbbb1234-5678-9abc-def0-123456788888",  # → bbbb_8888
+    unit_without_energy = create_mock_ata_unit(
+        unit_id="bbbb1234-5678-9abc-def0-123456788888",
         name="Unit Without Energy",
-        has_energy_meter=False,  # No energy capability
-        energy_consumed=None,
+        has_energy_meter=False,
     )
-
-    mock_context = create_mock_user_context(
-        buildings=[create_mock_building(units=[unit_with_energy, unit_without_energy])]
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[unit_with_energy, unit_without_energy])]
     )
+    mock_energy_data = _create_mock_energy_response(10000.0)
 
-    # Mock energy response for unit with energy capability
-    mock_energy_data = create_mock_energy_response(10000.0)  # 10 kWh
+    def configure(client: Any) -> None:
+        client.get_energy_data = AsyncMock(return_value=mock_energy_data)
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        # Set up mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        # Mock storage
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        # Set up integration
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_ata_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
-        # ✅ CORRECT: Assert through state machine
-        # Unit WITH energy capability should have energy sensor (starts at 0.0)
         energy_state_1 = hass.states.get("sensor.melcloudhome_aaaa_9999_energy")
         assert energy_state_1 is not None
-        assert float(energy_state_1.state) == 0.0  # First init starts at 0
+        assert float(energy_state_1.state) == 0.0
 
-        # Unit WITHOUT energy capability should NOT have energy sensor
         energy_state_2 = hass.states.get("sensor.melcloudhome_bbbb_8888_energy")
-        assert energy_state_2 is None  # Should not exist
+        assert energy_state_2 is None
 
-        # Both units should have temp and WiFi sensors (always created)
-        temp_state_1 = hass.states.get("sensor.melcloudhome_aaaa_9999_room_temperature")
-        assert temp_state_1 is not None
-
-        temp_state_2 = hass.states.get("sensor.melcloudhome_bbbb_8888_room_temperature")
-        assert temp_state_2 is not None
+        assert (
+            hass.states.get("sensor.melcloudhome_aaaa_9999_room_temperature")
+            is not None
+        )
+        assert (
+            hass.states.get("sensor.melcloudhome_bbbb_8888_room_temperature")
+            is not None
+        )
 
 
 @pytest.mark.asyncio
 async def test_sensor_state_updates_on_refresh(hass: HomeAssistant) -> None:
-    """Test that sensor values update when coordinator refreshes.
-
-    When coordinator receives new data:
-    1. Temperature sensor updates to new value
-    2. WiFi signal sensor updates to new value
-    3. Updates happen automatically via coordinator
-
-    Validates: Sensor state synchronization with coordinator
-    Tests through: hass.states (sensor values after refresh)
-    """
-    # Initial data (no energy meter to simplify test)
-    initial_unit = create_mock_unit(
-        room_temperature=20.0,
-        rssi=-50,
-        has_energy_meter=False,  # Skip energy for this test
+    """Test that sensor values update when coordinator refreshes."""
+    initial_unit = create_mock_ata_unit(room_temperature=20.0, rssi=-50)
+    initial_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[initial_unit])]
     )
-    initial_context = create_mock_user_context(
-        buildings=[create_mock_building(units=[initial_unit])]
+    updated_unit = create_mock_ata_unit(room_temperature=22.0, rssi=-45)
+    updated_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[updated_unit])]
     )
 
-    # Updated data (simulate coordinator refresh)
-    updated_unit = create_mock_unit(
-        room_temperature=22.0,  # Temperature increased
-        rssi=-45,  # WiFi signal improved
-        has_energy_meter=False,
-    )
-    updated_context = create_mock_user_context(
-        buildings=[create_mock_building(units=[updated_unit])]
-    )
-
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        # Set up mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        # First call returns initial data, second call returns updated data
-        mock_client.get_user_context = AsyncMock(
+    def configure(client: Any) -> None:
+        client.get_user_context = AsyncMock(
             side_effect=[initial_context, updated_context]
         )
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
 
-        # Set up integration
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await setup_ata_integration_custom(
+        hass, initial_context, configure_client=configure
+    )
 
-        # ✅ CORRECT: Verify initial values through state machine
-        temp_state = hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature")
-        assert float(temp_state.state) == 20.0
+    temp_state = hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature")
+    assert float(temp_state.state) == 20.0
 
-        wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
-        assert int(wifi_state.state) == -50
+    from custom_components.melcloudhome.const import DOMAIN
 
-        # ✅ CORRECT: Trigger coordinator refresh through core interface
-        await hass.services.async_call(
-            DOMAIN,
-            "force_refresh",
-            {},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+    await hass.async_block_till_done()
 
-        # ✅ CORRECT: Verify updated values through state machine
-        temp_state = hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature")
-        assert float(temp_state.state) == 22.0
-
-        wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
-        assert int(wifi_state.state) == -45
+    assert (
+        float(hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature").state)
+        == 22.0
+    )
+    assert (
+        int(hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal").state) == -45
+    )
 
 
 @pytest.mark.asyncio
 async def test_energy_sensor_availability(hass: HomeAssistant) -> None:
-    """Test that energy sensor availability depends on data presence.
-
-    Energy sensor behavior:
-    1. Created if unit has energy meter capability (even without data)
-    2. Unavailable when energy_consumed is None (no data fetched yet)
-    3. Becomes available when energy data is fetched
-
-    Validates: Energy sensor availability logic
-    Tests through: hass.states (sensor unavailable initially, then available)
-    """
-    # Create unit with energy meter but no initial energy fetch will fail
-    unit_with_energy = create_mock_unit(
-        has_energy_meter=True,
-        energy_consumed=None,  # No data yet
+    """Test that energy sensor availability depends on data presence."""
+    unit_with_energy = create_mock_ata_unit(has_energy_meter=True)
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[unit_with_energy])]
     )
-    mock_context = create_mock_user_context(
-        buildings=[create_mock_building(units=[unit_with_energy])]
-    )
+    no_energy_data: dict = {"measureData": []}
 
-    # Mock energy response - empty response (no data)
-    no_energy_data: dict = {"measureData": []}  # Empty energy response
+    def configure(client: Any) -> None:
+        client.get_energy_data = AsyncMock(return_value=no_energy_data)
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        # Set up mock client
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.get_energy_data = AsyncMock(return_value=no_energy_data)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        # Mock storage - no stored data
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        # Set up integration
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_ata_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
-        # ✅ CORRECT: Verify energy sensor exists but unavailable (no data fetched)
         energy_state = hass.states.get("sensor.melcloudhome_0efc_9abc_energy")
         assert energy_state is not None
-        assert energy_state.state == "unavailable"  # No energy data fetched
+        assert energy_state.state == "unavailable"
 
-        # Other sensors should still be available
         temp_state = hass.states.get("sensor.melcloudhome_0efc_9abc_room_temperature")
         assert temp_state is not None
         assert float(temp_state.state) == 20.0

--- a/tests/integration/test_sensor_atw.py
+++ b/tests/integration/test_sensor_atw.py
@@ -7,14 +7,11 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, PropertyMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.melcloudhome.const import DOMAIN
 
 from .conftest import (
     TEST_SENSOR_COP,
@@ -24,10 +21,9 @@ from .conftest import (
     create_mock_atw_energy_response,
     create_mock_atw_unit,
     create_mock_atw_user_context,
+    setup_atw_integration_custom,
 )
 
-# Mock at API boundary (NOT coordinator or sensor classes)
-MOCK_CLIENT_PATH = "custom_components.melcloudhome.MELCloudHomeClient"
 MOCK_STORE_PATH = "custom_components.melcloudhome.energy_tracker_base.Store"
 
 
@@ -38,27 +34,11 @@ async def test_atw_zone_1_temperature_sensor_created(hass: HomeAssistant) -> Non
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check Zone 1 temperature sensor exists
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
-        assert state is not None
-        assert float(state.state) == 20.5
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
+    assert state is not None
+    assert float(state.state) == 20.5
 
 
 @pytest.mark.asyncio
@@ -68,27 +48,11 @@ async def test_atw_tank_temperature_sensor_created(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check tank temperature sensor exists
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
-        assert state is not None
-        assert float(state.state) == 48.5
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
+    assert state is not None
+    assert float(state.state) == 48.5
 
 
 @pytest.mark.asyncio
@@ -98,27 +62,11 @@ async def test_atw_operation_status_sensor_created(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check operation status sensor exists
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
-        assert state is not None
-        assert state.state == "HotWater"
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
+    assert state is not None
+    assert state.state == "HotWater"
 
 
 @pytest.mark.asyncio
@@ -128,26 +76,11 @@ async def test_atw_operation_status_shows_raw_api_value(hass: HomeAssistant) -> 
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
-        # Raw API value, not mapped
-        assert state.state == "Heating"
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
+    # Raw API value, not mapped
+    assert state.state == "Heating"
 
 
 @pytest.mark.asyncio
@@ -159,29 +92,13 @@ async def test_atw_sensor_unavailable_when_temp_none(hass: HomeAssistant) -> Non
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    zone_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
+    tank_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Temperature sensors should be unavailable when data is None
-        zone_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
-        tank_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
-
-        assert zone_temp.state == "unavailable"
-        assert tank_temp.state == "unavailable"
+    assert zone_temp.state == "unavailable"
+    assert tank_temp.state == "unavailable"
 
 
 @pytest.mark.asyncio
@@ -193,31 +110,15 @@ async def test_atw_sensors_unavailable_when_device_in_error(
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    zone_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
+    tank_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
+    operation = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # All ATW sensors should be unavailable
-        zone_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_zone_1_temperature")
-        tank_temp = hass.states.get("sensor.melcloudhome_0efc_9abc_tank_temperature")
-        operation = hass.states.get("sensor.melcloudhome_0efc_9abc_operation_status")
-
-        assert zone_temp.state == "unavailable"
-        assert tank_temp.state == "unavailable"
-        assert operation.state == "unavailable"
+    assert zone_temp.state == "unavailable"
+    assert tank_temp.state == "unavailable"
+    assert operation.state == "unavailable"
 
 
 # =============================================================================
@@ -230,51 +131,28 @@ async def test_atw_energy_sensors_created_when_capability_present(
     hass: HomeAssistant,
 ) -> None:
     """Test energy sensors are created when device has energy meter capability."""
-    mock_unit = create_mock_atw_unit(
-        has_energy_meter=True,
-    )
+    mock_unit = create_mock_atw_unit(has_energy_meter=True)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
 
-    # Mock energy responses (in watt-hours)
-    mock_consumed = create_mock_atw_energy_response(
-        10000.0, "intervalEnergyConsumed"
-    )  # 10 kWh
-    mock_produced = create_mock_atw_energy_response(
-        40000.0, "intervalEnergyProduced"
-    )  # 40 kWh
+    mock_consumed = create_mock_atw_energy_response(10000.0, "intervalEnergyConsumed")
+    mock_produced = create_mock_atw_energy_response(40000.0, "intervalEnergyProduced")
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    def configure(client: Any) -> None:
+        client.atw = AsyncMock()
+        client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
+        client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
 
-        # Mock ATW energy API methods
-        mock_client.atw = AsyncMock()
-        mock_client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
-        mock_client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
-
-        # Mock storage (both ATA and ATW trackers use the same Store class)
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_atw_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
-        # Check all 3 energy sensors exist
         consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
         produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
         cop = hass.states.get(TEST_SENSOR_COP)
@@ -296,37 +174,15 @@ async def test_atw_energy_sensors_not_created_without_capability(
     hass: HomeAssistant,
 ) -> None:
     """Test energy sensors are NOT created when device lacks energy capability."""
-    mock_unit = create_mock_atw_unit(
-        has_energy_meter=False,  # No energy meter
-    )
+    mock_unit = create_mock_atw_unit(has_energy_meter=False)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Energy sensors should NOT exist
-        consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
-        produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
-        cop = hass.states.get(TEST_SENSOR_COP)
-
-        assert consumed is None
-        assert produced is None
-        assert cop is None
+    assert hass.states.get(TEST_SENSOR_ENERGY_CONSUMED) is None
+    assert hass.states.get(TEST_SENSOR_ENERGY_PRODUCED) is None
+    assert hass.states.get(TEST_SENSOR_COP) is None
 
 
 @pytest.mark.asyncio
@@ -335,43 +191,27 @@ async def test_atw_energy_sensors_unavailable_when_values_none(
 ) -> None:
     """Test energy sensors unavailable when energy values are None."""
     mock_unit = create_mock_atw_unit(
-        has_energy_meter=True,  # Has capability
-        energy_consumed=None,  # But no data yet
+        has_energy_meter=True,
+        energy_consumed=None,
         energy_produced=None,
         cop=None,
     )
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
+    produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
+    cop = hass.states.get(TEST_SENSOR_COP)
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    assert consumed is not None
+    assert produced is not None
+    assert cop is not None
 
-        # Sensors created but unavailable (no data yet)
-        consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
-        produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
-        cop = hass.states.get(TEST_SENSOR_COP)
-
-        assert consumed is not None
-        assert produced is not None
-        assert cop is not None
-
-        assert consumed.state == "unavailable"
-        assert produced.state == "unavailable"
-        assert cop.state == "unavailable"
+    assert consumed.state == "unavailable"
+    assert produced.state == "unavailable"
+    assert cop.state == "unavailable"
 
 
 @pytest.mark.asyncio
@@ -381,48 +221,28 @@ async def test_atw_cop_calculation_correct(hass: HomeAssistant) -> None:
     On first init, energy values start at 0.0, so COP is unavailable (divide by zero).
     This test verifies the COP sensor is created and becomes unavailable when consumed=0.
     """
-    mock_unit = create_mock_atw_unit(
-        has_energy_meter=True,
-    )
+    mock_unit = create_mock_atw_unit(has_energy_meter=True)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
 
-    # Mock energy responses (first init)
     mock_consumed = create_mock_atw_energy_response(1000.0, "intervalEnergyConsumed")
     mock_produced = create_mock_atw_energy_response(4000.0, "intervalEnergyProduced")
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    def configure(client: Any) -> None:
+        client.atw = AsyncMock()
+        client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
+        client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
 
-        # Mock ATW energy API
-        mock_client.atw = AsyncMock()
-        mock_client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
-        mock_client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
-
-        # Mock storage (no stored data - first init)
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_atw_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
-        # After first init, consumed and produced start at 0.0
-        # COP is unavailable (cannot divide by zero)
         consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
         produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
         cop = hass.states.get(TEST_SENSOR_COP)
@@ -443,65 +263,44 @@ async def test_atw_energy_sensors_have_correct_device_class(
     hass: HomeAssistant,
 ) -> None:
     """Test energy sensors have correct device classes for Energy Dashboard."""
-    mock_unit = create_mock_atw_unit(
-        has_energy_meter=True,
-    )
+    mock_unit = create_mock_atw_unit(has_energy_meter=True)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
 
-    # Mock energy responses
     mock_consumed = create_mock_atw_energy_response(10000.0, "intervalEnergyConsumed")
     mock_produced = create_mock_atw_energy_response(40000.0, "intervalEnergyProduced")
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    def configure(client: Any) -> None:
+        client.atw = AsyncMock()
+        client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
+        client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
 
-        # Mock ATW energy API
-        mock_client.atw = AsyncMock()
-        mock_client.atw.get_energy_consumed = AsyncMock(return_value=mock_consumed)
-        mock_client.atw.get_energy_produced = AsyncMock(return_value=mock_produced)
-
-        # Mock storage (both ATA and ATW trackers use the same Store class)
+    with patch(MOCK_STORE_PATH) as mock_store_class:
         mock_store = mock_store_class.return_value
         mock_store.async_load = AsyncMock(return_value=None)
         mock_store.async_save = AsyncMock()
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
+        await setup_atw_integration_custom(
+            hass, mock_context, configure_client=configure
         )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
         consumed = hass.states.get(TEST_SENSOR_ENERGY_CONSUMED)
         produced = hass.states.get(TEST_SENSOR_ENERGY_PRODUCED)
         cop = hass.states.get(TEST_SENSOR_COP)
 
-        # Energy sensors should have energy device class
         assert consumed.attributes.get("device_class") == "energy"
         assert produced.attributes.get("device_class") == "energy"
 
         # COP is dimensionless, no device class
         assert cop.attributes.get("device_class") is None
 
-        # Energy sensors should have TOTAL_INCREASING state class
         assert consumed.attributes.get("state_class") == "total_increasing"
         assert produced.attributes.get("state_class") == "total_increasing"
 
         # COP should have MEASUREMENT state class
         assert cop.attributes.get("state_class") == "measurement"
 
-        # Check units
         assert consumed.attributes.get("unit_of_measurement") == "kWh"
         assert produced.attributes.get("unit_of_measurement") == "kWh"
         assert cop.attributes.get("unit_of_measurement") is None
@@ -514,28 +313,13 @@ async def test_atw_outdoor_temperature_sensor_created(hass: HomeAssistant) -> No
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
-        assert state is not None
-        assert float(state.state) == 12.5
-        assert state.attributes["unit_of_measurement"] == "°C"
-        assert state.attributes["device_class"] == "temperature"
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
+    assert state is not None
+    assert float(state.state) == 12.5
+    assert state.attributes["unit_of_measurement"] == "°C"
+    assert state.attributes["device_class"] == "temperature"
 
 
 @pytest.mark.asyncio
@@ -547,26 +331,11 @@ async def test_atw_outdoor_temperature_not_created_when_none(
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Entity should not exist at all — not permanently unavailable
-        state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
-        assert state is None
+    # Entity should not exist at all — not permanently unavailable
+    state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
+    assert state is None
 
 
 @pytest.mark.asyncio
@@ -576,27 +345,11 @@ async def test_atw_rssi_sensor_created(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check WiFi signal sensor exists with correct attributes
-        wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
-        assert wifi_state is not None
-        # Sensor starts unavailable (no telemetry fetched yet - that happens on schedule)
-        assert wifi_state.state == "unavailable"
-        assert wifi_state.attributes["unit_of_measurement"] == "dBm"
-        assert wifi_state.attributes["device_class"] == "signal_strength"
+    wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
+    assert wifi_state is not None
+    # Sensor starts unavailable (no telemetry fetched yet - that happens on schedule)
+    assert wifi_state.state == "unavailable"
+    assert wifi_state.attributes["unit_of_measurement"] == "dBm"
+    assert wifi_state.attributes["device_class"] == "signal_strength"

--- a/tests/integration/test_switch.py
+++ b/tests/integration/test_switch.py
@@ -7,189 +7,101 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.const import (
-    ATTR_FRIENDLY_NAME,
-    CONF_EMAIL,
-    CONF_PASSWORD,
-    STATE_OFF,
-    STATE_ON,
-)
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.const import DOMAIN
-
-# Import shared test helpers from conftest
 from .conftest import (
-    MOCK_CLIENT_PATH,
     TEST_ATW_UNIT_ID,
     TEST_SWITCH_SYSTEM_POWER,
     create_mock_atw_building,
     create_mock_atw_unit,
     create_mock_atw_user_context,
+    setup_atw_integration_custom,
 )
 
 
 @pytest.mark.asyncio
 async def test_switch_entity_created_with_correct_attributes(
     hass: HomeAssistant,
-    setup_atw_integration: MockConfigEntry,
+    setup_atw_integration,
 ) -> None:
     """Test switch entity is created with correct attributes."""
-    # Check entity exists
     state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
     assert state is not None
-    assert state.state == STATE_ON  # Mock unit has power=True by default
+    assert state.state == STATE_ON
     assert "System Power" in state.attributes[ATTR_FRIENDLY_NAME]
 
 
 @pytest.mark.asyncio
 async def test_turn_on_powers_atw_system(hass: HomeAssistant) -> None:
     """Test turning on switch powers entire ATW system."""
-    mock_unit = create_mock_atw_unit(power=False)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(power=False)])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_power = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
-        mock_client.atw.set_power = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
+    assert state is not None
+    assert state.state == STATE_OFF
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {"entity_id": TEST_SWITCH_SYSTEM_POWER}, blocking=True
+    )
+    await hass.async_block_till_done()
 
-        # Check initial state - powered off
-        state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
-        assert state is not None
-        assert state.state == STATE_OFF
-
-        # Call turn_on service
-        await hass.services.async_call(
-            SWITCH_DOMAIN,
-            "turn_on",
-            {"entity_id": TEST_SWITCH_SYSTEM_POWER},
-            blocking=True,
-        )
-
-        # Verify API was called correctly
-        await hass.async_block_till_done()
-        mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, True)
+    mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, True)
 
 
 @pytest.mark.asyncio
 async def test_turn_off_powers_off_atw_system(hass: HomeAssistant) -> None:
     """Test turning off switch powers off entire ATW system."""
-    mock_unit = create_mock_atw_unit(power=True)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(power=True)])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_power = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
-        mock_client.atw.set_power = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
+    assert state is not None
+    assert state.state == STATE_ON
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        "turn_off",
+        {"entity_id": TEST_SWITCH_SYSTEM_POWER},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        # Check initial state - powered on
-        state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
-        assert state is not None
-        assert state.state == STATE_ON
-
-        # Call turn_off service
-        await hass.services.async_call(
-            SWITCH_DOMAIN,
-            "turn_off",
-            {"entity_id": TEST_SWITCH_SYSTEM_POWER},
-            blocking=True,
-        )
-
-        # Verify API was called correctly
-        await hass.async_block_till_done()
-        mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, False)
+    mock_client.atw.set_power.assert_called_once_with(TEST_ATW_UNIT_ID, False)
 
 
 @pytest.mark.asyncio
 async def test_switch_state_reflects_system_power(hass: HomeAssistant) -> None:
     """Test switch state reflects actual system power state."""
-    mock_unit_off = create_mock_atw_unit(power=False)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit_off])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(power=False)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check state reflects power off
-        state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
-        assert state is not None
-        assert state.state == STATE_OFF
+    state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
+    assert state is not None
+    assert state.state == STATE_OFF
 
 
 @pytest.mark.asyncio
 async def test_switch_unavailable_when_device_in_error(hass: HomeAssistant) -> None:
     """Test switch becomes unavailable when device is in error state."""
-    mock_unit = create_mock_atw_unit(is_in_error=True)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(is_in_error=True)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Check switch is unavailable
-        state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
-        assert state is not None
-        assert state.state == "unavailable"
+    state = hass.states.get(TEST_SWITCH_SYSTEM_POWER)
+    assert state is not None
+    assert state.state == "unavailable"

--- a/tests/integration/test_water_heater.py
+++ b/tests/integration/test_water_heater.py
@@ -7,7 +7,7 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
-from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.components.water_heater import (
@@ -15,44 +15,30 @@ from homeassistant.components.water_heater import (
     STATE_ECO,
     STATE_HIGH_DEMAND,
 )
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    CONF_EMAIL,
-    CONF_PASSWORD,
-)
+from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.melcloudhome.const import DOMAIN
 
 from .conftest import (
-    MOCK_CLIENT_PATH,
     TEST_ATW_UNIT_ID,
     TEST_WATER_HEATER_ENTITY_ID,
     create_mock_atw_building,
     create_mock_atw_unit,
     create_mock_atw_user_context,
+    setup_atw_integration_custom,
 )
 
 
 @pytest.mark.asyncio
 async def test_water_heater_entity_created_with_correct_attributes(
     hass: HomeAssistant,
-    setup_atw_integration: MockConfigEntry,
+    setup_atw_integration,
 ) -> None:
     """Test water heater entity is created with correct attributes."""
-    # Check entity exists
     state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
     assert state is not None
-    # Water heater state is the operation mode, not ON/OFF
     assert state.state == STATE_ECO
-    # ATTR_TEMPERATURE is target temp (not current)
-    assert (
-        state.attributes[ATTR_TEMPERATURE] == 50.0
-    )  # Target (set_tank_water_temperature)
-    assert (
-        state.attributes["current_temperature"] == 48.5
-    )  # Current (tank_water_temperature)
+    assert state.attributes[ATTR_TEMPERATURE] == 50.0
+    assert state.attributes["current_temperature"] == 48.5
     assert state.attributes[ATTR_OPERATION_MODE] == STATE_ECO
 
 
@@ -60,42 +46,18 @@ async def test_water_heater_entity_created_with_correct_attributes(
 async def test_set_temperature_updates_dhw_temp(hass: HomeAssistant) -> None:
     """Test setting DHW temperature via service."""
     mock_context = create_mock_atw_user_context()
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_dhw_temperature = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw = MagicMock()
+    await hass.services.async_call(
+        "water_heater",
+        "set_temperature",
+        {"entity_id": TEST_WATER_HEATER_ENTITY_ID, "temperature": 55},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        mock_client.atw.set_dhw_temperature = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Call set_temperature service
-        await hass.services.async_call(
-            "water_heater",
-            "set_temperature",
-            {
-                "entity_id": TEST_WATER_HEATER_ENTITY_ID,
-                "temperature": 55,
-            },
-            blocking=True,
-        )
-
-        # Verify API was called correctly
-        await hass.async_block_till_done()
-        mock_client.atw.set_dhw_temperature.assert_called_once_with(
-            TEST_ATW_UNIT_ID, 55
-        )
+    mock_client.atw.set_dhw_temperature.assert_called_once_with(TEST_ATW_UNIT_ID, 55)
 
 
 @pytest.mark.asyncio
@@ -105,44 +67,21 @@ async def test_set_operation_mode_eco_to_performance(hass: HomeAssistant) -> Non
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_forced_hot_water = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw.set_forced_hot_water = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    state = hass.states.get(TEST_WATER_HEATER_ENTITY_ID)
+    assert state.attributes[ATTR_OPERATION_MODE] == STATE_ECO
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.services.async_call(
+        "water_heater",
+        "set_operation_mode",
+        {"entity_id": TEST_WATER_HEATER_ENTITY_ID, "operation_mode": STATE_HIGH_DEMAND},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        # Check initial state
-        state = hass.states.get(TEST_WATER_HEATER_ENTITY_ID)
-        assert state.attributes[ATTR_OPERATION_MODE] == STATE_ECO
-
-        # Call set_operation_mode service
-        await hass.services.async_call(
-            "water_heater",
-            "set_operation_mode",
-            {
-                "entity_id": TEST_WATER_HEATER_ENTITY_ID,
-                "operation_mode": STATE_HIGH_DEMAND,
-            },
-            blocking=True,
-        )
-
-        # Verify API was called correctly
-        await hass.async_block_till_done()
-        mock_client.atw.set_forced_hot_water.assert_called_once_with(
-            TEST_ATW_UNIT_ID, True
-        )
+    mock_client.atw.set_forced_hot_water.assert_called_once_with(TEST_ATW_UNIT_ID, True)
 
 
 @pytest.mark.asyncio
@@ -152,101 +91,53 @@ async def test_set_operation_mode_performance_to_eco(hass: HomeAssistant) -> Non
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    _, mock_client = await setup_atw_integration_custom(hass, mock_context)
+    mock_client.atw.set_forced_hot_water = AsyncMock()
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.atw.set_forced_hot_water = AsyncMock()
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+    state = hass.states.get(TEST_WATER_HEATER_ENTITY_ID)
+    assert state.attributes[ATTR_OPERATION_MODE] == STATE_HIGH_DEMAND
 
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.services.async_call(
+        "water_heater",
+        "set_operation_mode",
+        {"entity_id": TEST_WATER_HEATER_ENTITY_ID, "operation_mode": STATE_ECO},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
 
-        # Check initial state
-        state = hass.states.get(TEST_WATER_HEATER_ENTITY_ID)
-        assert state.attributes[ATTR_OPERATION_MODE] == STATE_HIGH_DEMAND
-
-        # Call set_operation_mode service
-        await hass.services.async_call(
-            "water_heater",
-            "set_operation_mode",
-            {
-                "entity_id": TEST_WATER_HEATER_ENTITY_ID,
-                "operation_mode": STATE_ECO,
-            },
-            blocking=True,
-        )
-
-        # Verify API was called correctly
-        await hass.async_block_till_done()
-        mock_client.atw.set_forced_hot_water.assert_called_once_with(
-            TEST_ATW_UNIT_ID, False
-        )
+    mock_client.atw.set_forced_hot_water.assert_called_once_with(
+        TEST_ATW_UNIT_ID, False
+    )
 
 
 @pytest.mark.asyncio
 async def test_current_operation_reflects_forced_dhw_mode(hass: HomeAssistant) -> None:
     """Test current_operation reflects forced_hot_water_mode."""
-    # Test eco mode (forced_hot_water_mode = False)
-    mock_unit = create_mock_atw_unit(forced_hot_water_mode=False)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [
+            create_mock_atw_building(
+                units=[create_mock_atw_unit(forced_hot_water_mode=False)]
+            )
+        ]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
-        assert state.attributes[ATTR_OPERATION_MODE] == STATE_ECO
+    state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
+    assert state.attributes[ATTR_OPERATION_MODE] == STATE_ECO
 
 
 @pytest.mark.asyncio
 async def test_availability_false_when_device_in_error(hass: HomeAssistant) -> None:
     """Test water heater unavailable when device in error."""
-    mock_unit = create_mock_atw_unit(is_in_error=True)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [create_mock_atw_building(units=[create_mock_atw_unit(is_in_error=True)])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
-        assert state.state == "unavailable"
+    assert (
+        hass.states.get("water_heater.melcloudhome_0efc_9abc_tank").state
+        == "unavailable"
+    )
 
 
 @pytest.mark.asyncio
@@ -254,89 +145,49 @@ async def test_extra_state_attributes_include_operation_status(
     hass: HomeAssistant,
 ) -> None:
     """Test extra state attributes include operation_status."""
-    mock_unit = create_mock_atw_unit(operation_status="HotWater")
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [
+            create_mock_atw_building(
+                units=[create_mock_atw_unit(operation_status="HotWater")]
+            )
+        ]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
-        assert state.attributes["operation_status"] == "HotWater"
-        assert "forced_dhw_active" in state.attributes
-        assert "zone_heating_suspended" in state.attributes
+    state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
+    assert state.attributes["operation_status"] == "HotWater"
+    assert "forced_dhw_active" in state.attributes
+    assert "zone_heating_suspended" in state.attributes
 
 
 @pytest.mark.asyncio
 async def test_water_heater_with_performance_mode(hass: HomeAssistant) -> None:
     """Test water heater reflects performance mode correctly."""
-    mock_unit = create_mock_atw_unit(forced_hot_water_mode=True)
     mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
+        [
+            create_mock_atw_building(
+                units=[create_mock_atw_unit(forced_hot_water_mode=True)]
+            )
+        ]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
-        assert state.attributes[ATTR_OPERATION_MODE] == STATE_HIGH_DEMAND
+    assert (
+        hass.states.get("water_heater.melcloudhome_0efc_9abc_tank").attributes[
+            ATTR_OPERATION_MODE
+        ]
+        == STATE_HIGH_DEMAND
+    )
 
 
 @pytest.mark.asyncio
 async def test_water_heater_device_info_matches_climate(hass: HomeAssistant) -> None:
     """Test water heater and climate entities share same device."""
     mock_context = create_mock_atw_user_context()
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Both entities should exist
-        water_heater = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
-        climate = hass.states.get("climate.melcloudhome_0efc_9abc_zone_1")
-
-        assert water_heater is not None
-        assert climate is not None
-        # Device info is same (tested through entity registry, but state confirms entities exist)
+    assert hass.states.get("water_heater.melcloudhome_0efc_9abc_tank") is not None
+    assert hass.states.get("climate.melcloudhome_0efc_9abc_zone_1") is not None
 
 
 @pytest.mark.asyncio
@@ -348,52 +199,20 @@ async def test_water_heater_temperature_in_range(hass: HomeAssistant) -> None:
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
-        # ATTR_TEMPERATURE is target, current_temperature is current
-        assert state.attributes["current_temperature"] == 45.0
-        assert state.attributes[ATTR_TEMPERATURE] == 50.0  # Target
-        assert 40 <= state.attributes[ATTR_TEMPERATURE] <= 60
+    state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
+    assert state.attributes["current_temperature"] == 45.0
+    assert state.attributes[ATTR_TEMPERATURE] == 50.0
+    assert 40 <= state.attributes[ATTR_TEMPERATURE] <= 60
 
 
 @pytest.mark.asyncio
 async def test_water_heater_entity_naming_includes_tank(hass: HomeAssistant) -> None:
     """Test water heater entity ID includes 'tank' suffix."""
     mock_context = create_mock_atw_user_context()
+    await setup_atw_integration_custom(hass, mock_context)
 
-    with patch(MOCK_CLIENT_PATH) as mock_client_class:
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        # Entity ID should include _tank suffix
-        state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
-        assert state is not None
-        assert "_tank" in state.entity_id
+    state = hass.states.get("water_heater.melcloudhome_0efc_9abc_tank")
+    assert state is not None
+    assert "_tank" in state.entity_id


### PR DESCRIPTION
## Summary

- Remove the three pre-existing issues from ATW development (debug `import json`, duplicate `MOCK_CLIENT_PATH`, unimplemented fixture factory)
- Add `create_mock_ata_unit/building/user_context` helpers to `conftest.py` — ATA test files had local copies of these functions, each slightly different
- Add `setup_ata_integration_custom` and update `setup_atw_integration_custom` — both return `(entry, mock_client)` so tests that assert on mock calls can capture the client without keeping a patch context open
- Refactor 11 test files to use the shared helpers, eliminating ~10 lines of repeated mock+entry boilerplate per test

Net change: -1,836 lines across 12 files. Test count unchanged at 168.

## Test Plan

- [x] All 168 integration tests pass (`make test-integration`)
- [x] Pre-commit hooks pass (ruff, mypy, codespell, secrets)