### PR TITLE
chore: prepare v2.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [2.3.5] - 2026-07-03
+## [2.3.5] - 2026-07-06
 
 ### Added
 
@@ -14,10 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Corrupt hourly energy readings from the MELCloud cloud (~6,553 kWh for a single hour) are now rejected instead of being added to the energy sensor, which permanently inflated totals and corrupted the Energy Dashboard. (#161)
+- Corrupt hourly energy readings from the MELCloud cloud (~6,553 kWh for a single hour) are now rejected instead of being added to the energy sensor, which could permanently inflate totals and corrupt the Energy Dashboard. A warning is logged once per rejected reading. (#161)
 - Installs that already accumulated a corrupt reading have the affected energy sensor reset to 0 automatically on upgrade, and it counts normally from there. Note this does not repair Energy Dashboard history: spikes already recorded there need a one-time manual fix (see `tools/README.md`). (#161)
-- The "rejecting reading" warning now appears once per corrupt reading instead of repeating every 30 minutes while the cloud keeps re-sending the same corrupt hour. (#161)
-- Energy tracking now starts correctly when every reading in the initial data window is corrupt; previously initialization retried (and re-warned) on every poll without ever starting. (#161)
 
 
 ## [2.3.4] - 2026-06-18


### PR DESCRIPTION
Promotes v2.3.5-beta.2 to a stable release — same code, no functional changes. Trims two CHANGELOG bullets that only described bugs introduced and fixed within the beta cycle itself, and updates the release date.

Merge, then tag `v2.3.5` and push to trigger the release workflow.