### PR TITLE
feat: mock-server WebSocket support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ dev-up:  ## Start dev environment (mock API + Home Assistant)
 dev-down:  ## Stop dev environment
 	docker compose -f docker-compose.dev.yml down
 
-dev-restart:  ## Restart Home Assistant (quick reload after code changes)
+dev-restart:  ## Restart HA (reloads integration code only — mock server changes need dev-rebuild)
 	docker compose -f docker-compose.dev.yml restart homeassistant
 	@echo "✅ Home Assistant restarted - code changes loaded"
 
@@ -201,7 +201,7 @@ dev-restore-snapshot:  ## Restore dev environment from snapshot (SNAPSHOT=path/t
 dev-logs:  ## View Home Assistant logs (Ctrl+C to exit)
 	docker compose -f docker-compose.dev.yml logs -f homeassistant
 
-dev-rebuild:  ## Rebuild mock server image (after updating mock server code)
+dev-rebuild:  ## Rebuild mock server image (required for mock server code changes — image has no volume mount)
 	docker compose -f docker-compose.dev.yml down
 	docker compose -f docker-compose.dev.yml build --no-cache melcloud-mock
 	docker compose -f docker-compose.dev.yml up -d

--- a/custom_components/melcloudhome/api/client.py
+++ b/custom_components/melcloudhome/api/client.py
@@ -27,8 +27,11 @@ from .const_shared import (
     API_USER_CONTEXT,
     BASE_URL,
     MOCK_BASE_URL,
+    MOCK_WS_HASH_URL,
+    MOCK_WS_HOST,
     USER_AGENT,
     WS_HASH_URL,
+    WS_HOST,
 )
 from .exceptions import ApiError, AuthenticationError, ServiceUnavailableError
 from .models import UserContext
