### PR TITLE
fix: reject corrupt hourly energy readings and self-heal existing totals (#161)

### DIFF
--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -25,6 +25,22 @@ CONF_DEBUG_MODE = "debug_mode"
 UPDATE_INTERVAL_ENERGY = timedelta(minutes=30)
 DATA_LOOKBACK_HOURS_ENERGY = 48
 
+# Sanity ceiling for a single hourly energy reading (kWh). The MELCloud cloud
+# API has been observed to occasionally return corrupt values around 65536 *
+# 100 Wh (~6553.6 kWh) for one hour, consistent with a 16-bit counter wrap on
+# the device side (see GitHub issue #161). No residential ATA/ATW unit can
+# plausibly draw this much power in an hour, so readings above this ceiling
+# are rejected rather than accumulated.
+MAX_PLAUSIBLE_HOURLY_ENERGY_KWH = 100.0
+
+# Retention window (hours) for persisted per-hour delta-tracking entries.
+# A poll only ever fetches the last DATA_LOOKBACK_HOURS_ENERGY hours from
+# the API, so once a stored hour_values entry falls outside that window it
+# can never be looked up again - keeping it is pure unbounded storage
+# growth. The multiplier gives a buffer for extended HA downtime (e.g. a
+# multi-day outage) without losing legitimate delta-tracking state.
+HOUR_VALUE_RETENTION_HOURS = DATA_LOOKBACK_HOURS_ENERGY * 3
+
 # Telemetry polling configuration
 UPDATE_INTERVAL_TELEMETRY = timedelta(minutes=60)  # Hourly (temps change slowly)
 DATA_LOOKBACK_HOURS_TELEMETRY = 4  # Sparse data, 4 hours sufficient
@@ -59,6 +75,8 @@ __all__ = [
     "DATA_LOOKBACK_HOURS_ENERGY",
     "DATA_LOOKBACK_HOURS_TELEMETRY",
     "DOMAIN",
+    "HOUR_VALUE_RETENTION_HOURS",
+    "MAX_PLAUSIBLE_HOURLY_ENERGY_KWH",
     "PLATFORMS",
     "UPDATE_INTERVAL",
     "UPDATE_INTERVAL_ENERGY",

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -174,8 +174,12 @@ class EnergyTrackerBase(ABC):
 
         - Implausible (> MAX_PLAUSIBLE_HOURLY_ENERGY_KWH): a corrupt cloud
           reading persisted before the sanity check existed (GitHub issue
-          #161) is subtracted back out of the cumulative total and dropped,
-          so a future legitimate reading for that hour is accepted fresh.
+          #161) is dropped, and the unit+measure's cumulative total is
+          reset to 0.0. Resetting (not subtracting back to the true total)
+          is deliberate: HA's total_increasing reset handling records the
+          post-revision state as new consumption, so landing on 0.0
+          records nothing while landing on the true total would record a
+          phantom consumption of that entire amount.
         - Stale (older than HOUR_VALUE_RETENTION_HOURS): the API never
           returns hours outside its lookback window again, so old entries
           are pure unbounded storage growth.
@@ -185,9 +189,8 @@ class EnergyTrackerBase(ABC):
         next real poll as "historical" instead of counting it. The most
         recent parseable entry is kept as a sentinel, preferring plausible
         entries; if every entry is implausible the sentinel is kept as a
-        0.0 placeholder (its corrupt value still subtracted) - a re-sent
-        corrupt value is rejected by the ceiling, a legitimate one counts
-        as a normal delta from 0.0.
+        0.0 placeholder - a re-sent corrupt value is rejected by the
+        ceiling, a legitimate one counts as a normal delta from 0.0.
 
         Returns:
             True if any entry was changed (caller should persist).
@@ -209,28 +212,22 @@ class EnergyTrackerBase(ABC):
                     max(plausible or dated, key=dated.__getitem__) if dated else None
                 )
 
+                purged = 0
                 for hour_timestamp, value in list(hours.items()):
                     if value > MAX_PLAUSIBLE_HOURLY_ENERGY_KWH:
                         if hour_timestamp == sentinel:
                             hours[hour_timestamp] = 0.0
                         else:
                             del hours[hour_timestamp]
-                        before = self._energy_cumulative[unit_id][measure]
-                        self._energy_cumulative[unit_id][measure] = max(
-                            0.0, before - value
-                        )
+                        purged += 1
                         changed = True
                         _LOGGER.warning(
                             "Energy (%s): %s - Hour %s: purging implausible "
-                            "historical value %.1f kWh from cumulative total: "
-                            "%.3f kWh. Revised cumulative total: %.3f kWh. "
-                            "See GitHub issue #161.",
+                            "historical value %.1f kWh. See GitHub issue #161.",
                             measure,
                             unit_id,
                             hour_timestamp[:16],
                             value,
-                            before,
-                            self._energy_cumulative[unit_id][measure],
                         )
                         continue
 
@@ -244,6 +241,20 @@ class EnergyTrackerBase(ABC):
                     del hours[hour_timestamp]
                     changed = True
                     stale_count += 1
+
+                if purged:
+                    before = self._energy_cumulative[unit_id][measure]
+                    self._energy_cumulative[unit_id][measure] = 0.0
+                    _LOGGER.warning(
+                        "Energy (%s): %s - resetting cumulative total to 0.0 "
+                        "kWh (was %.3f) after purging %d implausible hourly "
+                        "value(s). Home Assistant records this as a meter "
+                        "reset; delta tracking continues from 0.",
+                        measure,
+                        unit_id,
+                        before,
+                        purged,
+                    )
 
         if stale_count:
             _LOGGER.debug(

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -170,41 +170,24 @@ class EnergyTrackerBase(ABC):
     def _clean_hour_values(self, now: datetime) -> bool:
         """Purge implausible and stale entries from persisted hour_values.
 
-        Two independent, unconditionally-safe cleanup passes over the same
-        data, run on every load:
+        Runs on every load. Two passes:
 
-        - Implausible: a corrupt cloud reading (e.g. a 16-bit counter wrap,
-          ~6553.6 kWh for one hour) could already have been added to a
-          unit's cumulative total and recorded in hour_values before the
-          sanity check in _update_cumulative_values existed. Undo it by
-          subtracting the stored value back out of cumulative and dropping
-          the entry, so a future legitimate reading for that hour is
-          accepted fresh. See GitHub issue #161.
-        - Stale: hour_values only needs to cover the API's lookback window
-          (DATA_LOOKBACK_HOURS_ENERGY) - once an hour falls outside that
-          window the API will never return it again, so the entry can
-          never be looked up again. Without pruning, this dict grows
-          without bound for the lifetime of the install.
+        - Implausible (> MAX_PLAUSIBLE_HOURLY_ENERGY_KWH): a corrupt cloud
+          reading persisted before the sanity check existed (GitHub issue
+          #161) is subtracted back out of the cumulative total and dropped,
+          so a future legitimate reading for that hour is accepted fresh.
+        - Stale (older than HOUR_VALUE_RETENTION_HOURS): the API never
+          returns hours outside its lookback window again, so old entries
+          are pure unbounded storage growth.
 
-          The single most-recent plausible, parseable entry per unit +
-          measure is always kept regardless of age. Emptying hour_values
-          entirely would make _is_first_initialization() think the device
-          had never been tracked, silently absorbing the next real poll
-          as "historical" instead of counting it - worse than the
-          unbounded growth this pruning is meant to fix.
-
-          That never-empty invariant must also hold for the implausible
-          pass: if EVERY entry is implausible there is no plausible
-          sentinel, so the most recent implausible entry's timestamp is
-          kept as a 0.0 placeholder instead of being deleted (its corrupt
-          value is still subtracted from cumulative). A re-sent corrupt
-          value for that hour is rejected by the sanity ceiling before
-          the delta lookup, and a legitimate one is counted as a normal
-          delta from 0.0 - both correct.
-
-        Args:
-            now: Current time (UTC), used to determine entry age for the
-                staleness check.
+        Invariant: hour_values is never emptied for a tracked unit +
+        measure, or _is_first_initialization() would silently absorb the
+        next real poll as "historical" instead of counting it. The most
+        recent parseable entry is kept as a sentinel, preferring plausible
+        entries; if every entry is implausible the sentinel is kept as a
+        0.0 placeholder (its corrupt value still subtracted) - a re-sent
+        corrupt value is rejected by the ceiling, a legitimate one counts
+        as a normal delta from 0.0.
 
         Returns:
             True if any entry was changed (caller should persist).
@@ -214,34 +197,21 @@ class EnergyTrackerBase(ABC):
         stale_count = 0
         for unit_id, measures in self._energy_hour_values.items():
             for measure, hours in measures.items():
-                parsed = {
-                    hour_timestamp: self._parse_hour_timestamp(hour_timestamp)
-                    for hour_timestamp, value in hours.items()
-                    if value <= MAX_PLAUSIBLE_HOURLY_ENERGY_KWH
+                dated = {
+                    ts: dt
+                    for ts in hours
+                    if (dt := self._parse_hour_timestamp(ts)) is not None
                 }
-                dated = {k: v for k, v in parsed.items() if v is not None}
-                sentinel = max(dated, key=lambda k: dated[k]) if dated else None
-
-                # No plausible entry can serve as the sentinel - keep the
-                # most recent implausible one as a 0.0 placeholder so the
-                # purge below can't empty hour_values entirely.
-                placeholder = None
-                if sentinel is None:
-                    implausible_dated = {
-                        hour_timestamp: hour_dt
-                        for hour_timestamp, value in hours.items()
-                        if value > MAX_PLAUSIBLE_HOURLY_ENERGY_KWH
-                        and (hour_dt := self._parse_hour_timestamp(hour_timestamp))
-                        is not None
-                    }
-                    if implausible_dated:
-                        placeholder = max(
-                            implausible_dated, key=lambda k: implausible_dated[k]
-                        )
+                plausible = [
+                    ts for ts in dated if hours[ts] <= MAX_PLAUSIBLE_HOURLY_ENERGY_KWH
+                ]
+                sentinel = (
+                    max(plausible or dated, key=dated.__getitem__) if dated else None
+                )
 
                 for hour_timestamp, value in list(hours.items()):
                     if value > MAX_PLAUSIBLE_HOURLY_ENERGY_KWH:
-                        if hour_timestamp == placeholder:
+                        if hour_timestamp == sentinel:
                             hours[hour_timestamp] = 0.0
                         else:
                             del hours[hour_timestamp]
@@ -266,7 +236,7 @@ class EnergyTrackerBase(ABC):
                     if hour_timestamp == sentinel:
                         continue
 
-                    hour_dt = parsed.get(hour_timestamp)
+                    hour_dt = dated.get(hour_timestamp)
                     if hour_dt is None or hour_dt >= cutoff:
                         continue
 
@@ -276,9 +246,8 @@ class EnergyTrackerBase(ABC):
 
         if stale_count:
             _LOGGER.debug(
-                "Pruned %d stale hour_values entr%s older than %d hours",
+                "Pruned %d stale hour_values entries older than %d hours",
                 stale_count,
-                "y" if stale_count == 1 else "ies",
                 HOUR_VALUE_RETENTION_HOURS,
             )
         return changed

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -193,6 +193,15 @@ class EnergyTrackerBase(ABC):
           as "historical" instead of counting it - worse than the
           unbounded growth this pruning is meant to fix.
 
+          That never-empty invariant must also hold for the implausible
+          pass: if EVERY entry is implausible there is no plausible
+          sentinel, so the most recent implausible entry's timestamp is
+          kept as a 0.0 placeholder instead of being deleted (its corrupt
+          value is still subtracted from cumulative). A re-sent corrupt
+          value for that hour is rejected by the sanity ceiling before
+          the delta lookup, and a legitimate one is counted as a normal
+          delta from 0.0 - both correct.
+
         Args:
             now: Current time (UTC), used to determine entry age for the
                 staleness check.
@@ -213,9 +222,29 @@ class EnergyTrackerBase(ABC):
                 dated = {k: v for k, v in parsed.items() if v is not None}
                 sentinel = max(dated, key=lambda k: dated[k]) if dated else None
 
+                # No plausible entry can serve as the sentinel - keep the
+                # most recent implausible one as a 0.0 placeholder so the
+                # purge below can't empty hour_values entirely.
+                placeholder = None
+                if sentinel is None:
+                    implausible_dated = {
+                        hour_timestamp: hour_dt
+                        for hour_timestamp, value in hours.items()
+                        if value > MAX_PLAUSIBLE_HOURLY_ENERGY_KWH
+                        and (hour_dt := self._parse_hour_timestamp(hour_timestamp))
+                        is not None
+                    }
+                    if implausible_dated:
+                        placeholder = max(
+                            implausible_dated, key=lambda k: implausible_dated[k]
+                        )
+
                 for hour_timestamp, value in list(hours.items()):
                     if value > MAX_PLAUSIBLE_HOURLY_ENERGY_KWH:
-                        del hours[hour_timestamp]
+                        if hour_timestamp == placeholder:
+                            hours[hour_timestamp] = 0.0
+                        else:
+                            del hours[hour_timestamp]
                         before = self._energy_cumulative[unit_id][measure]
                         self._energy_cumulative[unit_id][measure] = max(
                             0.0, before - value

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -222,8 +222,9 @@ class EnergyTrackerBase(ABC):
                         changed = True
                         _LOGGER.warning(
                             "Energy (%s): %s - Hour %s: purging implausible "
-                            "historical value %.1f kWh from cumulative total "
-                            "(%.3f -> %.3f kWh). See GitHub issue #161.",
+                            "historical value %.1f kWh from cumulative total: "
+                            "%.3f kWh. Revised cumulative total: %.3f kWh. "
+                            "See GitHub issue #161.",
                             measure,
                             unit_id,
                             hour_timestamp[:16],

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.storage import Store
 
-if TYPE_CHECKING:
-    from datetime import datetime
+from .const import HOUR_VALUE_RETENTION_HOURS, MAX_PLAUSIBLE_HOURLY_ENERGY_KWH
 
+if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
@@ -145,6 +146,114 @@ class EnergyTrackerBase(ABC):
         else:
             _LOGGER.info("No stored energy data found, starting fresh")
 
+        # Self-heal installs that accumulated a corrupt reading before the
+        # sanity check existed, and bound storage growth (see GitHub issue
+        # #161). Persist immediately so the correction survives even if no
+        # new energy data arrives.
+        if self._clean_hour_values(datetime.now(UTC)):
+            await self._save_energy_data()
+
+    @staticmethod
+    def _parse_hour_timestamp(hour_timestamp: str) -> datetime | None:
+        """Parse a stored hour_values key into a UTC-aware datetime.
+
+        Returns None if the timestamp can't be parsed (defensive - should
+        not happen with well-formed data, but a corrupt/foreign key must
+        not crash cleanup).
+        """
+        try:
+            hour_dt = datetime.fromisoformat(hour_timestamp)
+        except ValueError:
+            return None
+        return hour_dt if hour_dt.tzinfo else hour_dt.replace(tzinfo=UTC)
+
+    def _clean_hour_values(self, now: datetime) -> bool:
+        """Purge implausible and stale entries from persisted hour_values.
+
+        Two independent, unconditionally-safe cleanup passes over the same
+        data, run on every load:
+
+        - Implausible: a corrupt cloud reading (e.g. a 16-bit counter wrap,
+          ~6553.6 kWh for one hour) could already have been added to a
+          unit's cumulative total and recorded in hour_values before the
+          sanity check in _update_cumulative_values existed. Undo it by
+          subtracting the stored value back out of cumulative and dropping
+          the entry, so a future legitimate reading for that hour is
+          accepted fresh. See GitHub issue #161.
+        - Stale: hour_values only needs to cover the API's lookback window
+          (DATA_LOOKBACK_HOURS_ENERGY) - once an hour falls outside that
+          window the API will never return it again, so the entry can
+          never be looked up again. Without pruning, this dict grows
+          without bound for the lifetime of the install.
+
+          The single most-recent plausible, parseable entry per unit +
+          measure is always kept regardless of age. Emptying hour_values
+          entirely would make _is_first_initialization() think the device
+          had never been tracked, silently absorbing the next real poll
+          as "historical" instead of counting it - worse than the
+          unbounded growth this pruning is meant to fix.
+
+        Args:
+            now: Current time (UTC), used to determine entry age for the
+                staleness check.
+
+        Returns:
+            True if any entry was changed (caller should persist).
+        """
+        cutoff = now - timedelta(hours=HOUR_VALUE_RETENTION_HOURS)
+        changed = False
+        stale_count = 0
+        for unit_id, measures in self._energy_hour_values.items():
+            for measure, hours in measures.items():
+                parsed = {
+                    hour_timestamp: self._parse_hour_timestamp(hour_timestamp)
+                    for hour_timestamp, value in hours.items()
+                    if value <= MAX_PLAUSIBLE_HOURLY_ENERGY_KWH
+                }
+                dated = {k: v for k, v in parsed.items() if v is not None}
+                sentinel = max(dated, key=lambda k: dated[k]) if dated else None
+
+                for hour_timestamp, value in list(hours.items()):
+                    if value > MAX_PLAUSIBLE_HOURLY_ENERGY_KWH:
+                        del hours[hour_timestamp]
+                        before = self._energy_cumulative[unit_id][measure]
+                        self._energy_cumulative[unit_id][measure] = max(
+                            0.0, before - value
+                        )
+                        changed = True
+                        _LOGGER.warning(
+                            "Energy (%s): %s - Hour %s: purging implausible "
+                            "historical value %.1f kWh from cumulative total "
+                            "(%.3f -> %.3f kWh). See GitHub issue #161.",
+                            measure,
+                            unit_id,
+                            hour_timestamp[:16],
+                            value,
+                            before,
+                            self._energy_cumulative[unit_id][measure],
+                        )
+                        continue
+
+                    if hour_timestamp == sentinel:
+                        continue
+
+                    hour_dt = parsed.get(hour_timestamp)
+                    if hour_dt is None or hour_dt >= cutoff:
+                        continue
+
+                    del hours[hour_timestamp]
+                    changed = True
+                    stale_count += 1
+
+        if stale_count:
+            _LOGGER.debug(
+                "Pruned %d stale hour_values entr%s older than %d hours",
+                stale_count,
+                "y" if stale_count == 1 else "ies",
+                HOUR_VALUE_RETENTION_HOURS,
+            )
+        return changed
+
     def _is_first_initialization(self, unit_id: str, measure: str) -> bool:
         """Check if this is first energy data for unit + measure.
 
@@ -187,6 +296,23 @@ class EnergyTrackerBase(ABC):
             raw_value = float(value_entry["value"])
             # ATW API returns kWh, ATA API returns Wh
             kwh_value = raw_value if values_in_kwh else raw_value / WH_TO_KWH_FACTOR
+
+            if kwh_value > MAX_PLAUSIBLE_HOURLY_ENERGY_KWH:
+                # Corrupt reading from cloud (e.g. 16-bit counter wrap) - don't
+                # seed the baseline with it, or a later legitimate value would
+                # look like a "decrease" and be ignored. See GitHub issue #161.
+                _LOGGER.warning(
+                    "Energy (%s): %s (%s) - Hour %s implausible value %.1f kWh "
+                    "exceeds sanity ceiling (%.1f kWh) - skipping",
+                    measure,
+                    unit_name,
+                    unit_id,
+                    hour_timestamp[:16],
+                    kwh_value,
+                    MAX_PLAUSIBLE_HOURLY_ENERGY_KWH,
+                )
+                continue
+
             self._energy_hour_values[unit_id][measure][hour_timestamp] = kwh_value
 
         _LOGGER.info(
@@ -224,6 +350,22 @@ class EnergyTrackerBase(ABC):
             raw_value = float(value_entry["value"])
             # ATW API returns kWh, ATA API returns Wh
             kwh_value = raw_value if values_in_kwh else raw_value / WH_TO_KWH_FACTOR
+
+            if kwh_value > MAX_PLAUSIBLE_HOURLY_ENERGY_KWH:
+                # Corrupt reading from cloud (e.g. 16-bit counter wrap) - reject
+                # without persisting so a later legitimate value for this hour
+                # is still accepted normally. See GitHub issue #161.
+                _LOGGER.warning(
+                    "Energy (%s): %s (%s) - Hour %s implausible value %.1f kWh "
+                    "exceeds sanity ceiling (%.1f kWh) - rejecting reading",
+                    measure,
+                    unit_name,
+                    unit_id,
+                    hour_timestamp[:16],
+                    kwh_value,
+                    MAX_PLAUSIBLE_HOURLY_ENERGY_KWH,
+                )
+                continue
 
             # Get previous value for this specific hour (default 0.0 from defaultdict)
             previous_value = self._energy_hour_values[unit_id][measure].get(

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -367,6 +367,91 @@ async def test_corrupt_historical_value_self_heals_on_load(
 
 
 @pytest.mark.asyncio
+async def test_all_corrupt_hour_values_self_heal_keeps_delta_tracking(
+    hass: HomeAssistant,
+) -> None:
+    """Test self-heal when EVERY persisted hour_values entry is corrupt.
+
+    Edge case of GitHub issue #161's self-heal: if a unit's entire persisted
+    hour_values consists of implausible entries (e.g. a device whose very
+    first tracked hour was the corrupt reading), purging them all would
+    empty the dict. _is_first_initialization() would then treat the device
+    as brand-new on the next poll, silently absorbing that poll's real
+    energy as "historical" instead of counting it.
+
+    The purge must instead keep the most recent corrupt entry's timestamp
+    as a 0.0 placeholder: the cumulative total is still fully healed, and
+    the next poll's legitimate values are counted as normal deltas.
+
+    Validates: GitHub issue #161 - self-heal must never empty hour_values
+    Tests through: hass.states (next poll's real energy is counted)
+    """
+    mock_context = create_mock_ata_energy_context()
+
+    now = datetime.now(UTC)
+    corrupt_ts = (now - timedelta(hours=3)).isoformat()
+    new_hour_1 = (now - timedelta(hours=2)).isoformat()
+    new_hour_2 = (now - timedelta(hours=1)).isoformat()
+
+    # Pre-fix install where the ONLY entry ever recorded is the corrupt one.
+    polluted_storage = {
+        "cumulative": {TEST_UNIT_ID: {"consumed": 6553.3}},
+        "hour_values": {TEST_UNIT_ID: {"consumed": {corrupt_ts: 6553.3}}},
+    }
+
+    # Next poll: API re-sends the corrupt hour (rejected by the ceiling)
+    # plus two legitimate new hours that MUST be counted.
+    mock_energy_data = create_mock_energy_response(
+        [
+            (corrupt_ts, 6553300.0),  # corrupt - rejected
+            (new_hour_1, 500.0),  # NEW - add 0.5 kWh
+            (new_hour_2, 800.0),  # NEW - add 0.8 kWh
+        ]
+    )
+
+    with (
+        patch(MOCK_CLIENT_PATH) as mock_client_class,
+        patch(MOCK_STORE_PATH) as mock_store_class,
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_store = mock_store_class.return_value
+        mock_store.async_load = AsyncMock(return_value=polluted_storage)
+        mock_store.async_save = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
+        assert state is not None
+
+        # Cumulative healed to 0.0, then the poll's two legitimate hours
+        # counted as normal deltas: 0.5 + 0.8 = 1.3 kWh. If hour_values had
+        # been emptied, the poll would be absorbed as first-init and the
+        # sensor would wrongly read 0.0.
+        assert float(state.state) == pytest.approx(1.3, rel=0.01)
+
+        # The self-heal save (earliest): cumulative healed, and the corrupt
+        # hour kept as a 0.0 placeholder rather than the dict going empty.
+        saved_data = mock_store.async_save.call_args_list[0][0][0]
+        assert saved_data["cumulative"][TEST_UNIT_ID]["consumed"] == pytest.approx(
+            0.0, abs=1e-9
+        )
+        assert saved_data["hour_values"][TEST_UNIT_ID]["consumed"] == {corrupt_ts: 0.0}
+
+
+@pytest.mark.asyncio
 async def test_stale_hour_values_pruned_on_load(hass: HomeAssistant) -> None:
     """Test that hour_values entries older than the retention window are pruned.
 

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -301,8 +301,11 @@ async def test_corrupt_historical_value_self_heals_on_load(
     that hit the corrupt cloud reading before the sanity check existed have
     it permanently baked into their stored cumulative total. On upgrade,
     the tracker should detect the implausible historical hour_value entry,
-    subtract it back out of the cumulative total, and drop the entry so a
-    future legitimate reading for that hour is accepted fresh.
+    drop it, and reset the cumulative total to 0.0. Resetting (rather than
+    subtracting back to the true total) matters because HA's
+    total_increasing reset handling records the post-revision state as new
+    consumption - landing on 0.0 records nothing, while landing on the true
+    total would record a phantom consumption of that entire amount.
 
     Note: this only heals the integration's own persisted counter. Home
     Assistant's Long-Term Statistics (Energy Dashboard history) are
@@ -342,15 +345,16 @@ async def test_corrupt_historical_value_self_heals_on_load(
         state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
-        # Expected: 6556.4 - 6553.3 (purged) = 3.1 kWh. The 13:00 hour was
-        # already seen (same value in this poll), so no new delta is added.
-        assert float(state.state) == pytest.approx(3.1, rel=0.01)
+        # Expected: cumulative reset to 0.0 after the purge. The 12:00 and
+        # 13:00 hours were already seen (same values in this poll), so no
+        # new delta is added.
+        assert float(state.state) == pytest.approx(0.0, abs=1e-9)
 
         # The purge should have persisted immediately during async_setup,
         # before any new energy poll ran - check the earliest ATA save.
         saved_data = mock_store.async_save.call_args_list[0][0][0]
         assert saved_data["cumulative"][TEST_UNIT_ID]["consumed"] == pytest.approx(
-            3.1, rel=0.01
+            0.0, abs=1e-9
         )
         assert (
             "2026-06-30T13:00:00Z"

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -7,8 +7,10 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, PropertyMock, patch
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
@@ -54,6 +56,42 @@ def create_mock_energy_response(
             }
         ]
     }
+
+
+@asynccontextmanager
+async def setup_energy_entry(
+    hass: HomeAssistant, storage: dict | None, energy_data: dict
+) -> AsyncGenerator[MagicMock]:
+    """Set up the integration with mocked client and store.
+
+    Yields the store mock for save-call assertions.
+    """
+    with (
+        patch(MOCK_CLIENT_PATH) as mock_client_class,
+        patch(MOCK_STORE_PATH) as mock_store_class,
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(
+            return_value=create_mock_ata_energy_context()
+        )
+        mock_client.get_energy_data = AsyncMock(return_value=energy_data)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_store = mock_store_class.return_value
+        mock_store.async_load = AsyncMock(return_value=storage)
+        mock_store.async_save = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        yield mock_store
 
 
 @pytest.mark.asyncio
@@ -215,8 +253,6 @@ async def test_corrupt_hourly_energy_value_rejected(hass: HomeAssistant) -> None
     Validates: GitHub issue #161 - corrupt energy value accepted without check
     Tests through: hass.states (sensor total excludes the corrupt spike)
     """
-    mock_context = create_mock_ata_energy_context()
-
     # Initial state: 12:00 hour already fully processed (3100 Wh = 3.1 kWh),
     # matching the issue's reported baseline before the corrupt spike.
     initial_storage = {
@@ -233,30 +269,9 @@ async def test_corrupt_hourly_energy_value_rejected(hass: HomeAssistant) -> None
         ]
     )
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        mock_store = mock_store_class.return_value
-        mock_store.async_load = AsyncMock(return_value=initial_storage)
-        mock_store.async_save = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
+    async with setup_energy_entry(
+        hass, initial_storage, mock_energy_data
+    ) as mock_store:
         state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
@@ -297,8 +312,6 @@ async def test_corrupt_historical_value_self_heals_on_load(
     Validates: GitHub issue #161 - fixing already-polluted stored totals
     Tests through: hass.states (sensor total is corrected after setup)
     """
-    mock_context = create_mock_ata_energy_context()
-
     # Simulates a pre-fix install: the corrupt 13:00 spike was already
     # added in full to the cumulative total and recorded in hour_values.
     polluted_storage = {
@@ -323,30 +336,9 @@ async def test_corrupt_historical_value_self_heals_on_load(
         ]
     )
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        mock_store = mock_store_class.return_value
-        mock_store.async_load = AsyncMock(return_value=polluted_storage)
-        mock_store.async_save = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
+    async with setup_energy_entry(
+        hass, polluted_storage, mock_energy_data
+    ) as mock_store:
         state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
@@ -386,8 +378,6 @@ async def test_all_corrupt_hour_values_self_heal_keeps_delta_tracking(
     Validates: GitHub issue #161 - self-heal must never empty hour_values
     Tests through: hass.states (next poll's real energy is counted)
     """
-    mock_context = create_mock_ata_energy_context()
-
     now = datetime.now(UTC)
     corrupt_ts = (now - timedelta(hours=3)).isoformat()
     new_hour_1 = (now - timedelta(hours=2)).isoformat()
@@ -409,30 +399,9 @@ async def test_all_corrupt_hour_values_self_heal_keeps_delta_tracking(
         ]
     )
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        mock_store = mock_store_class.return_value
-        mock_store.async_load = AsyncMock(return_value=polluted_storage)
-        mock_store.async_save = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
+    async with setup_energy_entry(
+        hass, polluted_storage, mock_energy_data
+    ) as mock_store:
         state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
 
@@ -465,8 +434,6 @@ async def test_stale_hour_values_pruned_on_load(hass: HomeAssistant) -> None:
     Tests through: hass.states + persisted storage (stale entry removed,
     cumulative total and recent entry left untouched by pruning alone)
     """
-    mock_context = create_mock_ata_energy_context()
-
     now = datetime.now(UTC)
     stale_timestamp = (
         now - timedelta(hours=HOUR_VALUE_RETENTION_HOURS + 24)
@@ -488,30 +455,9 @@ async def test_stale_hour_values_pruned_on_load(hass: HomeAssistant) -> None:
     # Same recent hour, same value - already seen, no new delta
     mock_energy_data = create_mock_energy_response([(recent_timestamp, 500.0)])
 
-    with (
-        patch(MOCK_CLIENT_PATH) as mock_client_class,
-        patch(MOCK_STORE_PATH) as mock_store_class,
-    ):
-        mock_client = mock_client_class.return_value
-        mock_client.login = AsyncMock()
-        mock_client.close = AsyncMock()
-        mock_client.get_user_context = AsyncMock(return_value=mock_context)
-        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
-        type(mock_client).is_authenticated = PropertyMock(return_value=True)
-
-        mock_store = mock_store_class.return_value
-        mock_store.async_load = AsyncMock(return_value=initial_storage)
-        mock_store.async_save = AsyncMock()
-
-        entry = MockConfigEntry(
-            domain=DOMAIN,
-            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
-            unique_id="test@example.com",
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
+    async with setup_energy_entry(
+        hass, initial_storage, mock_energy_data
+    ) as mock_store:
         state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert state is not None
         # Pruning stale entries alone must not touch the cumulative total -

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -7,6 +7,7 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
@@ -14,7 +15,7 @@ from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.const import DOMAIN
+from custom_components.melcloudhome.const import DOMAIN, HOUR_VALUE_RETENTION_HOURS
 
 from .conftest import (
     MOCK_CLIENT_PATH,
@@ -202,6 +203,245 @@ async def test_energy_accumulation_cumulative_totals(hass: HomeAssistant) -> Non
 
 
 @pytest.mark.asyncio
+async def test_corrupt_hourly_energy_value_rejected(hass: HomeAssistant) -> None:
+    """Test that an implausible hourly energy value from the cloud is rejected.
+
+    Reproduces GitHub issue #161: the MELCloud cloud API occasionally returns
+    a corrupt hourly value of ~6,553,600 Wh (~65536 * 100 Wh, consistent with
+    a 16-bit counter wrap) for a single hour. Without a sanity check, this
+    delta is added straight into the cumulative total, permanently inflating
+    it by ~6553.6 kWh.
+
+    Validates: GitHub issue #161 - corrupt energy value accepted without check
+    Tests through: hass.states (sensor total excludes the corrupt spike)
+    """
+    mock_context = create_mock_ata_energy_context()
+
+    # Initial state: 12:00 hour already fully processed (3100 Wh = 3.1 kWh),
+    # matching the issue's reported baseline before the corrupt spike.
+    initial_storage = {
+        "cumulative": {TEST_UNIT_ID: 3.1},
+        "hour_values": {TEST_UNIT_ID: {"2026-06-30T12:00:00Z": 3.1}},
+    }
+
+    # New energy data includes the corrupt spike reported in the issue
+    mock_energy_data = create_mock_energy_response(
+        [
+            ("2026-06-30T12:00:00Z", 3100.0),  # Already processed - skip
+            ("2026-06-30T13:00:00Z", 6553300.0),  # CORRUPT - must be rejected
+            ("2026-06-30T14:00:00Z", 800.0),  # NEW - add 0.8 kWh (legitimate)
+        ]
+    )
+
+    with (
+        patch(MOCK_CLIENT_PATH) as mock_client_class,
+        patch(MOCK_STORE_PATH) as mock_store_class,
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_store = mock_store_class.return_value
+        mock_store.async_load = AsyncMock(return_value=initial_storage)
+        mock_store.async_save = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
+        assert state is not None
+
+        # Expected: 3.1 (initial, 12:00 already seen) + 0.8 (14:00, legitimate)
+        # = 3.9 kWh. The corrupt 13:00 spike (~6553.3 kWh) must NOT be added.
+        assert float(state.state) == pytest.approx(3.9, rel=0.01)
+
+        saved_data = mock_store.async_save.call_args_list[0][0][0]
+        assert saved_data["cumulative"][TEST_UNIT_ID]["consumed"] == pytest.approx(
+            3.9, rel=0.01
+        )
+        # Corrupt hour must not be persisted as a seen value either, so a
+        # later corrected reading for that hour can still be accepted.
+        assert (
+            "2026-06-30T13:00:00Z"
+            not in saved_data["hour_values"][TEST_UNIT_ID]["consumed"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_corrupt_historical_value_self_heals_on_load(
+    hass: HomeAssistant,
+) -> None:
+    """Test that a previously-persisted corrupt value is purged on load.
+
+    Reproduces the "already polluted" half of GitHub issue #161: installs
+    that hit the corrupt cloud reading before the sanity check existed have
+    it permanently baked into their stored cumulative total. On upgrade,
+    the tracker should detect the implausible historical hour_value entry,
+    subtract it back out of the cumulative total, and drop the entry so a
+    future legitimate reading for that hour is accepted fresh.
+
+    Note: this only heals the integration's own persisted counter. Home
+    Assistant's Long-Term Statistics (Energy Dashboard history) are
+    recorded separately and are not touched by this - the user still needs
+    HA's built-in "Adjust statistics" tool for the affected day.
+
+    Validates: GitHub issue #161 - fixing already-polluted stored totals
+    Tests through: hass.states (sensor total is corrected after setup)
+    """
+    mock_context = create_mock_ata_energy_context()
+
+    # Simulates a pre-fix install: the corrupt 13:00 spike was already
+    # added in full to the cumulative total and recorded in hour_values.
+    polluted_storage = {
+        "cumulative": {
+            TEST_UNIT_ID: {"consumed": 6556.4}
+        },  # 3.1 + 6553.3 legit+corrupt
+        "hour_values": {
+            TEST_UNIT_ID: {
+                "consumed": {
+                    "2026-06-30T12:00:00Z": 3.1,
+                    "2026-06-30T13:00:00Z": 6553.3,  # corrupt - must be purged
+                }
+            }
+        },
+    }
+
+    # No new data this poll - just verifying the load-time self-heal
+    mock_energy_data = create_mock_energy_response(
+        [
+            ("2026-06-30T12:00:00Z", 3100.0),
+            ("2026-06-30T13:00:00Z", 6553300.0),
+        ]
+    )
+
+    with (
+        patch(MOCK_CLIENT_PATH) as mock_client_class,
+        patch(MOCK_STORE_PATH) as mock_store_class,
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_store = mock_store_class.return_value
+        mock_store.async_load = AsyncMock(return_value=polluted_storage)
+        mock_store.async_save = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
+        assert state is not None
+
+        # Expected: 6556.4 - 6553.3 (purged) = 3.1 kWh. The 13:00 hour was
+        # already seen (same value in this poll), so no new delta is added.
+        assert float(state.state) == pytest.approx(3.1, rel=0.01)
+
+        # The purge should have persisted immediately during async_setup,
+        # before any new energy poll ran - check the earliest ATA save.
+        saved_data = mock_store.async_save.call_args_list[0][0][0]
+        assert saved_data["cumulative"][TEST_UNIT_ID]["consumed"] == pytest.approx(
+            3.1, rel=0.01
+        )
+        assert (
+            "2026-06-30T13:00:00Z"
+            not in saved_data["hour_values"][TEST_UNIT_ID]["consumed"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_stale_hour_values_pruned_on_load(hass: HomeAssistant) -> None:
+    """Test that hour_values entries older than the retention window are pruned.
+
+    hour_values only needs to cover the API's polling lookback window
+    (DATA_LOOKBACK_HOURS_ENERGY) - once an hour falls outside
+    HOUR_VALUE_RETENTION_HOURS, the API will never return that timestamp
+    again, so the entry can never be looked up again. Without pruning,
+    this dict grows unbounded for the lifetime of the install.
+
+    Validates: bounded hour_values retention (companion to GitHub issue #161)
+    Tests through: hass.states + persisted storage (stale entry removed,
+    cumulative total and recent entry left untouched by pruning alone)
+    """
+    mock_context = create_mock_ata_energy_context()
+
+    now = datetime.now(UTC)
+    stale_timestamp = (
+        now - timedelta(hours=HOUR_VALUE_RETENTION_HOURS + 24)
+    ).isoformat()
+    recent_timestamp = (now - timedelta(hours=1)).isoformat()
+
+    initial_storage = {
+        "cumulative": {TEST_UNIT_ID: {"consumed": 5.0}},
+        "hour_values": {
+            TEST_UNIT_ID: {
+                "consumed": {
+                    stale_timestamp: 1.0,  # outside retention window - pruned
+                    recent_timestamp: 0.5,  # inside retention window - kept
+                }
+            }
+        },
+    }
+
+    # Same recent hour, same value - already seen, no new delta
+    mock_energy_data = create_mock_energy_response([(recent_timestamp, 500.0)])
+
+    with (
+        patch(MOCK_CLIENT_PATH) as mock_client_class,
+        patch(MOCK_STORE_PATH) as mock_store_class,
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_store = mock_store_class.return_value
+        mock_store.async_load = AsyncMock(return_value=initial_storage)
+        mock_store.async_save = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
+        assert state is not None
+        # Pruning stale entries alone must not touch the cumulative total -
+        # only implausible-value purging does that.
+        assert float(state.state) == pytest.approx(5.0, rel=0.01)
+
+        # The pruning save happens during async_setup, before the energy
+        # poll runs - check the earliest ATA save.
+        saved_data = mock_store.async_save.call_args_list[0][0][0]
+        hour_values = saved_data["hour_values"][TEST_UNIT_ID]["consumed"]
+        assert stale_timestamp not in hour_values
+        assert recent_timestamp in hour_values
+
+
+@pytest.mark.asyncio
 async def test_double_hour_prevention(hass: HomeAssistant) -> None:
     """Test that same hour is never counted twice.
 
@@ -215,13 +455,20 @@ async def test_double_hour_prevention(hass: HomeAssistant) -> None:
     """
     mock_context = create_mock_ata_energy_context()
 
+    # Timestamps must be recent (within HOUR_VALUE_RETENTION_HOURS) - the
+    # real API only ever reports hours within its lookback window, so a
+    # "duplicate old hour" scenario using stale timestamps isn't realistic
+    # and would be pruned by _clean_hour_values before this test's poll runs.
+    hour_10 = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    hour_11 = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
     # Initial state: 2 hours already processed
     initial_storage = {
         "cumulative": {TEST_UNIT_ID: 1.1},  # 1.1 kWh already
         "hour_values": {
             TEST_UNIT_ID: {
-                "2025-01-15T10:00:00Z": 0.5,  # Already processed
-                "2025-01-15T11:00:00Z": 0.6,  # Already processed
+                hour_10: 0.5,  # Already processed
+                hour_11: 0.6,  # Already processed
             }
         },
     }
@@ -229,8 +476,8 @@ async def test_double_hour_prevention(hass: HomeAssistant) -> None:
     # Energy response has SAME hours again with SAME values (should skip all)
     mock_energy_data_duplicate = create_mock_energy_response(
         [
-            ("2025-01-15T10:00:00Z", 500.0),  # Same value - skip
-            ("2025-01-15T11:00:00Z", 600.0),  # Same value - skip
+            (hour_10, 500.0),  # Same value - skip
+            (hour_11, 600.0),  # Same value - skip
         ]
     )
 
@@ -273,7 +520,7 @@ async def test_double_hour_prevention(hass: HomeAssistant) -> None:
             0
         ]  # First call (ATA tracker)
         assert saved_data["hour_values"][TEST_UNIT_ID]["consumed"][
-            "2025-01-15T11:00:00Z"
+            hour_11
         ] == pytest.approx(0.6, rel=0.01)
 
 
@@ -505,6 +752,14 @@ async def test_storage_migration_from_v1_3_4_to_v2_0(hass: HomeAssistant) -> Non
     """
     mock_context = create_mock_ata_energy_context()
 
+    # Timestamps must be recent (within HOUR_VALUE_RETENTION_HOURS) - the
+    # real API only ever reports hours within its lookback window, so a
+    # "duplicate old hour" scenario using stale timestamps isn't realistic
+    # and would be pruned by _clean_hour_values before this test's poll runs.
+    hour_10 = (datetime.now(UTC) - timedelta(hours=3)).isoformat()
+    hour_11 = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    hour_12 = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
     # v1.3.4 storage format (single-measure)
     v1_3_4_storage = {
         "cumulative": {
@@ -512,8 +767,8 @@ async def test_storage_migration_from_v1_3_4_to_v2_0(hass: HomeAssistant) -> Non
         },
         "hour_values": {
             TEST_UNIT_ID: {
-                "2025-01-15T10:00:00Z": 0.5,  # Direct timestamp mapping (v1.3.4)
-                "2025-01-15T11:00:00Z": 0.6,
+                hour_10: 0.5,  # Direct timestamp mapping (v1.3.4)
+                hour_11: 0.6,
             }
         },
     }
@@ -521,9 +776,9 @@ async def test_storage_migration_from_v1_3_4_to_v2_0(hass: HomeAssistant) -> Non
     # New energy data after migration (1 new hour to verify accumulation still works)
     mock_energy_data = create_mock_energy_response(
         [
-            ("2025-01-15T10:00:00Z", 500.0),  # Already tracked - skip
-            ("2025-01-15T11:00:00Z", 600.0),  # Already tracked - skip
-            ("2025-01-15T12:00:00Z", 700.0),  # NEW - add 0.7 kWh
+            (hour_10, 500.0),  # Already tracked - skip
+            (hour_11, 600.0),  # Already tracked - skip
+            (hour_12, 700.0),  # NEW - add 0.7 kWh
         ]
     )
 
@@ -575,10 +830,10 @@ async def test_storage_migration_from_v1_3_4_to_v2_0(hass: HomeAssistant) -> Non
         assert isinstance(saved_data["hour_values"][TEST_UNIT_ID], dict)
         assert "consumed" in saved_data["hour_values"][TEST_UNIT_ID]
         assert saved_data["hour_values"][TEST_UNIT_ID]["consumed"][
-            "2025-01-15T10:00:00Z"
+            hour_10
         ] == pytest.approx(0.5, rel=0.01)
         assert saved_data["hour_values"][TEST_UNIT_ID]["consumed"][
-            "2025-01-15T12:00:00Z"
+            hour_12
         ] == pytest.approx(0.7, rel=0.01)
 
 
@@ -596,6 +851,14 @@ async def test_storage_no_migration_for_v2_0_format(hass: HomeAssistant) -> None
     """
     mock_context = create_mock_ata_energy_context()
 
+    # Timestamps must be recent (within HOUR_VALUE_RETENTION_HOURS) - the
+    # real API only ever reports hours within its lookback window, so a
+    # "duplicate old hour" scenario using stale timestamps isn't realistic
+    # and would be pruned by _clean_hour_values before this test's poll runs.
+    hour_10 = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+    hour_11 = (datetime.now(UTC) - timedelta(hours=1, minutes=30)).isoformat()
+    hour_12 = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
     # v2.0 storage format (multi-measure)
     v2_0_storage = {
         "cumulative": {
@@ -607,12 +870,12 @@ async def test_storage_no_migration_for_v2_0_format(hass: HomeAssistant) -> None
         "hour_values": {
             TEST_UNIT_ID: {
                 "consumed": {
-                    "2025-01-15T10:00:00Z": 0.5,
-                    "2025-01-15T11:00:00Z": 0.6,
+                    hour_10: 0.5,
+                    hour_11: 0.6,
                 },
                 "produced": {
-                    "2025-01-15T10:00:00Z": 0.2,
-                    "2025-01-15T11:00:00Z": 0.3,
+                    hour_10: 0.2,
+                    hour_11: 0.3,
                 },
             }
         },
@@ -621,8 +884,8 @@ async def test_storage_no_migration_for_v2_0_format(hass: HomeAssistant) -> None
     # New energy data (1 new hour)
     mock_energy_data = create_mock_energy_response(
         [
-            ("2025-01-15T11:00:00Z", 600.0),  # Already tracked - skip
-            ("2025-01-15T12:00:00Z", 700.0),  # NEW - add 0.7 kWh
+            (hour_11, 600.0),  # Already tracked - skip
+            (hour_12, 700.0),  # NEW - add 0.7 kWh
         ]
     )
 
@@ -672,7 +935,7 @@ async def test_storage_no_migration_for_v2_0_format(hass: HomeAssistant) -> None
         # Check hour_values structure preserved
         assert isinstance(saved_data["hour_values"][TEST_UNIT_ID]["consumed"], dict)
         assert saved_data["hour_values"][TEST_UNIT_ID]["consumed"][
-            "2025-01-15T12:00:00Z"
+            hour_12
         ] == pytest.approx(0.7, rel=0.01)
 
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -368,4 +368,17 @@ uv run tools/find_corrupt_energy_readings.py --all --csv bad_points.csv  # scan 
 uv run tools/find_corrupt_energy_readings.py --insecure              # self-signed local cert
 ```
 
+**Fixing a flagged point:**
+
+For each entity/timestamp the script flags:
+
+1. Open **Developer Tools → Statistics** in Home Assistant
+2. Search for the entity (e.g. `sensor.melcloudhome_b657_22c6_energy`) and click
+   the **ramp icon** on its row ("Adjust a statistic")
+3. Pick the flagged hour from the list (times are shown in your local timezone —
+   the script prints UTC)
+4. Correct the value: change the corrupt hour's consumption to what it plausibly
+   was (usually `0`, or a typical value for that hour). Home Assistant
+   automatically shifts all later totals so your history stays consistent.
+
 **Complementary tip:** the "Adjust a statistic" dialog itself has an **Outliers** button (bottom-left, before you pick a specific hour) that ranks the 10 largest deltas in that entity's *entire* history, using 5-minute data where available — finer-grained than this script's hourly scan. It's a bare magnitude ranking though (no plausibility check, no signature matching, capped at 10, one entity at a time), so it's a good quick sanity-check per entity but doesn't replace running this script across a whole install.

--- a/tools/README.md
+++ b/tools/README.md
@@ -327,3 +327,43 @@ python tools/dump_device_state.py --unit-id <uuid>    # Single device
 ```
 
 Both tools require `MELCLOUD_USER` and `MELCLOUD_PASSWORD` environment variables.
+
+## Home Assistant Diagnostic Tools
+
+### `find_corrupt_energy_readings.py`
+
+Scans your Home Assistant instance's Long-Term Statistics for implausible hourly
+jumps in cumulative (`total`/`total_increasing`) energy sensors — in particular
+the corrupt ~6553.6 kWh spike described in [issue #161](https://github.com/andrew-blake/melcloudhome/issues/161),
+where the MELCloud cloud API occasionally returns a corrupt hourly value
+consistent with a 16-bit counter wrap.
+
+Upgrading the integration stops new occurrences and self-heals its own internal
+running total, but it can't rewrite Home Assistant's Long-Term Statistics (what
+the Energy Dashboard's history graph reads) — those are recorded separately by
+HA core. If a corrupt reading already made it into your history before
+upgrading, use this script to find exactly which entity and timestamp to fix,
+then correct it manually via **Developer Tools → Statistics → (find the
+entity) → Adjust a statistic**.
+
+**Read-only** — it never writes anything, and works against any recorder
+backend (SQLite/MySQL/Postgres) via Home Assistant's WebSocket API (the same
+one the History and Energy Dashboard pages use), authenticated with a normal
+long-lived access token.
+
+**Setup:**
+
+1. Home Assistant → Profile → Security → Long-Lived Access Tokens → Create Token
+2. `export HA_URL=https://homeassistant.local:8123`
+3. `export HA_TOKEN=your_long_lived_token_here`
+
+**Usage:**
+
+```bash
+uv run tools/find_corrupt_energy_readings.py                       # auto-discovers sensor.melcloudhome_* energy sensors
+uv run tools/find_corrupt_energy_readings.py --days 1095            # scan further back (default: 730 days)
+uv run tools/find_corrupt_energy_readings.py --threshold-kwh 50     # lower the sensitivity
+uv run tools/find_corrupt_energy_readings.py --entity sensor.melcloudhome_0efc_76db_energy
+uv run tools/find_corrupt_energy_readings.py --all --csv bad_points.csv  # scan every cumulative sensor, export to CSV
+uv run tools/find_corrupt_energy_readings.py --insecure              # self-signed local cert
+```

--- a/tools/README.md
+++ b/tools/README.md
@@ -367,3 +367,5 @@ uv run tools/find_corrupt_energy_readings.py --entity sensor.melcloudhome_0efc_7
 uv run tools/find_corrupt_energy_readings.py --all --csv bad_points.csv  # scan every cumulative sensor, export to CSV
 uv run tools/find_corrupt_energy_readings.py --insecure              # self-signed local cert
 ```
+
+**Complementary tip:** the "Adjust a statistic" dialog itself has an **Outliers** button (bottom-left, before you pick a specific hour) that ranks the 10 largest deltas in that entity's *entire* history, using 5-minute data where available — finer-grained than this script's hourly scan. It's a bare magnitude ranking though (no plausibility check, no signature matching, capped at 10, one entity at a time), so it's a good quick sanity-check per entity but doesn't replace running this script across a whole install.

--- a/tools/README.md
+++ b/tools/README.md
@@ -381,4 +381,16 @@ For each entity/timestamp the script flags:
    was (usually `0`, or a typical value for that hour). Home Assistant
    automatically shifts all later totals so your history stays consistent.
 
+**Known limitation — the entity's own history chart:** "Adjust a statistic"
+corrects the consumption series the **Energy Dashboard** reads, and that is
+the fix that matters. The *entity's* history chart (open the sensor →
+History) plots a different series — the sensor's recorded state — and will
+still show the spike after your adjustment. Recent history clears by itself
+when it ages past the recorder purge window (10 days by default). History
+older than that is drawn from hourly mean/min/max statistics that Home
+Assistant keeps forever and provides **no supported way to edit**, so a
+spike there is permanent. This is cosmetic only: nothing is computed from
+those values, and your Energy Dashboard, sensor readings, and automations
+are unaffected.
+
 **Complementary tip:** the "Adjust a statistic" dialog itself has an **Outliers** button (bottom-left, before you pick a specific hour) that ranks the 10 largest deltas in that entity's *entire* history, using 5-minute data where available — finer-grained than this script's hourly scan. It's a bare magnitude ranking though (no plausibility check, no signature matching, capped at 10, one entity at a time), so it's a good quick sanity-check per entity but doesn't replace running this script across a whole install.

--- a/tools/find_corrupt_energy_readings.py
+++ b/tools/find_corrupt_energy_readings.py
@@ -49,6 +49,7 @@ import ssl
 import sys
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
+from pathlib import Path
 from typing import Any
 
 import aiohttp
@@ -285,7 +286,9 @@ async def run(args: argparse.Namespace) -> int:
                 all_flagged.extend((statistic_id, item) for item in flagged)
 
             if args.csv:
-                with open(args.csv, "w", newline="") as f:
+                csv_path = Path(args.csv)
+                csv_path.parent.mkdir(parents=True, exist_ok=True)
+                with open(csv_path, "w", newline="") as f:
                     writer = csv_module.writer(f)
                     writer.writerow(
                         [

--- a/tools/find_corrupt_energy_readings.py
+++ b/tools/find_corrupt_energy_readings.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Scan Home Assistant's Long-Term Statistics for corrupt energy jumps.
+
+Background: the MELCloud cloud API has occasionally returned a corrupt
+hourly energy value of ~6,553,600 Wh (~6553.6 kWh) for one hour, consistent
+with a 16-bit counter wrap (65536 * 100 Wh). Before this was caught by a
+sanity check in the integration (see GitHub issue #161), a value like that
+could get written straight into a total_increasing energy sensor's history,
+permanently distorting the Energy Dashboard for that day.
+
+Upgrading the integration stops new occurrences and self-heals its own
+internal running total, but Home Assistant's Long-Term Statistics (what the
+Energy Dashboard's history graph actually reads) are recorded separately by
+HA core and are NOT touched by the integration. Any spike already baked into
+your statistics history needs a one-time manual fix via Developer Tools ->
+Statistics -> (find the entity) -> Adjust a statistic.
+
+This script only finds the bad points for you - it never writes anything.
+It works against any recorder backend (SQLite/MySQL/Postgres) because it
+goes through Home Assistant's WebSocket API, the same one the frontend's
+History and Energy Dashboard pages use, authenticated with a normal
+long-lived access token - no database credentials needed.
+
+Prerequisites:
+    A Home Assistant long-lived access token (Profile -> Security ->
+    Long-Lived Access Tokens -> Create Token).
+
+Usage:
+    export HA_URL=https://homeassistant.local:8123
+    export HA_TOKEN=your_long_lived_token_here
+    uv run tools/find_corrupt_energy_readings.py
+    uv run tools/find_corrupt_energy_readings.py --days 1095 --threshold-kwh 50
+    uv run tools/find_corrupt_energy_readings.py --entity sensor.melcloudhome_0efc_76db_energy
+    uv run tools/find_corrupt_energy_readings.py --insecure --csv bad_points.csv
+
+Note: uses recorder/list_statistic_ids and recorder/statistics_during_period,
+the same internal WebSocket commands the frontend uses. These aren't part of
+HA's stable public API and could change shape between versions; this script
+fails loudly rather than guessing if a response doesn't look as expected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv as csv_module
+import os
+import ssl
+import sys
+from datetime import UTC, datetime, timedelta
+from itertools import pairwise
+from typing import Any
+
+import aiohttp
+
+DEFAULT_THRESHOLD_KWH = 100.0
+# Signature of the known root cause (65536 * 100 Wh). Deltas within this
+# tolerance of the signature are called out specifically as high-confidence
+# matches for the counter-wrap bug, rather than some other kind of outlier.
+KNOWN_SIGNATURE_KWH = 6553.6
+KNOWN_SIGNATURE_TOLERANCE_KWH = 5.0
+# A jump spanning a multi-hour gap can be legitimate accumulation, but only
+# up to a physically sane rate - no single residential ATA/ATW unit sustains
+# continuous draw/output anywhere near this, even generously accounting for
+# large multi-split systems. Above this, a gap doesn't excuse the jump.
+MAX_PLAUSIBLE_CONTINUOUS_KW = 30.0
+
+
+class HaWebSocketClient:
+    """Minimal client for the subset of the HA WebSocket API this script needs."""
+
+    def __init__(self, session: aiohttp.ClientSession, ws_url: str, token: str) -> None:
+        self._session = session
+        self._ws_url = ws_url
+        self._token = token
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
+        self._next_id = 1
+
+    async def connect(self) -> None:
+        ws = await self._session.ws_connect(self._ws_url)
+        self._ws = ws
+
+        hello = await ws.receive_json()
+        if hello.get("type") != "auth_required":
+            raise RuntimeError(f"Unexpected handshake message: {hello}")
+
+        await ws.send_json({"type": "auth", "access_token": self._token})
+        auth_result = await ws.receive_json()
+        if auth_result.get("type") != "auth_ok":
+            raise RuntimeError(
+                f"Authentication failed: {auth_result.get('message', auth_result)}"
+            )
+
+    async def command(self, payload: dict[str, Any]) -> Any:
+        if self._ws is None:
+            raise RuntimeError("call connect() first")
+        message_id = self._next_id
+        self._next_id += 1
+        await self._ws.send_json({"id": message_id, **payload})
+
+        while True:
+            response = await self._ws.receive_json()
+            if response.get("id") != message_id:
+                continue
+            if not response.get("success", False):
+                error = response.get("error", {})
+                raise RuntimeError(
+                    f"{payload.get('type')} failed: "
+                    f"{error.get('code', '?')}: {error.get('message', response)}"
+                )
+            return response.get("result", {})
+
+    async def close(self) -> None:
+        if self._ws is not None:
+            await self._ws.close()
+
+
+def _to_datetime(value: Any) -> datetime | None:
+    """Parse a statistics 'start' field - can be epoch ms (number) or ISO string."""
+    if value is None:
+        return None
+    if isinstance(value, int | float):
+        return datetime.fromtimestamp(value / 1000, tz=UTC)
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+async def discover_energy_statistic_ids(
+    client: HaWebSocketClient, prefix: str | None
+) -> list[str]:
+    """Find sum-type (cumulative) statistic_ids, optionally filtered by prefix."""
+    result = await client.command({"type": "recorder/list_statistic_ids"})
+    entries: list[dict[str, Any]] = result if isinstance(result, list) else []
+    ids = [
+        entry["statistic_id"]
+        for entry in entries
+        if entry.get("has_sum") and entry.get("statistic_id")
+    ]
+    if prefix:
+        ids = [sid for sid in ids if sid.startswith(prefix)]
+    return sorted(ids)
+
+
+async def fetch_hourly_sums(
+    client: HaWebSocketClient, statistic_id: str, start: datetime, end: datetime
+) -> list[tuple[datetime, float]]:
+    """Fetch (timestamp, sum) pairs for one statistic_id over the given window."""
+    result = await client.command(
+        {
+            "type": "recorder/statistics_during_period",
+            "start_time": start.isoformat(),
+            "end_time": end.isoformat(),
+            "statistic_ids": [statistic_id],
+            "period": "hour",
+            "types": ["sum"],
+        }
+    )
+    rows = result.get(statistic_id, []) if isinstance(result, dict) else []
+    points = []
+    for row in rows:
+        ts = _to_datetime(row.get("start"))
+        value = row.get("sum")
+        if ts is not None and value is not None:
+            points.append((ts, float(value)))
+    points.sort(key=lambda p: p[0])
+    return points
+
+
+def find_suspicious_jumps(
+    points: list[tuple[datetime, float]], threshold_kwh: float
+) -> list[dict]:
+    """Flag consecutive points whose sum increased by more than threshold_kwh."""
+    flagged = []
+    for (prev_ts, prev_sum), (ts, value) in pairwise(points):
+        delta = value - prev_sum
+        if delta <= threshold_kwh:
+            continue
+        gap_hours = (ts - prev_ts).total_seconds() / 3600
+        implied_kw = delta / gap_hours if gap_hours > 0 else float("inf")
+        signature_match = (
+            abs(delta - KNOWN_SIGNATURE_KWH) <= KNOWN_SIGNATURE_TOLERANCE_KWH
+        )
+        flagged.append(
+            {
+                "timestamp": ts,
+                "previous_timestamp": prev_ts,
+                "previous_sum": prev_sum,
+                "sum": value,
+                "delta_kwh": delta,
+                "gap_hours": gap_hours,
+                "implied_kw": implied_kw,
+                "signature_match": signature_match,
+            }
+        )
+    return flagged
+
+
+def print_report(statistic_id: str, flagged: list[dict]) -> None:
+    if not flagged:
+        print(f"  OK - no jumps above threshold for {statistic_id}")
+        return
+
+    print(f"  {len(flagged)} suspicious jump(s) for {statistic_id}:")
+    for item in flagged:
+        if item["signature_match"]:
+            note = " <- matches known ~6553.6 kWh counter-wrap signature"
+        elif item["implied_kw"] > MAX_PLAUSIBLE_CONTINUOUS_KW:
+            note = (
+                f" <- implausible even accounting for the "
+                f"{item['gap_hours']:.1f}h gap (~{item['implied_kw']:.0f} kW "
+                "implied continuous average - no residential unit sustains "
+                "this)"
+            )
+        elif item["gap_hours"] > 1.5:
+            note = (
+                f" <- spans a {item['gap_hours']:.1f}h gap "
+                f"(~{item['implied_kw']:.1f} kW implied average - plausible "
+                "legitimate accumulation, verify before adjusting)"
+            )
+        else:
+            note = ""
+        print(
+            f"    {item['previous_timestamp'].isoformat()} -> "
+            f"{item['timestamp'].isoformat()}: "
+            f"{item['previous_sum']:.3f} -> {item['sum']:.3f} kWh "
+            f"(+{item['delta_kwh']:.1f} kWh){note}"
+        )
+
+
+async def run(args: argparse.Namespace) -> int:
+    ha_url = os.environ.get("HA_URL")
+    token = os.environ.get("HA_TOKEN")
+    if not ha_url or not token:
+        print("HA_URL and HA_TOKEN must be set (see script docstring)", file=sys.stderr)
+        return 1
+
+    ws_url = (
+        ha_url.rstrip("/").replace("https://", "wss://").replace("http://", "ws://")
+        + "/api/websocket"
+    )
+
+    connector = None
+    if args.insecure:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        connector = aiohttp.TCPConnector(ssl=ctx)
+
+    end = datetime.now(UTC)
+    start = end - timedelta(days=args.days)
+
+    async with aiohttp.ClientSession(connector=connector) as session:
+        client = HaWebSocketClient(session, ws_url, token)
+        try:
+            await client.connect()
+        except Exception as err:
+            print(f"Failed to connect/authenticate to {ws_url}: {err}", file=sys.stderr)
+            return 1
+
+        try:
+            if args.entity:
+                statistic_ids = args.entity
+            else:
+                prefix = None if args.all else "sensor.melcloudhome_"
+                statistic_ids = await discover_energy_statistic_ids(client, prefix)
+
+            if not statistic_ids:
+                print("No matching cumulative (sum-type) statistics found.")
+                return 0
+
+            print(
+                f"Scanning {len(statistic_ids)} statistic(s) from "
+                f"{start.date()} to {end.date()} "
+                f"(threshold: +{args.threshold_kwh:.0f} kWh/hour)...\n"
+            )
+
+            all_flagged: list[tuple[str, dict]] = []
+            for statistic_id in statistic_ids:
+                points = await fetch_hourly_sums(client, statistic_id, start, end)
+                flagged = find_suspicious_jumps(points, args.threshold_kwh)
+                print_report(statistic_id, flagged)
+                all_flagged.extend((statistic_id, item) for item in flagged)
+
+            if all_flagged and args.csv:
+                with open(args.csv, "w", newline="") as f:
+                    writer = csv_module.writer(f)
+                    writer.writerow(
+                        [
+                            "statistic_id",
+                            "previous_timestamp",
+                            "timestamp",
+                            "gap_hours",
+                            "implied_kw",
+                            "previous_sum_kwh",
+                            "sum_kwh",
+                            "delta_kwh",
+                            "matches_known_signature",
+                            "implausible_even_with_gap",
+                        ]
+                    )
+                    for statistic_id, item in all_flagged:
+                        writer.writerow(
+                            [
+                                statistic_id,
+                                item["previous_timestamp"].isoformat(),
+                                item["timestamp"].isoformat(),
+                                round(item["gap_hours"], 2),
+                                round(item["implied_kw"], 2),
+                                item["previous_sum"],
+                                item["sum"],
+                                item["delta_kwh"],
+                                item["signature_match"],
+                                item["implied_kw"] > MAX_PLAUSIBLE_CONTINUOUS_KW,
+                            ]
+                        )
+                print(f"\nWrote {len(all_flagged)} row(s) to {args.csv}")
+
+            if all_flagged:
+                print(
+                    "\nThis script is read-only. To fix a flagged point:\n"
+                    "  Developer Tools -> Statistics -> search for the entity ->\n"
+                    "  click the entity -> 'Adjust a statistic' -> pick the "
+                    "timestamp above and correct or zero out the value."
+                )
+            return 0
+        finally:
+            await client.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Find corrupt (implausibly large) hourly jumps in Home "
+        "Assistant Long-Term Statistics for cumulative energy sensors."
+    )
+    parser.add_argument(
+        "--days", type=int, default=730, help="Lookback window in days (default: 730)"
+    )
+    parser.add_argument(
+        "--threshold-kwh",
+        type=float,
+        default=DEFAULT_THRESHOLD_KWH,
+        help=f"Flag single-hour jumps above this many kWh (default: {DEFAULT_THRESHOLD_KWH})",
+    )
+    parser.add_argument(
+        "--entity",
+        action="append",
+        help="Specific statistic_id to check (repeatable). Default: "
+        "auto-discover sensor.melcloudhome_* cumulative sensors.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Scan all cumulative (sum-type) statistics, not just melcloudhome ones.",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Skip TLS certificate verification (self-signed local certs).",
+    )
+    parser.add_argument("--csv", help="Optional path to write flagged points as CSV.")
+    args = parser.parse_args()
+
+    try:
+        exit_code = asyncio.run(run(args))
+    except KeyboardInterrupt:
+        exit_code = 130
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/find_corrupt_energy_readings.py
+++ b/tools/find_corrupt_energy_readings.py
@@ -45,7 +45,6 @@ import argparse
 import asyncio
 import csv as csv_module
 import os
-import ssl
 import sys
 from datetime import UTC, datetime, timedelta
 from itertools import pairwise
@@ -243,12 +242,7 @@ async def run(args: argparse.Namespace) -> int:
         + "/api/websocket"
     )
 
-    connector = None
-    if args.insecure:
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
-        connector = aiohttp.TCPConnector(ssl=ctx)
+    connector = aiohttp.TCPConnector(ssl=False) if args.insecure else None
 
     end = datetime.now(UTC)
     start = end - timedelta(days=args.days)

--- a/tools/find_corrupt_energy_readings.py
+++ b/tools/find_corrupt_energy_readings.py
@@ -309,9 +309,9 @@ async def run(args: argparse.Namespace) -> int:
                                 item["timestamp"].isoformat(),
                                 round(item["gap_hours"], 2),
                                 round(item["implied_kw"], 2),
-                                item["previous_sum"],
-                                item["sum"],
-                                item["delta_kwh"],
+                                round(item["previous_sum"], 3),
+                                round(item["sum"], 3),
+                                round(item["delta_kwh"], 3),
                                 item["signature_match"],
                                 item["implied_kw"] > MAX_PLAUSIBLE_CONTINUOUS_KW,
                             ]

--- a/tools/find_corrupt_energy_readings.py
+++ b/tools/find_corrupt_energy_readings.py
@@ -284,7 +284,7 @@ async def run(args: argparse.Namespace) -> int:
                 print_report(statistic_id, flagged)
                 all_flagged.extend((statistic_id, item) for item in flagged)
 
-            if all_flagged and args.csv:
+            if args.csv:
                 with open(args.csv, "w", newline="") as f:
                     writer = csv_module.writer(f)
                     writer.writerow(


### PR DESCRIPTION
## Summary

Addresses #161 (left open until the fix graduates to a stable release). The MELCloud cloud API occasionally returns a corrupt hourly energy value of ~6,553,600 Wh - a 16-bit counter wrap (`65536 x 100 Wh`). Without a sanity check it was added straight into the `total_increasing` energy sensor, permanently inflating it and corrupting the Energy Dashboard.

### Integration fix

- **Reject** any hourly value above a 100 kWh sanity ceiling, before it can be accumulated or seed the delta-tracking baseline.
- **Self-heal on load**: drop already-persisted implausible `hour_values` entries and reset the affected cumulative total to 0.0 - the lifetime total on the entity card restarts from 0; the Energy Dashboard is unaffected.
- **Never-empty invariant**: the purge keeps at least one entry per tracked unit+measure (a 0.0 placeholder if all were corrupt), so `_is_first_initialization()` can't mistake a tracked device for a new one and silently absorb the next poll.
- **Bound storage**: `hour_values` was never pruned; now bounded to a retention window.

### What affected users will see in their logs

Per poll, while the API is still serving a corrupt reading (repeats for up to 48 h - expected, harmless):

```
WARNING ... Energy (consumed): Bedroom (aaaaaaaa-...) - Hour 2026-07-03 06:00 implausible value 6553.6 kWh exceeds sanity ceiling (100.0 kWh) - rejecting reading
```

Once, at first startup after upgrading, on installs already affected:

```
WARNING ... Energy (consumed): aaaaaaaa-... - Hour 2026-07-03 06:00: purging implausible historical value 6553.6 kWh. See GitHub issue #161.
WARNING ... Energy (consumed): aaaaaaaa-... - resetting cumulative total to 0.0 kWh (was 6562.300) after purging 1 implausible hourly value(s). Home Assistant records this as a meter reset; delta tracking continues from 0.
```

### Known limitations

- Long-Term Statistics (Energy Dashboard history) can't be rewritten by the integration - spikes already in history need a one-time fix via Developer Tools -> Statistics. The tool below finds the exact points; `tools/README.md` has step-by-step instructions.
- The entity's own history chart may still show the spike afterwards: recent history self-purges after the recorder window (default 10 days); older history is drawn from hourly mean/min/max statistics HA provides no way to edit. Cosmetic only.

### New tool: `tools/find_corrupt_energy_readings.py`

Read-only scanner for implausible hourly jumps in Long-Term Statistics - reports the exact entity/timestamp to fix. Works against any recorder backend via HA's WebSocket API + long-lived token. Distinguishes known-signature matches from jumps implausible even across a data gap (implied continuous kW) from plausible post-downtime accumulation. `--csv` export; see `tools/README.md`.

## Test plan

- [x] Tests: rejection, self-heal reset, all-corrupt edge case, stale pruning; 172 integration + 251 API tests, lint/type-check/format clean
- [x] Verified live on real installs: corrupt reading rejected on every poll; self-heal purged 13 real corrupt points (incl. a 26,215 kWh quadruple wrap) with no statistics artifacts; script found all real corrupt points and rescanned clean after fixes (`--insecure` negative-control checked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
