### PR TITLE
fix: warn only once per rejected corrupt energy reading (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Corrupt hourly energy readings from the MELCloud cloud (~6,553 kWh for a single hour) are now rejected instead of being added to the energy sensor, which permanently inflated totals and corrupted the Energy Dashboard. (#161)
 - Installs that already accumulated a corrupt reading have the affected energy sensor reset to 0 automatically on upgrade, and it counts normally from there. Note this does not repair Energy Dashboard history: spikes already recorded there need a one-time manual fix (see `tools/README.md`). (#161)
+- The "rejecting reading" warning now appears once per corrupt reading instead of repeating every 30 minutes while the cloud keeps re-sending the same corrupt hour. (#161)
 
 
 ## [2.3.4] - 2026-06-18

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -81,6 +81,12 @@ class EnergyTrackerBase(ABC):
             str, defaultdict[str, defaultdict[str, float]]
         ] = defaultdict(lambda: defaultdict(lambda: defaultdict(float)))
 
+        # Rejected (unit, measure, hour) keys already warned about - the cloud
+        # re-sends the same corrupt hour every poll for days, so only the
+        # first rejection warns. Per-runtime; a restart warns once more.
+        # ponytail: unbounded set, but corrupt hours are rare (~50 B each)
+        self._warned_rejections: set[tuple[str, str, str]] = set()
+
         # Persistent storage
         self._store: Store = Store(hass, STORAGE_VERSION, storage_key)
 
@@ -365,16 +371,20 @@ class EnergyTrackerBase(ABC):
                 # Corrupt reading from cloud (e.g. 16-bit counter wrap) - reject
                 # without persisting so a later legitimate value for this hour
                 # is still accepted normally. See GitHub issue #161.
-                _LOGGER.warning(
-                    "Energy (%s): %s (%s) - Hour %s implausible value %.1f kWh "
-                    "exceeds sanity ceiling (%.1f kWh) - rejecting reading",
-                    measure,
-                    unit_name,
-                    unit_id,
-                    hour_timestamp[:16],
-                    kwh_value,
-                    MAX_PLAUSIBLE_HOURLY_ENERGY_KWH,
-                )
+                key = (unit_id, measure, hour_timestamp)
+                if key not in self._warned_rejections:
+                    self._warned_rejections.add(key)
+                    _LOGGER.warning(
+                        "Energy (%s): %s (%s) - Hour %s implausible value "
+                        "%.1f kWh exceeds sanity ceiling (%.1f kWh) - "
+                        "rejecting reading",
+                        measure,
+                        unit_name,
+                        unit_id,
+                        hour_timestamp[:16],
+                        kwh_value,
+                        MAX_PLAUSIBLE_HOURLY_ENERGY_KWH,
+                    )
                 continue
 
             # Get previous value for this specific hour (default 0.0 from defaultdict)

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -15,7 +15,11 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.melcloudhome.const import DOMAIN, HOUR_VALUE_RETENTION_HOURS
 
@@ -289,6 +293,42 @@ async def test_corrupt_hourly_energy_value_rejected(hass: HomeAssistant) -> None
             "2026-06-30T13:00:00Z"
             not in saved_data["hour_values"][TEST_UNIT_ID]["consumed"]
         )
+
+
+@pytest.mark.asyncio
+async def test_corrupt_reading_rejection_warns_only_once(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a re-sent corrupt reading is only warned about once.
+
+    The cloud re-sends the same corrupt hour on every poll (observed for
+    days after the event), which produced an identical WARNING every 30
+    minutes. The first rejection must warn; repeats of the same
+    (unit, measure, hour) must stay silent.
+
+    Validates: GitHub issue #161 follow-up - rejection log spam
+    Tests through: caplog (log output is the observable behavior here)
+    """
+    initial_storage = {
+        "cumulative": {TEST_UNIT_ID: 3.1},
+        "hour_values": {TEST_UNIT_ID: {"2026-06-30T12:00:00Z": 3.1}},
+    }
+    mock_energy_data = create_mock_energy_response(
+        [
+            ("2026-06-30T12:00:00Z", 3100.0),  # Already processed - skip
+            ("2026-06-30T13:00:00Z", 6553300.0),  # CORRUPT - rejected every poll
+        ]
+    )
+
+    async with setup_energy_entry(hass, initial_storage, mock_energy_data):
+        assert caplog.text.count("exceeds sanity ceiling") == 1
+
+        # Advance past the energy update interval - the mock re-sends the
+        # same corrupt hour, mirroring observed cloud behavior.
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=31))
+        await hass.async_block_till_done()
+
+        assert caplog.text.count("exceeds sanity ceiling") == 1
 
 
 @pytest.mark.asyncio

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -939,6 +939,13 @@ class MockMELCloudServer:
             else:
                 value = 0
 
+            # Known cloud quirk (issue #161): the real API re-sends a corrupt
+            # 16-bit-wrapped reading (65536 * 100 Wh) for the same hour on
+            # every poll, for days. Reproduce it at today's 00:00 UTC so the
+            # hour key is stable across polls within a day.
+            if timestamp == now.replace(hour=0, minute=0, second=0, microsecond=0):
+                value = 6553600
+
             values.append(
                 {
                     "time": timestamp.strftime("%Y-%m-%d %H:%M:%S"),


### PR DESCRIPTION
The cloud re-sends the same corrupt hour on every poll — observed on prod still re-sending a reading two days after the event — which produced an identical rejection WARNING every 30 minutes. This tracks rejected (unit, measure, hour) keys in a small per-runtime set so only the first rejection warns; a restart warns once more, keeping the condition discoverable for users reporting #161.

Also adds the corrupt re-sent reading to the mock server (stable hour key at today's 00:00 UTC) so the dev environment permanently exercises the rejection path, and a changelog bullet under the existing 2.3.5 entry ahead of beta.2.

Tested via a new integration test that drives a second energy poll re-sending the same corrupt hour and asserts the warning is logged exactly once (verified failing before the fix). Full integration suite passes (173 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)