@@ -53,6 +56,8 @@ class MELCloudHomeClient:
         """
         self._debug_mode = debug_mode
         self._base_url = MOCK_BASE_URL if debug_mode else BASE_URL
+        self._ws_hash_url = MOCK_WS_HASH_URL if debug_mode else WS_HASH_URL
+        self._ws_host = MOCK_WS_HOST if debug_mode else WS_HOST
         self._user_context: UserContext | None = None
         self._on_tokens_refreshed: Callable[[], None] | None = None
         self._refresh_lock = asyncio.Lock()
@@ -129,6 +134,11 @@ class MELCloudHomeClient:
         """Refresh the access token using stored refresh token."""
         return await self._auth.refresh_access_token()
 
+    @property
+    def ws_host(self) -> str:
+        """WebSocket host for this client's mode (mock in debug mode)."""
+        return self._ws_host
+
     async def async_ws_session(self) -> Any:
         """Return the authenticated aiohttp session (for the WebSocket).
 
@@ -142,7 +152,7 @@ class MELCloudHomeClient:
         Exchanges the mobile-BFF bearer for a ``{"hash", "userId"}`` document
         at the Lambda token endpoint, mirroring what the official app does.
         Refreshes the access token first if it is expired, so callers don't
-        need to. Returns the ``hash`` used to open ``WS_HOST/?hash=<hash>``.
+        need to. Returns the ``hash`` used to open ``ws_host/?hash=<hash>``.
 
         Raises:
             AuthenticationError: if the endpoint rejects the bearer (401/403).
@@ -158,7 +168,7 @@ class MELCloudHomeClient:
 
         session = await self._auth.get_session()
         headers = {"Authorization": f"Bearer {self._auth.access_token}"}
-        async with session.get(WS_HASH_URL, headers=headers) as resp:
+        async with session.get(self._ws_hash_url, headers=headers) as resp:
             if resp.status in (401, 403):
                 raise AuthenticationError(
                     f"WebSocket token endpoint rejected credentials ({resp.status})"

--- a/custom_components/melcloudhome/api/const_shared.py
+++ b/custom_components/melcloudhome/api/const_shared.py
@@ -44,6 +44,13 @@ COGNITO_DOMAIN_SUFFIX = ".amazoncognito.com"
 WS_HASH_URL = "https://6x2dgdulg7omjsxalnhmo4ynba0dcgwk.lambda-url.eu-west-1.on.aws/"
 WS_HOST = "wss://ws.melcloudhome.com"
 
+# Debug-mode equivalents — the mock server serves the hash at /ws/token and
+# the socket at /ws on the same host/port as REST. Derived from MOCK_BASE_URL
+# so the Docker env var override carries through. Zero prod contact in debug
+# mode is a hard project rule.
+MOCK_WS_HASH_URL = MOCK_BASE_URL + "/ws/token"
+MOCK_WS_HOST = MOCK_BASE_URL.replace("http", "ws", 1) + "/ws"
+
 __all__ = [
     "API_FIELD_BUILDINGS",
     "API_FIELD_MEASURE_DATA",
@@ -58,6 +65,8 @@ __all__ = [
     "COGNITO_BASE_URL",
     "COGNITO_DOMAIN_SUFFIX",
     "MOCK_BASE_URL",
+    "MOCK_WS_HASH_URL",
+    "MOCK_WS_HOST",
     "OAUTH_CLIENT_ID",
     "OAUTH_REDIRECT_URI",
     "OAUTH_SCOPES",

--- a/custom_components/melcloudhome/api/websocket.py
+++ b/custom_components/melcloudhome/api/websocket.py
@@ -77,6 +77,7 @@ class MELCloudHomeWebSocket:
                 # Best-effort listener: any failure just backs off and retries.
                 _LOGGER.debug("WebSocket session ended: %s", err)
 
+            was_connected = self._connected
             if self._connected:
                 self._connected = False
                 if not self._closing:
@@ -85,10 +86,11 @@ class MELCloudHomeWebSocket:
                         " (polling continues meanwhile)"
                     )
 
-            # Reset only after a session that actually survived — a clean
-            # return from an accept-then-immediately-close server must keep
-            # escalating.
-            if time.monotonic() - started >= _STABLE_SESSION_SECS:
+            # Reset only after a session that actually connected and survived.
+            # A clean return from an accept-then-immediately-close server must
+            # keep escalating, and so must a hash endpoint that hangs past the
+            # threshold before failing — elapsed time alone proves nothing.
+            if was_connected and time.monotonic() - started >= _STABLE_SESSION_SECS:
                 backoff = _INITIAL_BACKOFF
 
             if self._closing:

--- a/custom_components/melcloudhome/api/websocket.py
+++ b/custom_components/melcloudhome/api/websocket.py
@@ -27,8 +27,6 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
-from .const_shared import WS_HOST
-
 if TYPE_CHECKING:
     from .client import MELCloudHomeClient
 
@@ -105,7 +103,7 @@ class MELCloudHomeWebSocket:
         ws_hash = await self._client.async_get_ws_hash()
         session = await self._client.async_ws_session()
         async with session.ws_connect(
-            f"{WS_HOST}/?hash={ws_hash}",
+            f"{self._client.ws_host}/?hash={ws_hash}",
             heartbeat=_HEARTBEAT,
         ) as ws:
             _LOGGER.info(

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -18,7 +18,6 @@ from .api.exceptions import ApiError, AuthenticationError, ServiceUnavailableErr
 from .api.models import AirToAirUnit, AirToWaterUnit, Building, UserContext
 from .api.websocket import MELCloudHomeWebSocket
 from .const import (
-    CONF_DEBUG_MODE,
     CONF_ENABLE_WEBSOCKET,
     DOMAIN,
     UPDATE_INTERVAL,
@@ -410,13 +409,8 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         self._async_setup_websocket()
 
     def _websocket_enabled(self) -> bool:
-        """Whether the opt-in WebSocket accelerator should run.
-
-        Disabled in debug/mock mode (the mock server has no WS endpoint).
-        """
+        """Whether the opt-in WebSocket accelerator should run."""
         if self._config_entry is None:
-            return False
-        if self._config_entry.data.get(CONF_DEBUG_MODE, False):
             return False
         return bool(self._config_entry.options.get(CONF_ENABLE_WEBSOCKET, False))
 

--- a/docs/decisions/019-opt-in-websocket-realtime-updates.md
+++ b/docs/decisions/019-opt-in-websocket-realtime-updates.md
@@ -94,7 +94,8 @@ It is disabled in debug/mock mode.
   the debounce delay plus one REST poll — which also defuses the dedup
   command-drop scenario in practice. ADR-018's limitation still applies to
   the default (off) configuration.
-- The integration requires HA ≥ 2025.8.0 (entry-scoped background tasks).
+- The integration requires HA ≥ 2025.8.0 (`OptionsFlowWithReload`, new in
+  2025.8; entry-scoped background tasks have been available since ~2023.4).
 - One extra long-lived connection and a hash fetch per (re)connect; steady
   state adds no REST traffic beyond the refreshes that real changes trigger.
 - The mock server does not yet expose a WS endpoint; local dev/e2e coverage

--- a/tests/api/test_mock_ws_server.py
+++ b/tests/api/test_mock_ws_server.py
@@ -115,6 +115,22 @@ async def test_noop_put_emits_nothing(mock_client):
     await ws.close()
 
 
+async def test_put_fan_speed_word_value_emits_typed_int(mock_client):
+    # Regression: fan speed is a word ("Auto".."Five"), not a numeric string.
+    # int("Three") used to raise ValueError inside _broadcast_delta after the
+    # PUT had already mutated state, 500ing the whole request.
+    client, _ = mock_client
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    resp = await client.put(
+        f"/monitor/ataunit/{ATA_ID}", json={"setFanSpeed": "Three"}, headers=BEARER
+    )
+    assert resp.status == 200
+    frame = await ws.receive_json(timeout=2)
+    by_name = {s["name"]: s["value"] for s in frame[0]["Data"]["settings"]}
+    assert by_name["SetFanSpeed"] == 3
+    await ws.close()
+
+
 async def test_atw_put_emits_assumed_shape_delta(mock_client):
     client, _ = mock_client
     atw_id = "bf2d256c-42ac-4799-a6d8-c6ab433e5666"  # House Heat Pump (seeded)

--- a/tests/api/test_mock_ws_server.py
+++ b/tests/api/test_mock_ws_server.py
@@ -144,3 +144,60 @@ async def test_atw_put_emits_assumed_shape_delta(mock_client):
     by_name = {s["name"]: s["value"] for s in frame[0]["Data"]["settings"]}
     assert by_name["SetTankWaterTemperature"] == 52.0
     await ws.close()
+
+
+async def test_control_reject_hash(mock_client):
+    client, _ = mock_client
+    await client.post("/_mock/ws", json={"action": "reject-hash"})
+    with pytest.raises(aiohttp.WSServerHandshakeError) as err:
+        await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    assert err.value.status == 403
+    await client.post("/_mock/ws", json={"action": "clear"})
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")  # works again
+    await ws.close()
+
+
+async def test_control_accept_then_close(mock_client):
+    client, _ = mock_client
+    await client.post("/_mock/ws", json={"action": "accept-then-close"})
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")  # 101 succeeds...
+    msg = await ws.receive(timeout=2)  # ...then server closes immediately
+    assert msg.type == aiohttp.WSMsgType.CLOSE
+    await client.post("/_mock/ws", json={"action": "clear"})
+
+
+async def test_control_close_now(mock_client):
+    client, server = mock_client
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    await client.post("/_mock/ws", json={"action": "close-now"})
+    msg = await ws.receive(timeout=2)
+    assert msg.type == aiohttp.WSMsgType.CLOSE
+    assert server.ws_clients == set()
+
+
+async def test_control_emit_delta_passive_push(mock_client):
+    client, _ = mock_client
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    # Canonical passive push observed on prod: RoomTemperature + ActualFanSpeed
+    await client.post(
+        "/_mock/ws",
+        json={
+            "action": "emit-delta",
+            "unit_id": ATA_ID,
+            "settings": [
+                {"name": "RoomTemperature", "value": 22.5},
+                {"name": "ActualFanSpeed", "value": "2"},  # string, per capture
+            ],
+        },
+    )
+    frame = await ws.receive_json(timeout=2)
+    by_name = {s["name"]: s["value"] for s in frame[0]["Data"]["settings"]}
+    assert by_name["RoomTemperature"] == 22.5
+    assert by_name["ActualFanSpeed"] == "2"
+    await ws.close()
+
+
+async def test_control_unknown_action_400(mock_client):
+    client, _ = mock_client
+    resp = await client.post("/_mock/ws", json={"action": "explode"})
+    assert resp.status == 400

--- a/tests/api/test_mock_ws_server.py
+++ b/tests/api/test_mock_ws_server.py
@@ -204,6 +204,22 @@ async def test_control_unknown_action_400(mock_client):
     assert resp.status == 400
 
 
+async def test_control_emit_delta_missing_fields_400(mock_client):
+    client, _ = mock_client
+    resp = await client.post("/_mock/ws", json={"action": "emit-delta"})
+    assert resp.status == 400
+
+
+async def test_control_status_reports_client_count(mock_client):
+    client, _ = mock_client
+    resp = await client.post("/_mock/ws", json={"action": "status"})
+    assert (await resp.json())["clients"] == 0
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    resp = await client.post("/_mock/ws", json={"action": "status"})
+    assert (await resp.json())["clients"] == 1
+    await ws.close()
+
+
 async def test_ws_paths_exempt_from_rate_limiting(mock_client, monkeypatch):
     """Regression: with the limiter live, the client hits /ws/token then
     immediately opens /ws — <50ms apart. Without the exemption this

