### PR TITLE
fix: complete first init when every energy reading is implausible (#161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrupt hourly energy readings from the MELCloud cloud (~6,553 kWh for a single hour) are now rejected instead of being added to the energy sensor, which permanently inflated totals and corrupted the Energy Dashboard. (#161)
 - Installs that already accumulated a corrupt reading have the affected energy sensor reset to 0 automatically on upgrade, and it counts normally from there. Note this does not repair Energy Dashboard history: spikes already recorded there need a one-time manual fix (see `tools/README.md`). (#161)
 - The "rejecting reading" warning now appears once per corrupt reading instead of repeating every 30 minutes while the cloud keeps re-sending the same corrupt hour. (#161)
+- Energy tracking now starts correctly when every reading in the initial data window is corrupt; previously initialization retried (and re-warned) on every poll without ever starting. (#161)
 
 
 ## [2.3.4] - 2026-06-18

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -331,6 +331,15 @@ class EnergyTrackerBase(ABC):
 
             self._energy_hour_values[unit_id][measure][hour_timestamp] = kwh_value
 
+        if values and not self._energy_hour_values[unit_id][measure]:
+            # Every reading was implausible - keep the newest hour as a 0.0
+            # placeholder so initialization completes instead of re-running
+            # (and re-warning) every poll. Mirrors the all-corrupt self-heal
+            # strategy: a re-sent corrupt value hits the rejection ceiling,
+            # a legitimate one counts as a normal delta from 0.0.
+            newest = max(v["time"] for v in values)
+            self._energy_hour_values[unit_id][measure][newest] = 0.0
+
         _LOGGER.info(
             "Initializing %s tracking for %s (%s) at 0.0 kWh "
             "(marked %d hour(s) as seen, will track deltas from next update)",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,7 @@
+# Distinct project name so test runs never clobber the dev environment's
+# containers (see docker-compose.test.yml).
+name: melcloudhome-dev
+
 services:
   # Mock MELCloud API Server
   melcloud-mock:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,8 @@
+# Distinct project name so test runs never clobber the dev environment's
+# containers (both files define a melcloud-mock service; without this they
+# share the directory-derived project name and steal each other's container).
+name: melcloudhome-test
+
 services:
   # Mock MELCloud API Server (rate limiting disabled for CI tests)
   melcloud-mock:

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -332,6 +332,45 @@ async def test_corrupt_reading_rejection_warns_only_once(
 
 
 @pytest.mark.asyncio
+async def test_all_corrupt_first_init_completes_and_does_not_loop(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that first init with only implausible readings completes.
+
+    If every reading in the lookback window is corrupt, nothing was stored,
+    so the tracker re-ran first initialization on every poll - re-warning
+    for every hour, forever, and never starting delta tracking. Init must
+    complete by keeping a 0.0 placeholder (mirroring the all-corrupt
+    self-heal strategy), so the next poll takes the throttled rejection
+    path instead of re-initializing.
+
+    Validates: GitHub issue #161 follow-up - all-corrupt first init loop
+    Tests through: hass.states + caplog (init must not repeat)
+    """
+    mock_energy_data = create_mock_energy_response(
+        [
+            ("2026-06-30T12:00:00Z", 6553300.0),  # CORRUPT
+            ("2026-06-30T13:00:00Z", 6553400.0),  # CORRUPT
+        ]
+    )
+
+    async with setup_energy_entry(hass, None, mock_energy_data):
+        state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
+        assert state is not None
+        assert float(state.state) == 0.0
+        assert caplog.text.count("Initializing consumed tracking") == 1
+
+        # Second poll re-sends the same all-corrupt window.
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=31))
+        await hass.async_block_till_done()
+
+        # Init must not run again, and the re-sent corrupt hours must go
+        # through the warn-once rejection path, not the init path.
+        assert caplog.text.count("Initializing consumed tracking") == 1
+        assert caplog.text.count("- skipping") == 2  # once per hour, init only
+
+
+@pytest.mark.asyncio
 async def test_corrupt_historical_value_self_heals_on_load(
     hass: HomeAssistant,
 ) -> None:

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -930,21 +930,23 @@ class MockMELCloudServer:
                 minute=0, second=0, microsecond=0
             )
 
+            # ATW interval_energy_* values are kWh (the real API contract);
+            # anything else (ATA cumulative measures) is Wh.
             if measure == "interval_energy_consumed":
-                # Consumed: 2000-4000 Wh per hour (2-4 kWh)
-                value = random.randint(2000, 4000)
+                # Consumed: 2-4 kWh per hour
+                value: float = random.randint(2000, 4000) / 1000
             elif measure == "interval_energy_produced":
-                # Produced: 6000-12000 Wh per hour (6-12 kWh, COP ~3)
-                value = random.randint(6000, 12000)
+                # Produced: 6-12 kWh per hour (COP ~3)
+                value = random.randint(6000, 12000) / 1000
             else:
                 value = 0
 
             # Known cloud quirk (issue #161): the real API re-sends a corrupt
-            # 16-bit-wrapped reading (65536 * 100 Wh) for the same hour on
-            # every poll, for days. Reproduce it at today's 00:00 UTC so the
-            # hour key is stable across polls within a day.
+            # 16-bit-wrapped reading (65536 * 100 Wh = 6553.6 kWh) for the
+            # same hour on every poll, for days. Reproduce it at today's
+            # 00:00 UTC so the hour key is stable across polls within a day.
             if timestamp == now.replace(hour=0, minute=0, second=0, microsecond=0):
-                value = 6553600
+                value = 6553.6 if measure.startswith("interval_energy") else 6553600
 
             values.append(
                 {


### PR DESCRIPTION
If every reading in the 48h lookback window breaches the sanity ceiling, nothing gets stored, so the tracker re-ran first initialization on every poll — re-warning for every hour, forever, and never starting delta tracking. This keeps the newest hour as a 0.0 placeholder (mirroring the all-corrupt self-heal strategy) so init completes and re-sent corrupt values take the warn-once rejection path from #164.

Found live in the dev environment, where a units mismatch made every mock ATW reading implausible — the mock generated Wh-scale values but the ATW API contract is kWh. That mock scaling is fixed here too, and the corrupt re-sent hour is now 6553.6 kWh for ATW measures, matching the real counter-wrap signature.

Also gives the dev and test compose files distinct project names — they both define a melcloud-mock service and previously clobbered each other's container when tests ran while the dev environment was up.

Tested via a new integration test asserting init runs exactly once across two polls of all-corrupt data (verified failing before the fix), plus live verification in the dev environment: three interval polls re-sending the corrupt hour produced exactly one warning per unit/measure. Full energy test file passes (15 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)