--- a/tests/api/test_mock_ws_server.py
+++ b/tests/api/test_mock_ws_server.py
@@ -1,5 +1,7 @@
 """In-process tests for the mock server's WebSocket support (no Docker)."""
 
+import asyncio
+
 import aiohttp
 import pytest
 from aiohttp.test_utils import TestClient, TestServer
@@ -63,3 +65,66 @@ async def test_ws_inbound_frames_ignored_and_disconnect_cleans_up(mock_client):
     await ws.send_str("garbage the real client never sends")
     await ws.close()
     assert server.ws_clients == set()
+
+
+ATA_ID = "0efc1234-5678-9abc-def0-123456787db"  # Living Room AC (seeded)
+
+
+async def test_put_emits_typed_delta_to_all_sockets(mock_client):
+    client, _ = mock_client
+    ws1 = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    ws2 = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+
+    # Living Room AC seeds power=True (see _init_ata_devices), so power=False
+    # here is the field that actually changes — power=True would be a noop
+    # and (correctly, per test_noop_put_emits_nothing) emit no delta for it.
+    resp = await client.put(
+        f"/monitor/ataunit/{ATA_ID}",
+        json={"power": False, "setTemperature": 21.5, "operationMode": "Cool"},
+        headers=BEARER,
+    )
+    assert resp.status == 200
+
+    for ws in (ws1, ws2):
+        frame = await ws.receive_json(timeout=2)
+        assert isinstance(frame, list) and len(frame) == 1
+        assert frame[0]["messageType"] == "unitStateChanged"
+        data = frame[0]["Data"]
+        assert data["id"] == ATA_ID
+        by_name = {s["name"]: s["value"] for s in data["settings"]}
+        # Typed values, per #175 capture — NOT the stringified REST forms
+        assert by_name["Power"] is False
+        assert by_name["SetTemperature"] == 21.5
+        assert by_name["OperationMode"] == 3  # int enum: 3=Cool (captured)
+    await ws1.close()
+    await ws2.close()
+
+
+async def test_noop_put_emits_nothing(mock_client):
+    client, _ = mock_client
+    # Set a known value, then re-send the identical value: no delta.
+    await client.put(
+        f"/monitor/ataunit/{ATA_ID}", json={"setTemperature": 22.0}, headers=BEARER
+    )
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    await client.put(
+        f"/monitor/ataunit/{ATA_ID}", json={"setTemperature": 22.0}, headers=BEARER
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await ws.receive_json(timeout=0.5)
+    await ws.close()
+
+
+async def test_atw_put_emits_assumed_shape_delta(mock_client):
+    client, _ = mock_client
+    atw_id = "bf2d256c-42ac-4799-a6d8-c6ab433e5666"  # House Heat Pump (seeded)
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    await client.put(
+        f"/monitor/atwunit/{atw_id}",
+        json={"setTankWaterTemperature": 52.0},
+        headers=BEARER,
+    )
+    frame = await ws.receive_json(timeout=2)
+    by_name = {s["name"]: s["value"] for s in frame[0]["Data"]["settings"]}
+    assert by_name["SetTankWaterTemperature"] == 52.0
+    await ws.close()

--- a/tests/api/test_mock_ws_server.py
+++ b/tests/api/test_mock_ws_server.py
@@ -1,0 +1,65 @@
+"""In-process tests for the mock server's WebSocket support (no Docker)."""
+
+import aiohttp
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from tools.mock_melcloud_server import MOCK_WS_HASH, MockMELCloudServer
+
+BEARER = {"Authorization": "Bearer mock-token"}
+
+
+@pytest.fixture(autouse=True)
+def _disable_rate_limiting(monkeypatch):
+    """The mock server's rate limiter tracks last-request time as module
+    state, which bleeds across tests run back-to-back in the same process
+    (no Docker, no real network delay between requests). Irrelevant to WS
+    behavior — disable it here rather than in the server itself.
+    """
+    monkeypatch.setattr("tools.mock_melcloud_server.ENABLE_RATE_LIMITING", False)
+
+
+@pytest.fixture
+async def mock_client():
+    server = MockMELCloudServer()
+    client = TestClient(TestServer(server.create_app()))
+    await client.start_server()
+    yield client, server
+    await client.close()
+
+
+async def test_ws_token_returns_hash_equal_userid(mock_client):
+    client, _ = mock_client
+    resp = await client.get("/ws/token", headers=BEARER)
+    assert resp.status == 200
+    data = await resp.json()
+    assert data["hash"] == MOCK_WS_HASH
+    assert data["userId"] == data["hash"]
+
+
+async def test_ws_token_requires_bearer(mock_client):
+    client, _ = mock_client
+    resp = await client.get("/ws/token")
+    assert resp.status == 401
+
+
+async def test_ws_upgrade_with_valid_hash_no_bearer(mock_client):
+    client, server = mock_client
+    ws = await client.ws_connect(f"/ws/?hash={MOCK_WS_HASH}")
+    assert len(server.ws_clients) == 1
+    await ws.close()
+
+
+async def test_ws_upgrade_rejects_bad_hash(mock_client):
+    client, _ = mock_client
+    with pytest.raises(aiohttp.WSServerHandshakeError) as err:
+        await client.ws_connect("/ws/?hash=wrong")
+    assert err.value.status == 403
+
+
+async def test_ws_inbound_frames_ignored_and_disconnect_cleans_up(mock_client):
+    client, server = mock_client
+    ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
+    await ws.send_str("garbage the real client never sends")
+    await ws.close()
+    assert server.ws_clients == set()

--- a/tests/api/test_mock_ws_server.py
+++ b/tests/api/test_mock_ws_server.py
@@ -1,6 +1,7 @@
 """In-process tests for the mock server's WebSocket support (no Docker)."""
 
 import asyncio
+from time import time
 
 import aiohttp
 import pytest
@@ -201,3 +202,20 @@ async def test_control_unknown_action_400(mock_client):
     client, _ = mock_client
     resp = await client.post("/_mock/ws", json={"action": "explode"})
     assert resp.status == 400
+
+
+async def test_ws_paths_exempt_from_rate_limiting(mock_client, monkeypatch):
+    """Regression: with the limiter live, the client hits /ws/token then
+    immediately opens /ws — <50ms apart. Without the exemption this
+    livelocks the listener (token 200 -> upgrade 429 -> backoff -> repeat).
+    """
+    client, _ = mock_client
+    monkeypatch.setattr("tools.mock_melcloud_server.ENABLE_RATE_LIMITING", True)
+    # Simulate a REST request having just consumed the rate limit window.
+    monkeypatch.setattr("tools.mock_melcloud_server.last_request_time", time())
+
+    resp = await client.get("/ws/token", headers=BEARER)
+    assert resp.status == 200
+
+    ws = await client.ws_connect(f"/ws/?hash={MOCK_WS_HASH}")
+    await ws.close()

--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -321,7 +321,8 @@ class TestRunLoop:
         async def fake_connect() -> None:
             attempts.append(1)
             if len(attempts) == 3:
-                # This session survives past the stability threshold.
+                # This session connects and survives past the threshold.
+                ws._connected = True
                 clock["now"] += _STABLE_SESSION_SECS
                 return
             if len(attempts) >= 4:
@@ -340,6 +341,39 @@ class TestRunLoop:
             _INITIAL_BACKOFF * 2,
             _INITIAL_BACKOFF,
         ]
+
+    async def test_slow_failure_without_connecting_keeps_escalating(
+        self, mocker
+    ) -> None:
+        """A hash fetch that hangs past the threshold must not reset the backoff.
+
+        Elapsed time alone doesn't prove a healthy session: an endpoint that
+        hangs >60s per attempt and then fails would otherwise reset every
+        cycle and never escalate past the initial backoff.
+        """
+        sleep = mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+        mocker.patch("random.uniform", return_value=1.0)
+        clock = {"now": 0.0}
+        mocker.patch(
+            "custom_components.melcloudhome.api.websocket.time.monotonic",
+            side_effect=lambda: clock["now"],
+        )
+        ws, _ = _make_ws()
+        attempts: list[int] = []
+
+        async def fake_connect() -> None:  # hangs past the threshold, never connects
+            attempts.append(1)
+            if len(attempts) >= 3:
+                ws.stop()
+                return
+            clock["now"] += _STABLE_SESSION_SECS
+            raise RuntimeError("timed out")
+
+        ws._connect_once = fake_connect  # type: ignore[method-assign]
+        await ws.run()
+
+        waited = [c.args[0] for c in sleep.await_args_list]
+        assert waited == [_INITIAL_BACKOFF, _INITIAL_BACKOFF * 2]
 
     async def test_reconnect_sleep_is_jittered(self, mocker) -> None:
         sleep = mocker.patch("asyncio.sleep", new_callable=AsyncMock)

--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -474,3 +474,30 @@ class TestAsyncWsSession:
         client, auth, session = _client_with_auth()
         assert await client.async_ws_session() is session
         auth.get_session.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# Debug-mode URL selection
+# --------------------------------------------------------------------------- #
+class TestDebugModeUrls:
+    """Hard principle: debug mode must have ZERO contact with prod services."""
+
+    def test_debug_mode_uses_mock_ws_urls(self):
+        from custom_components.melcloudhome.api.const_shared import MOCK_BASE_URL
+
+        client = MELCloudHomeClient(debug_mode=True)
+        assert client.ws_host.startswith("ws://")
+        assert client.ws_host == MOCK_BASE_URL.replace("http", "ws", 1) + "/ws"
+        assert client._ws_hash_url == MOCK_BASE_URL + "/ws/token"
+        assert "lambda-url" not in client._ws_hash_url
+        assert "melcloudhome.com" not in client.ws_host
+
+    def test_prod_mode_uses_real_ws_urls(self):
+        from custom_components.melcloudhome.api.const_shared import (
+            WS_HASH_URL,
+            WS_HOST,
+        )
+
+        client = MELCloudHomeClient(debug_mode=False)
+        assert client.ws_host == WS_HOST
+        assert client._ws_hash_url == WS_HASH_URL

--- a/tests/api/test_websocket_e2e.py
+++ b/tests/api/test_websocket_e2e.py
@@ -84,8 +84,10 @@ class TestWebSocketE2E:
             listener.stop()
             if task is not None:
                 task.cancel()
-                with pytest.raises(asyncio.CancelledError):
-                    await task
+                # Reap without raising: swallows the expected CancelledError
+                # and, unlike pytest.raises here in finally, can't mask the
+                # test's own failure if the task had already finished.
+                await asyncio.gather(task, return_exceptions=True)
             await client.close()
 
     @pytest.mark.e2e
@@ -113,6 +115,6 @@ class TestWebSocketE2E:
             listener.stop()
             if task is not None:
                 task.cancel()
-                with pytest.raises(asyncio.CancelledError):
-                    await task
+                # Reap without raising (see comment in the test above).
+                await asyncio.gather(task, return_exceptions=True)
             await client.close()

--- a/tests/api/test_websocket_e2e.py
+++ b/tests/api/test_websocket_e2e.py
@@ -1,0 +1,98 @@
+"""Real-wire e2e: real client + real WS listener against the Docker mock.
+
+Covers everything below the coordinator (hash fetch, handshake, frame
+parsing, reconnect). The hass side (delta -> debounced refresh -> states) is
+covered in tests/integration/ with a mocked client; the stitched seam was
+verified on prod 2026-07-18 (design doc, section 5).
+
+Requires: mock server running (make dev-up locally, or make test-e2e).
+"""
+
+import asyncio
+
+import aiohttp
+import pytest
+
+from custom_components.melcloudhome.api.client import MELCloudHomeClient
+from custom_components.melcloudhome.api.const_shared import MOCK_BASE_URL
+from custom_components.melcloudhome.api.websocket import MELCloudHomeWebSocket
+
+
+async def _ws_control(action: str) -> None:
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(f"{MOCK_BASE_URL}/_mock/ws", json={"action": action}) as resp,
+    ):
+        assert resp.status == 200
+
+
+class TestWebSocketE2E:
+    @pytest.mark.e2e
+    @pytest.mark.asyncio
+    async def test_put_reaches_delta_handler_over_real_wire(self):
+        client = MELCloudHomeClient(debug_mode=True)
+        deltas: list[tuple[str, list[str]]] = []
+        got_one = asyncio.Event()
+
+        async def on_delta(unit_id: str, names: list[str]) -> None:
+            deltas.append((unit_id, names))
+            got_one.set()
+
+        listener = MELCloudHomeWebSocket(client, on_delta=on_delta)
+        task: asyncio.Task | None = None
+        try:
+            # Login before starting the listener task: async_get_ws_hash()
+            # requires an authenticated session, and starting the task first
+            # makes its first connect attempt fail (no token yet), forcing a
+            # 5s backoff that reliably misses the PUT below. Matches
+            # production ordering (coordinator starts the WS task only after
+            # the client is already authenticated).
+            await client.login("test@example.com", "password")
+            task = asyncio.create_task(listener.run())
+            context = await client.get_user_context()
+            unit = context.buildings[0].air_to_air_units[0]
+            await asyncio.sleep(1)  # let the socket connect before the PUT
+
+            await client.ata.set_temperature(unit.id, 23.5)
+
+            await asyncio.wait_for(got_one.wait(), timeout=10)
+            unit_ids = [d[0] for d in deltas]
+            assert unit.id in unit_ids
+            names = [n for d in deltas if d[0] == unit.id for n in d[1]]
+            assert "SetTemperature" in names
+        finally:
+            listener.stop()
+            if task is not None:
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            await client.close()
+
+    @pytest.mark.e2e
+    @pytest.mark.asyncio
+    async def test_listener_survives_accept_then_close(self):
+        await _ws_control("accept-then-close")
+        client = MELCloudHomeClient(debug_mode=True)
+
+        async def on_delta(unit_id: str, names: list[str]) -> None:
+            pass
+
+        listener = MELCloudHomeWebSocket(client, on_delta=on_delta)
+        task: asyncio.Task | None = None
+        try:
+            # Login before starting the listener task (see comment in the
+            # test above) so the connect/close/backoff cycle under test is
+            # the accept-then-close one, not a pre-login auth failure.
+            await client.login("test@example.com", "password")
+            task = asyncio.create_task(listener.run())
+            # Long enough for >1 connect/close/backoff cycle (initial 5s)
+            await asyncio.sleep(8)
+            assert not task.done(), "listener died instead of backing off"
+        finally:
+            await _ws_control("clear")
+            listener.stop()
+            if task is not None:
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+            await client.close()

--- a/tests/api/test_websocket_e2e.py
+++ b/tests/api/test_websocket_e2e.py
@@ -26,6 +26,24 @@ async def _ws_control(action: str) -> None:
         assert resp.status == 200
 
 
+async def _ws_client_count() -> int:
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(f"{MOCK_BASE_URL}/_mock/ws", json={"action": "status"}) as resp,
+    ):
+        return int((await resp.json())["clients"])
+
+
+async def _wait_for_new_ws_client(baseline: int, timeout: float = 10.0) -> None:
+    """Block until the mock reports more sockets than `baseline`."""
+
+    async def poll() -> None:
+        while await _ws_client_count() <= baseline:
+            await asyncio.sleep(0.1)
+
+    await asyncio.wait_for(poll(), timeout=timeout)
+
+
 class TestWebSocketE2E:
     @pytest.mark.e2e
     @pytest.mark.asyncio
@@ -48,10 +66,12 @@ class TestWebSocketE2E:
             # production ordering (coordinator starts the WS task only after
             # the client is already authenticated).
             await client.login("test@example.com", "password")
+            baseline = await _ws_client_count()
             task = asyncio.create_task(listener.run())
             context = await client.get_user_context()
             unit = context.buildings[0].air_to_air_units[0]
-            await asyncio.sleep(1)  # let the socket connect before the PUT
+            # Deterministic connect wait — a fixed sleep raced slow runners.
+            await _wait_for_new_ws_client(baseline)
 
             await client.ata.set_temperature(unit.id, 23.5)
 

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -160,7 +160,7 @@ async def test_options_flow_change_reloads_entry(
             hass.config_entries, "async_reload", new=AsyncMock()
         ) as mock_reload:
             result = await hass.config_entries.options.async_init(entry.entry_id)
-            result = await hass.config_entries.options.async_configure(
+            await hass.config_entries.options.async_configure(
                 result["flow_id"], user_input={CONF_ENABLE_WEBSOCKET: True}
             )
             await hass.async_block_till_done()

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -92,6 +92,42 @@ async def rate_limit_middleware(request, handler):
 # hash == userId (#175 capture); one constant is all the mock needs.
 MOCK_WS_HASH = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 
+# Wire-format mapping for ATA deltas, per the #175 captures: the socket sends
+# NATIVELY TYPED values (int enums, bools, floats) even though REST /context
+# stringifies everything. The integration only reads setting NAMES (values
+# trigger a refresh, never parsed), so unlisted enum ints are plausible
+# placeholders — only 3=Cool, 4=Fan, 0=Auto(fan) were captured.
+_ATA_OPERATION_MODE_ENUM = {"Heat": 1, "Dry": 2, "Cool": 3, "Fan": 4, "Automatic": 8}
+_ATA_VANE_ENUM = {"Auto": 0, "Swing": 7}  # 6/7 = swing captured; rest plausible
+
+
+def _fan_speed_enum(value):
+    return 0 if value == "Auto" else int(value)
+
+
+ATA_WIRE_MAP = {
+    "power": ("Power", bool),
+    "set_temperature": ("SetTemperature", float),
+    "operation_mode": ("OperationMode", lambda v: _ATA_OPERATION_MODE_ENUM.get(v, 1)),
+    "set_fan_speed": ("SetFanSpeed", _fan_speed_enum),
+    "vane_vertical_direction": (
+        "VaneVerticalDirection",
+        lambda v: _ATA_VANE_ENUM.get(v, 0),
+    ),
+    "vane_horizontal_direction": (
+        "VaneHorizontalDirection",
+        lambda v: _ATA_VANE_ENUM.get(v, 0),
+    ),
+    "in_standby_mode": ("InStandbyMode", bool),
+}
+
+
+def _atw_wire_name(key: str) -> str:
+    """snake_case -> PascalCase. ASSUMPTION: no ATW frame has ever been
+    captured; verify against Andrew's prod soak (backlog) and correct here."""
+    return "".join(part.capitalize() for part in key.split("_"))
+
+
 # Paths that don't require Bearer auth
 # /ws is hash-in-URL auth (the real client sends no Authorization header on
 # the upgrade — matching prod). Both spellings: the client builds
@@ -362,6 +398,38 @@ class MockMELCloudServer:
             logger.info("🔌 WS client disconnected (%d left)", len(self.ws_clients))
         return ws
 
+    async def _broadcast_delta(self, unit_id, changed, wire_map=None):
+        """Push one unitStateChanged frame for `changed` to every socket.
+
+        wire_map maps internal keys -> (WireName, coercer); keys absent from
+        the map fall back to PascalCase name + raw value (the ATW path).
+        """
+        settings = []
+        for key, value in changed.items():
+            if wire_map and key in wire_map:
+                name, coerce = wire_map[key]
+                settings.append({"name": name, "value": coerce(value)})
+            else:
+                settings.append({"name": _atw_wire_name(key), "value": value})
+        if not settings or not self.ws_clients:
+            return
+        frame = [
+            {
+                "messageType": "unitStateChanged",
+                "Data": {"id": unit_id, "settings": settings},
+            }
+        ]
+        for ws in set(self.ws_clients):
+            try:
+                await ws.send_json(frame)
+            except (ConnectionResetError, RuntimeError):
+                self.ws_clients.discard(ws)
+        logger.info(
+            "📡 WS delta for %s: %s",
+            _safe_log(unit_id),
+            _safe_log([s["name"] for s in settings]),
+        )
+
     async def handle_login(self, request: web.Request) -> web.Response:
         """Mock OAuth login endpoint.
 
@@ -605,6 +673,7 @@ class MockMELCloudServer:
         logger.debug("   Request: %s", _safe_log(json.dumps(body)))
 
         state = self.ata_states[unit_id]
+        before = dict(state)
 
         # Update state based on non-null values (sparse update pattern)
         # Permissive: Accept all values, warn if suspicious
@@ -660,6 +729,9 @@ class MockMELCloudServer:
             _safe_log(state["room_temperature"]),
         )
 
+        changed = {k: v for k, v in state.items() if before.get(k) != v}
+        await self._broadcast_delta(unit_id, changed, ATA_WIRE_MAP)
+
         # Real API returns 200 with empty body
         return web.Response(status=200, body=b"")
 
@@ -705,6 +777,7 @@ class MockMELCloudServer:
         logger.debug("   Request: %s", _safe_log(json.dumps(body)))
 
         state = self.atw_states[unit_id]
+        before = dict(state)
 
         # Update state based on non-null values
         if body.get("power") is not None:
@@ -799,6 +872,9 @@ class MockMELCloudServer:
             _safe_log(state["set_tank_water_temperature"]),
         )
         self._log_3way_valve_status(unit_id)
+
+        changed = {k: v for k, v in state.items() if before.get(k) != v}
+        await self._broadcast_delta(unit_id, changed)
 
         # Real API returns 200 with empty body
         return web.Response(status=200, body=b"")

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -99,17 +99,14 @@ MOCK_WS_HASH = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 # placeholders — only 3=Cool, 4=Fan, 0=Auto(fan) were captured.
 _ATA_OPERATION_MODE_ENUM = {"Heat": 1, "Dry": 2, "Cool": 3, "Fan": 4, "Automatic": 8}
 _ATA_VANE_ENUM = {"Auto": 0, "Swing": 7}  # 6/7 = swing captured; rest plausible
-
-
-def _fan_speed_enum(value):
-    return 0 if value == "Auto" else int(value)
-
+# Only 0=Auto confirmed from capture; 1-5 for One..Five are plausible placeholders.
+_ATA_FAN_SPEED_ENUM = {"Auto": 0, "One": 1, "Two": 2, "Three": 3, "Four": 4, "Five": 5}
 
 ATA_WIRE_MAP = {
     "power": ("Power", bool),
     "set_temperature": ("SetTemperature", float),
     "operation_mode": ("OperationMode", lambda v: _ATA_OPERATION_MODE_ENUM.get(v, 1)),
-    "set_fan_speed": ("SetFanSpeed", _fan_speed_enum),
+    "set_fan_speed": ("SetFanSpeed", lambda v: _ATA_FAN_SPEED_ENUM.get(v, 0)),
     "vane_vertical_direction": (
         "VaneVerticalDirection",
         lambda v: _ATA_VANE_ENUM.get(v, 0),

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -135,6 +135,7 @@ AUTH_EXEMPT_PATHS = {
     "/connect/token",
     "/ws",
     "/ws/",
+    "/_mock/ws",
 }
 
 
@@ -169,6 +170,8 @@ class MockMELCloudServer:
         self.buildings = self._init_buildings()
         self.guest_buildings = self._init_guest_buildings()
         self.ws_clients: set[web.WebSocketResponse] = set()
+        self.ws_accept_then_close = False
+        self.ws_reject_hash = False
 
     def _init_ata_devices(self) -> dict[str, dict[str, Any]]:
         """Initialize default ATA (Air-to-Air) device states.
@@ -355,6 +358,9 @@ class MockMELCloudServer:
         app.router.add_get("/ws", self.handle_ws_upgrade)
         app.router.add_get("/ws/", self.handle_ws_upgrade)
 
+        # Test-only fault-injection control (not added to CORS)
+        app.router.add_post("/_mock/ws", self.handle_ws_control)
+
         # Add CORS to all routes
         for route in [
             auth_route,
@@ -381,10 +387,13 @@ class MockMELCloudServer:
 
     async def handle_ws_upgrade(self, request: web.Request) -> web.WebSocketResponse:
         """GET /ws?hash= - upgrade; server-push only, inbound is discarded."""
-        if request.query.get("hash") != MOCK_WS_HASH:
+        if self.ws_reject_hash or request.query.get("hash") != MOCK_WS_HASH:
             raise web.HTTPForbidden(reason="bad hash")
         ws = web.WebSocketResponse()
         await ws.prepare(request)
+        if self.ws_accept_then_close:
+            await ws.close()  # churn scenario: 101 then instant close
+            return ws
         self.ws_clients.add(ws)
         logger.info("🔌 WS client connected (%d total)", len(self.ws_clients))
         try:
@@ -394,6 +403,41 @@ class MockMELCloudServer:
             self.ws_clients.discard(ws)
             logger.info("🔌 WS client disconnected (%d left)", len(self.ws_clients))
         return ws
+
+    async def handle_ws_control(self, request: web.Request) -> web.Response:
+        """POST /_mock/ws - test-only fault injection (auth-exempt)."""
+        body = await request.json()
+        action = body.get("action")
+        if action == "close-now":
+            for ws in set(self.ws_clients):
+                await ws.close()
+            self.ws_clients.clear()
+        elif action == "accept-then-close":
+            self.ws_accept_then_close = True
+        elif action == "reject-hash":
+            self.ws_reject_hash = True
+        elif action == "clear":
+            self.ws_accept_then_close = False
+            self.ws_reject_hash = False
+        elif action == "emit-delta":
+            frame = [
+                {
+                    "messageType": "unitStateChanged",
+                    "Data": {
+                        "id": body["unit_id"],
+                        "settings": body["settings"],
+                    },
+                }
+            ]
+            for ws in set(self.ws_clients):
+                try:
+                    await ws.send_json(frame)
+                except (ConnectionResetError, RuntimeError):
+                    self.ws_clients.discard(ws)
+        else:
+            return web.json_response({"error": f"unknown action {action}"}, status=400)
+        logger.info("🎛️  WS control: %s", _safe_log(action))
+        return web.json_response({"ok": True})
 
     async def _broadcast_delta(self, unit_id, changed, wire_map=None):
         """Push one unitStateChanged frame for `changed` to every socket.

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -88,8 +88,21 @@ async def rate_limit_middleware(request, handler):
     return await handler(request)
 
 
+# Fixed WS credential — the real Lambda issues a per-user uuid where
+# hash == userId (#175 capture); one constant is all the mock needs.
+MOCK_WS_HASH = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
 # Paths that don't require Bearer auth
-AUTH_EXEMPT_PATHS = {"/api/login", "/api/auth/login", "/connect/token"}
+# /ws is hash-in-URL auth (the real client sends no Authorization header on
+# the upgrade — matching prod). Both spellings: the client builds
+# "{host}/?hash=", so the mock's path arrives as "/ws/" (trailing slash).
+AUTH_EXEMPT_PATHS = {
+    "/api/login",
+    "/api/auth/login",
+    "/connect/token",
+    "/ws",
+    "/ws/",
+}
 
 
 @web.middleware
@@ -116,12 +129,13 @@ async def bearer_auth_middleware(request, handler):
 class MockMELCloudServer:
     """Mock MELCloud Home API server supporting ATA and ATW devices."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize mock server with default device states."""
         self.ata_states = self._init_ata_devices()
         self.atw_states = self._init_atw_devices()
         self.buildings = self._init_buildings()
         self.guest_buildings = self._init_guest_buildings()
+        self.ws_clients: set[web.WebSocketResponse] = set()
 
     def _init_ata_devices(self) -> dict[str, dict[str, Any]]:
         """Initialize default ATA (Air-to-Air) device states.
@@ -303,6 +317,11 @@ class MockMELCloudServer:
             "/report/v1/trendsummary", self.get_trend_summary
         )
 
+        # WebSocket endpoints (not added to CORS — native ws handshake, no CORS preflight)
+        app.router.add_get("/ws/token", self.handle_ws_token)
+        app.router.add_get("/ws", self.handle_ws_upgrade)
+        app.router.add_get("/ws/", self.handle_ws_upgrade)
+
         # Add CORS to all routes
         for route in [
             auth_route,
@@ -322,6 +341,26 @@ class MockMELCloudServer:
             cors.add(route)
 
         return app
+
+    async def handle_ws_token(self, request: web.Request) -> web.Response:
+        """GET /ws/token - WS credential (bearer-checked by middleware)."""
+        return web.json_response({"hash": MOCK_WS_HASH, "userId": MOCK_WS_HASH})
+
+    async def handle_ws_upgrade(self, request: web.Request) -> web.WebSocketResponse:
+        """GET /ws?hash= - upgrade; server-push only, inbound is discarded."""
+        if request.query.get("hash") != MOCK_WS_HASH:
+            raise web.HTTPForbidden(reason="bad hash")
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        self.ws_clients.add(ws)
+        logger.info("🔌 WS client connected (%d total)", len(self.ws_clients))
+        try:
+            async for _msg in ws:
+                pass  # real clients send nothing, not even a subscribe
+        finally:
+            self.ws_clients.discard(ws)
+            logger.info("🔌 WS client disconnected (%d left)", len(self.ws_clients))
+        return ws
 
     async def handle_login(self, request: web.Request) -> web.Response:
         """Mock OAuth login endpoint.

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -60,11 +60,20 @@ RATE_LIMIT_INTERVAL = 0.5  # seconds
 rate_limit_lock = asyncio.Lock()
 last_request_time = 0.0
 
+# WS + control paths bypass rate limiting: prod's WS infra (API Gateway +
+# Lambda hash endpoint) is separate from the BFF the limiter simulates, and
+# the client opens /ws immediately after /ws/token — limiting them livelocks
+# the listener (token 200 -> upgrade 429 -> backoff -> repeat).
+RATE_LIMIT_EXEMPT_PATHS = {"/ws", "/ws/", "/ws/token", "/_mock/ws"}
+
 
 @web.middleware
 async def rate_limit_middleware(request, handler):
     """Enforce rate limiting on all requests."""
     if not ENABLE_RATE_LIMITING:
+        return await handler(request)
+
+    if request.path in RATE_LIMIT_EXEMPT_PATHS:
         return await handler(request)
 
     global last_request_time

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -128,6 +128,16 @@ ATA_WIRE_MAP = {
 }
 
 
+def _delta_frame(unit_id: str, settings: list) -> list:
+    """One unitStateChanged frame in the wire shape the socket sends."""
+    return [
+        {
+            "messageType": "unitStateChanged",
+            "Data": {"id": unit_id, "settings": settings},
+        }
+    ]
+
+
 def _atw_wire_name(key: str) -> str:
     """snake_case -> PascalCase. ASSUMPTION: no ATW frame has ever been
     captured; verify against Andrew's prod soak (backlog) and correct here."""
@@ -413,6 +423,14 @@ class MockMELCloudServer:
             logger.info("🔌 WS client disconnected (%d left)", len(self.ws_clients))
         return ws
 
+    async def _send_frame(self, frame: list) -> None:
+        """Send one frame to every connected socket, dropping dead ones."""
+        for ws in set(self.ws_clients):
+            try:
+                await ws.send_json(frame)
+            except (ConnectionResetError, RuntimeError):
+                self.ws_clients.discard(ws)
+
     async def handle_ws_control(self, request: web.Request) -> web.Response:
         """POST /_mock/ws - test-only fault injection (auth-exempt)."""
         body = await request.json()
@@ -429,20 +447,13 @@ class MockMELCloudServer:
             self.ws_accept_then_close = False
             self.ws_reject_hash = False
         elif action == "emit-delta":
-            frame = [
-                {
-                    "messageType": "unitStateChanged",
-                    "Data": {
-                        "id": body["unit_id"],
-                        "settings": body["settings"],
-                    },
-                }
-            ]
-            for ws in set(self.ws_clients):
-                try:
-                    await ws.send_json(frame)
-                except (ConnectionResetError, RuntimeError):
-                    self.ws_clients.discard(ws)
+            if "unit_id" not in body or "settings" not in body:
+                return web.json_response(
+                    {"error": "emit-delta requires unit_id and settings"}, status=400
+                )
+            await self._send_frame(_delta_frame(body["unit_id"], body["settings"]))
+        elif action == "status":
+            return web.json_response({"clients": len(self.ws_clients)})
         else:
             return web.json_response({"error": f"unknown action {action}"}, status=400)
         logger.info("🎛️  WS control: %s", _safe_log(action))
@@ -463,17 +474,7 @@ class MockMELCloudServer:
                 settings.append({"name": _atw_wire_name(key), "value": value})
         if not settings or not self.ws_clients:
             return
-        frame = [
-            {
-                "messageType": "unitStateChanged",
-                "Data": {"id": unit_id, "settings": settings},
-            }
-        ]
-        for ws in set(self.ws_clients):
-            try:
-                await ws.send_json(frame)
-            except (ConnectionResetError, RuntimeError):
-                self.ws_clients.discard(ws)
+        await self._send_frame(_delta_frame(unit_id, settings))
         logger.info(
             "📡 WS delta for %s: %s",
             _safe_log(unit_id),


### PR DESCRIPTION
## Summary

Adds WebSocket support to the local mock server so the real-time integration from #176 can be exercised end-to-end in the dev environment and e2e tests, with zero prod contact from mock mode. Also carries the small cleanups from the #176 round-2 review that weren't worth another contributor round-trip.

## Key changes

- **Mock server** (`tools/mock_melcloud_server.py`): WS hash endpoint, hash-authenticated upgrade route, typed `unitStateChanged` deltas broadcast on state mutations, and a fault-injection control endpoint for resilience testing. WS paths are exempt from the mock's rate limiting (token + upgrade back-to-back livelocked the listener).
- **API client**: debug mode now derives WS URLs from the mock base URL, and the WS listener runs in mock/debug mode — the dev environment gets a real socket instead of silently skipping.
- **Fix**: fan-speed wire coercer handles word values (`One`..`Five`) in deltas.
- **Tests**: mock WS server unit tests, plus e2e tests covering the real-wire WS loop and accept-then-close resilience.

## Post-#176 review cleanups (folded in here)

- **Backoff reset now requires a connected session**: elapsed time alone no longer resets the reconnect backoff, so a hash endpoint that hangs past the stability threshold before failing keeps escalating instead of retrying at the floor forever. New unit test covers the slow-failure path.
- **CodeQL fixes**: unused `result` reassignment in the options-reload test (alert 171 on main — closes when this merges), and e2e teardowns now reap cancelled listener tasks via `asyncio.gather(return_exceptions=True)` instead of `pytest.raises` in `finally` (alerts 172/173, plus it can no longer mask a real test failure).
- **ADR-019 correction**: the HA ≥ 2025.8.0 requirement comes from `OptionsFlowWithReload`, not entry-scoped background tasks.

## Testing

`make test-api`, `make test-integration`, `make test-e2e` all green after rebasing onto the merged #176; verified live against the dev container (deltas observed end-to-end from mock mutation to entity state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
