### PR TITLE
feat: enable real-time WebSocket updates by default + docs weave

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Fixes corrupt energy readings from the MELCloud cloud that could permanently inf
 
 - Full climate control (power, temperature, modes, fan speeds, vane directions)
 - Energy monitoring with Home Assistant Energy Dashboard support
-- Real-time sensors (room temperature, outdoor temperature*, WiFi signal, connection status)
-- 60-second polling for climate updates, 30-minute for outdoor temperature
+- Sensors (room temperature, outdoor temperature*, WiFi signal, connection status)
+- [Real-time updates](#real-time-updates) via WebSocket push, plus 60-second polling (30-minute for outdoor temperature)
 
 *Auto-detected from device capabilities - not all units have outdoor temperature sensors
 
@@ -33,12 +33,13 @@ Fixes corrupt energy readings from the MELCloud cloud that could permanently inf
 - Multiple sensors (temperatures, operation status, 6 telemetry sensors)
 - Energy monitoring* (consumed, produced, COP - Energy Dashboard compatible)
 - Cooling mode* (Cool Room/Cool Flow presets)
+- [Real-time updates](#real-time-updates) via WebSocket push
 
 *Auto-detected from device capabilities - see [docs/entities.md](docs/entities.md) for details
 
 ## Requirements
 
-- Home Assistant 2024.11.0 or newer
+- Home Assistant 2025.8.0 or newer
 - MELCloud Home account with configured devices
 - Internet connection for cloud API access
 
@@ -89,6 +90,20 @@ Or manually: **Settings** → **Devices & Services** → **Add Integration** →
 
 Enter your MELCloud Home credentials (email and password). Your devices will be automatically discovered and added.
 
+## Real-Time Updates
+
+Changes made outside Home Assistant — the physical remote, the MELCloud Home app, a schedule — normally take up to 60 seconds to appear (the polling interval). Real-time updates shrink that to a couple of seconds: the integration listens on a MELCloud WebSocket and refreshes a device as soon as the cloud reports a change.
+
+**On by default.** There is nothing to set up. It is safe by design:
+
+- The socket is receive-only — all control commands use the same cloud API as before
+- If the connection drops, the integration falls back to normal 60-second polling automatically; your devices keep working and never show as unavailable because of it
+- Reconnection is automatic (the MELCloud server routinely recycles connections about every 2 hours — this is normal)
+
+**How to tell it's working:** changes made on the remote or in the MELCloud app show up in Home Assistant within a few seconds. The log (Settings → System → Logs) shows `WebSocket connected` when it starts and `WebSocket connection lost; reconnecting (polling continues meanwhile)` if it drops.
+
+**How to turn it off:** Settings → Devices & Services → MELCloud Home → Configure → switch off "Real-time updates (WebSocket)" → Submit. The integration then uses 60-second polling only.
+
 ## Important Notes
 
 ### Stable Entity IDs
@@ -137,6 +152,14 @@ The integration creates the following entities for each device:
 - Verify MELCloud Home service is accessible
 - Review the integration logs for API errors
 
+### Out-of-Band Changes Slow to Appear
+
+If changes made with the remote or MELCloud app take up to a minute to show in Home Assistant, real-time updates may not be connected:
+
+- Check the logs for `WebSocket connected` / `WebSocket connection lost` messages
+- Verify the toggle is on: Settings → Devices & Services → MELCloud Home → Configure
+- Updates still arrive via 60-second polling even when the WebSocket is down
+
 ### Energy Sensor Unavailable
 
 - Some devices may not report energy data
@@ -158,7 +181,7 @@ The integration uses conservative polling intervals to respect API limits:
 - **Energy Data**: 30 minutes
 - **Outdoor Temperature**: 30 minutes
 
-These intervals balance update frequency with API rate limits.
+These intervals balance update frequency with API rate limits. Real-time updates don't add polling load — the WebSocket is a single long-lived connection, and it only triggers an extra state refresh when a device actually changes.
 
 ## Development & Code Quality
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@
 
 Home Assistant custom integration for **MELCloud Home**.
 
-## What's New in v2.3.5
+## What's New in v2.4.0
 
-Fixes corrupt energy readings from the MELCloud cloud that could permanently inflate energy sensors and corrupt the Energy Dashboard - bad readings are now rejected, and inflated sensor totals are reset automatically on upgrade. Spikes already recorded in Energy Dashboard history need a one-time manual fix; a new diagnostic tool finds them for you. See [CHANGELOG.md](CHANGELOG.md) for full history.
+**Real-time updates** - changes made with the remote control or the MELCloud Home app now appear in Home Assistant within seconds, instead of up to a minute. Enabled by default with automatic fallback to regular polling, so there's nothing to set up - see [Real-Time Updates](#real-time-updates) for details. Contributed by [@mrdjtoto](https://github.com/mrdjtoto), from protocol investigation through implementation.
+
+**Requires Home Assistant 2025.8.0 or newer.** If you're on an older version, HACS will not offer this update.
+
+See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 ## Features
 
@@ -219,3 +223,7 @@ This is an unofficial integration and is not affiliated with, endorsed by, or co
 ## Credits
 
 Developed by Andrew Blake ([@andrew-blake](https://github.com/andrew-blake))
+
+**Contributors:**
+
+- [@mrdjtoto](https://github.com/mrdjtoto) - real-time updates: WebSocket protocol investigation, captures, and implementation (#174-#176)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Changes made outside Home Assistant — the physical remote, the MELCloud Home a
 
 **How to tell it's working:** changes made on the remote or in the MELCloud app show up in Home Assistant within a few seconds. The log (Settings → System → Logs) shows `WebSocket connected` when it starts and `WebSocket connection lost; reconnecting (polling continues meanwhile)` if it drops.
 
-**How to turn it off:** Settings → Devices & Services → MELCloud Home → Configure → switch off "Real-time updates (WebSocket)" → Submit. The integration then uses 60-second polling only.
+**How to turn it off:** Settings → Devices & Services → MELCloud Home → Configure → switch off "Real-time updates" → Submit. The integration then uses 60-second polling only.
 
 ## Important Notes
 

--- a/custom_components/melcloudhome/api/const_shared.py
+++ b/custom_components/melcloudhome/api/const_shared.py
@@ -36,7 +36,7 @@ OAUTH_SCOPES = "openid profile email offline_access IdentityServerApi"
 COGNITO_BASE_URL = "https://live-melcloudhome.auth.eu-west-1.amazoncognito.com"
 COGNITO_DOMAIN_SUFFIX = ".amazoncognito.com"
 
-# Real-time WebSocket (opt-in accelerator over polling — see issue #174).
+# Real-time WebSocket (default-on accelerator over polling — see issue #174).
 # The WS credential ("hash") is issued by an AWS Lambda Function URL,
 # authenticated with the mobile-BFF bearer token (same one used for REST).
 # Fixed endpoint (not per-user); treated as best-effort — any failure falls

--- a/custom_components/melcloudhome/api/websocket.py
+++ b/custom_components/melcloudhome/api/websocket.py
@@ -1,6 +1,6 @@
 """Real-time WebSocket listener for MELCloud Home.
 
-Opt-in accelerator over REST polling (see issue #174). Connects to the same
+Default-on accelerator over REST polling (see issue #174). Connects to the same
 WebSocket the official app uses and reports per-unit ``unitStateChanged``
 deltas so out-of-band changes (physical remote, MELCloud app, another HA
 instance) surface without waiting for the next poll.

--- a/custom_components/melcloudhome/config_flow.py
+++ b/custom_components/melcloudhome/config_flow.py
@@ -20,7 +20,12 @@ from homeassistant.helpers.selector import (
 
 from .api.client import MELCloudHomeClient
 from .api.exceptions import ApiError, AuthenticationError, ServiceUnavailableError
-from .const import CONF_DEBUG_MODE, CONF_ENABLE_WEBSOCKET, DOMAIN
+from .const import (
+    CONF_DEBUG_MODE,
+    CONF_ENABLE_WEBSOCKET,
+    DEFAULT_ENABLE_WEBSOCKET,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -215,7 +220,7 @@ class MELCloudHomeOptionsFlow(config_entries.OptionsFlowWithReload):
                     vol.Optional(
                         CONF_ENABLE_WEBSOCKET,
                         default=self.config_entry.options.get(
-                            CONF_ENABLE_WEBSOCKET, False
+                            CONF_ENABLE_WEBSOCKET, DEFAULT_ENABLE_WEBSOCKET
                         ),
                     ): BooleanSelector(),
                 }

--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -22,8 +22,8 @@ PLATFORMS = ["climate"]
 CONF_DEBUG_MODE = "debug_mode"
 
 # Options keys
-# Real-time WebSocket updates (accelerator over polling — issue #174).
-# Default ON since v2.4.0 (ADR-019 amendment); the option is an opt-out.
+# Real-time WebSocket updates (accelerator over polling — ADR-019).
+# Default on; the option is an opt-out.
 CONF_ENABLE_WEBSOCKET = "enable_websocket"
 DEFAULT_ENABLE_WEBSOCKET = True
 

--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -22,8 +22,10 @@ PLATFORMS = ["climate"]
 CONF_DEBUG_MODE = "debug_mode"
 
 # Options keys
-# Opt-in real-time WebSocket updates (accelerator over polling — issue #174).
+# Real-time WebSocket updates (accelerator over polling — issue #174).
+# Default ON since v2.4.0 (ADR-019 amendment); the option is an opt-out.
 CONF_ENABLE_WEBSOCKET = "enable_websocket"
+DEFAULT_ENABLE_WEBSOCKET = True
 
 # Energy polling configuration
 UPDATE_INTERVAL_ENERGY = timedelta(minutes=30)
@@ -79,6 +81,7 @@ __all__ = [
     "CONF_ENABLE_WEBSOCKET",
     "DATA_LOOKBACK_HOURS_ENERGY",
     "DATA_LOOKBACK_HOURS_TELEMETRY",
+    "DEFAULT_ENABLE_WEBSOCKET",
     "DOMAIN",
     "HOUR_VALUE_RETENTION_HOURS",
     "MAX_PLAUSIBLE_HOURLY_ENERGY_KWH",

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -19,6 +19,7 @@ from .api.models import AirToAirUnit, AirToWaterUnit, Building, UserContext
 from .api.websocket import MELCloudHomeWebSocket
 from .const import (
     CONF_ENABLE_WEBSOCKET,
+    DEFAULT_ENABLE_WEBSOCKET,
     DOMAIN,
     UPDATE_INTERVAL,
     UPDATE_INTERVAL_ENERGY,
@@ -69,7 +70,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         self._cancel_energy_updates: CALLBACK_TYPE | None = None
         # SPIKE: Telemetry tracking cancellation callback
         self._cancel_telemetry_updates: CALLBACK_TYPE | None = None
-        # Real-time WebSocket listener (opt-in accelerator — issue #174)
+        # Real-time WebSocket listener (default-on accelerator — issue #174)
         self._websocket: MELCloudHomeWebSocket | None = None
         self._ws_task: asyncio.Task[None] | None = None
         # Re-authentication lock to prevent concurrent re-auth attempts
@@ -405,14 +406,18 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         )
         _LOGGER.info("Telemetry polling scheduled (every 60 minutes)")
 
-        # Start the real-time WebSocket listener if opted in
+        # Start the real-time WebSocket listener unless opted out
         self._async_setup_websocket()
 
     def _websocket_enabled(self) -> bool:
-        """Whether the opt-in WebSocket accelerator should run."""
+        """Whether the WebSocket accelerator should run (default on)."""
         if self._config_entry is None:
             return False
-        return bool(self._config_entry.options.get(CONF_ENABLE_WEBSOCKET, False))
+        return bool(
+            self._config_entry.options.get(
+                CONF_ENABLE_WEBSOCKET, DEFAULT_ENABLE_WEBSOCKET
+            )
+        )
 
     def _async_setup_websocket(self) -> None:
         """Launch the WebSocket listener as a background task if enabled."""

--- a/custom_components/melcloudhome/translations/de.json
+++ b/custom_components/melcloudhome/translations/de.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "MELCloud Home-Optionen",
+        "data": {
+          "enable_websocket": "Echtzeit-Updates"
+        },
+        "data_description": {
+          "enable_websocket": "Änderungen über die Fernbedienung oder die MELCloud Home App erscheinen innerhalb weniger Sekunden."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/el.json
+++ b/custom_components/melcloudhome/translations/el.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Επιλογές MELCloud Home",
+        "data": {
+          "enable_websocket": "Ενημερώσεις σε πραγματικό χρόνο"
+        },
+        "data_description": {
+          "enable_websocket": "Οι αλλαγές που γίνονται με το τηλεχειριστήριο ή την εφαρμογή MELCloud Home εμφανίζονται μέσα σε λίγα δευτερόλεπτα."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/en.json
+++ b/custom_components/melcloudhome/translations/en.json
@@ -4,10 +4,10 @@
       "init": {
         "title": "MELCloud Home options",
         "data": {
-          "enable_websocket": "Enable real-time updates (experimental)"
+          "enable_websocket": "Real-time updates (WebSocket)"
         },
         "data_description": {
-          "enable_websocket": "Receive out-of-band changes (physical remote, MELCloud app, another Home Assistant) in near real time over a WebSocket, in addition to periodic polling. Falls back to polling automatically if the connection is unavailable."
+          "enable_websocket": "Enabled by default. Receives out-of-band changes (physical remote, MELCloud app, another Home Assistant) in near real time over a WebSocket, in addition to periodic polling. Falls back to polling automatically if the connection is unavailable. Turn off to use periodic polling only."
         }
       }
     }

--- a/custom_components/melcloudhome/translations/en.json
+++ b/custom_components/melcloudhome/translations/en.json
@@ -4,10 +4,10 @@
       "init": {
         "title": "MELCloud Home options",
         "data": {
-          "enable_websocket": "Real-time updates (WebSocket)"
+          "enable_websocket": "Real-time updates"
         },
         "data_description": {
-          "enable_websocket": "Enabled by default. Receives out-of-band changes (physical remote, MELCloud app, another Home Assistant) in near real time over a WebSocket, in addition to periodic polling. Falls back to polling automatically if the connection is unavailable. Turn off to use periodic polling only."
+          "enable_websocket": "Show changes made with the remote control or the MELCloud Home app within a few seconds, instead of waiting up to a minute for the next scheduled update. If the connection is interrupted, the integration automatically falls back to regular updates - your devices keep working either way. Turn off to use scheduled updates only."
         }
       }
     }

--- a/custom_components/melcloudhome/translations/en.json
+++ b/custom_components/melcloudhome/translations/en.json
@@ -7,7 +7,7 @@
           "enable_websocket": "Real-time updates"
         },
         "data_description": {
-          "enable_websocket": "Show changes made with the remote control or the MELCloud Home app within a few seconds, instead of waiting up to a minute for the next scheduled update. If the connection is interrupted, the integration automatically falls back to regular updates - your devices keep working either way. Turn off to use scheduled updates only."
+          "enable_websocket": "Changes made with the remote control or the MELCloud Home app appear within seconds."
         }
       }
     }

--- a/custom_components/melcloudhome/translations/es.json
+++ b/custom_components/melcloudhome/translations/es.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de MELCloud Home",
+        "data": {
+          "enable_websocket": "Actualizaciones en tiempo real"
+        },
+        "data_description": {
+          "enable_websocket": "Los cambios realizados con el mando a distancia o la aplicación MELCloud Home aparecen en pocos segundos."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/fi.json
+++ b/custom_components/melcloudhome/translations/fi.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "MELCloud Home -asetukset",
+        "data": {
+          "enable_websocket": "Reaaliaikaiset päivitykset"
+        },
+        "data_description": {
+          "enable_websocket": "Kaukosäätimellä tai MELCloud Home -sovelluksella tehdyt muutokset näkyvät muutamassa sekunnissa."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/fr.json
+++ b/custom_components/melcloudhome/translations/fr.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Options MELCloud Home",
+        "data": {
+          "enable_websocket": "Mises à jour en temps réel"
+        },
+        "data_description": {
+          "enable_websocket": "Les modifications effectuées avec la télécommande ou l'application MELCloud Home apparaissent en quelques secondes."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/it.json
+++ b/custom_components/melcloudhome/translations/it.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opzioni di MELCloud Home",
+        "data": {
+          "enable_websocket": "Aggiornamenti in tempo reale"
+        },
+        "data_description": {
+          "enable_websocket": "Le modifiche effettuate con il telecomando o l'app MELCloud Home compaiono in pochi secondi."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/nl.json
+++ b/custom_components/melcloudhome/translations/nl.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "MELCloud Home-opties",
+        "data": {
+          "enable_websocket": "Realtime updates"
+        },
+        "data_description": {
+          "enable_websocket": "Wijzigingen via de afstandsbediening of de MELCloud Home-app verschijnen binnen enkele seconden."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/pt.json
+++ b/custom_components/melcloudhome/translations/pt.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opções do MELCloud Home",
+        "data": {
+          "enable_websocket": "Atualizações em tempo real"
+        },
+        "data_description": {
+          "enable_websocket": "As alterações feitas com o comando ou a aplicação MELCloud Home aparecem em poucos segundos."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/sv.json
+++ b/custom_components/melcloudhome/translations/sv.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Alternativ för MELCloud Home",
+        "data": {
+          "enable_websocket": "Realtidsuppdateringar"
+        },
+        "data_description": {
+          "enable_websocket": "Ändringar som görs med fjärrkontrollen eller MELCloud Home-appen visas inom några sekunder."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/th.json
+++ b/custom_components/melcloudhome/translations/th.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "ตัวเลือก MELCloud Home",
+        "data": {
+          "enable_websocket": "การอัปเดตแบบเรียลไทม์"
+        },
+        "data_description": {
+          "enable_websocket": "การเปลี่ยนแปลงที่ทำผ่านรีโมตหรือแอป MELCloud Home จะแสดงภายในไม่กี่วินาที"
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/tr.json
+++ b/custom_components/melcloudhome/translations/tr.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "MELCloud Home seçenekleri",
+        "data": {
+          "enable_websocket": "Gerçek zamanlı güncellemeler"
+        },
+        "data_description": {
+          "enable_websocket": "Kumanda veya MELCloud Home uygulamasıyla yapılan değişiklikler birkaç saniye içinde görünür."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/melcloudhome/translations/vi.json
+++ b/custom_components/melcloudhome/translations/vi.json
@@ -1,4 +1,17 @@
 {
+  "options": {
+    "step": {
+      "init": {
+        "title": "Tùy chọn MELCloud Home",
+        "data": {
+          "enable_websocket": "Cập nhật theo thời gian thực"
+        },
+        "data_description": {
+          "enable_websocket": "Các thay đổi được thực hiện bằng điều khiển từ xa hoặc ứng dụng MELCloud Home sẽ hiển thị trong vài giây."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Key architectural decisions for the MELCloud Home integration:
 - [ADR-016: Implement ATW Energy Monitoring](decisions/016-implement-atw-energy-monitoring.md) - Energy monitoring with capability-based detection (ERSC-VM2D)
 - [ADR-017: Migrate to Mobile BFF API](decisions/017-migrate-to-mobile-bff.md) - Move from the legacy web API to the mobile API (`mobile.bff.melcloudhome.com`), with OAuth 2.0 + PKCE at `auth.melcloudhome.com` (supersedes ADR-002)
 - [ADR-018: Out-of-Band State Sync Limitation](decisions/018-out-of-band-state-sync-limitation.md) - The ≤60s stale window for changes made outside HA (resolved by ADR-019's WebSocket, default on)
-- [ADR-019: Real-Time WebSocket Updates](decisions/019-opt-in-websocket-realtime-updates.md) - Receive-only WebSocket deltas trigger debounced REST refresh; default on since v2.4.0 (supersedes ADR-007)
+- [ADR-019: Real-Time WebSocket Updates](decisions/019-websocket-realtime-updates.md) - Receive-only WebSocket deltas trigger debounced REST refresh; default on, opt-out toggle (supersedes ADR-007)
 
 ## Architecture
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,7 +10,7 @@ Key architectural decisions for the MELCloud Home integration:
 - [ADR-004: Integration Refactoring](decisions/004-integration-refactoring.md) - Separation of concerns
 - [ADR-005: Divergence from Official MELCloud](decisions/005-divergence-from-official-melcloud.md) - Why we target different API
 - [ADR-006: Entity Description Pattern](decisions/006-entity-description-pattern.md) - Sensor/binary_sensor implementation
-- [ADR-007: Defer WebSocket Implementation](decisions/007-defer-websocket-implementation.md) - Real-time updates deferral
+- [ADR-007: Defer WebSocket Implementation](decisions/007-defer-websocket-implementation.md) - Real-time updates deferral (SUPERSEDED by ADR-019)
 - [ADR-008: Energy Monitoring Architecture](decisions/008-energy-monitoring-architecture.md) - Energy tracking with persistence
 - [ADR-009: Reconfigure Password-Only](decisions/009-reconfigure-password-only.md) - Config flow password updates
 - [ADR-010: Entity ID Prefix Change](decisions/010-entity-id-prefix-change.md) - Breaking change for stable IDs
@@ -21,6 +21,8 @@ Key architectural decisions for the MELCloud Home integration:
 - [ADR-015: Skip ATW Energy Monitoring](decisions/015-skip-atw-energy-monitoring.md) - Initial decision to skip energy (SUPERSEDED by ADR-016)
 - [ADR-016: Implement ATW Energy Monitoring](decisions/016-implement-atw-energy-monitoring.md) - Energy monitoring with capability-based detection (ERSC-VM2D)
 - [ADR-017: Migrate to Mobile BFF API](decisions/017-migrate-to-mobile-bff.md) - Move from the legacy web API to the mobile API (`mobile.bff.melcloudhome.com`), with OAuth 2.0 + PKCE at `auth.melcloudhome.com` (supersedes ADR-002)
+- [ADR-018: Out-of-Band State Sync Limitation](decisions/018-out-of-band-state-sync-limitation.md) - The ≤60s stale window for changes made outside HA (resolved by ADR-019's WebSocket, default on)
+- [ADR-019: Real-Time WebSocket Updates](decisions/019-opt-in-websocket-realtime-updates.md) - Receive-only WebSocket deltas trigger debounced REST refresh; default on since v2.4.0 (supersedes ADR-007)
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 Visual architecture documentation for the MELCloud Home custom integration for Home Assistant.
 
-**Last Updated:** 2026-07-19
+**Last Updated:** 2026-07-20
 
 **Terminology:** This document uses **ATA** (Air-to-Air) and **ATW** (Air-to-Water) to refer to the two device types.
 
@@ -15,7 +15,7 @@ Visual architecture documentation for the MELCloud Home custom integration for H
 3. **Multi-Type Container** - `UserContext` holds both device types in parallel arrays
 4. **Device-Specific Methods** - Method names indicate which device type they control
 5. **Equal Device Type Support** - ATA and ATW devices have full feature parity in their respective domains
-6. **Push Accelerates, REST Decides** - The WebSocket listener only signals that state is stale; entity state always comes from the REST `/context` parser, and all writes go over REST (see [ADR-019](decisions/019-opt-in-websocket-realtime-updates.md))
+6. **Push Accelerates, REST Decides** - The WebSocket listener only signals that state is stale; entity state always comes from the REST `/context` parser, and all writes go over REST (see [ADR-019](decisions/019-websocket-realtime-updates.md))
 
 **API target:** MELCloud mobile API at `https://mobile.bff.melcloudhome.com` (see [ADR-017](decisions/017-migrate-to-mobile-bff.md)). Canonical endpoint/auth constants live in [`api/const_shared.py`](../custom_components/melcloudhome/api/const_shared.py).
 
@@ -629,7 +629,7 @@ Energy data is polled on its own 30-minute timer (`UPDATE_INTERVAL_ENERGY`), ind
 
 ## Real-Time WebSocket Updates (Default On)
 
-An accelerator over REST polling, enabled by default (options toggle `enable_websocket` is an opt-out — see the ADR-019 amendment). It surfaces out-of-band changes — physical remote, MELCloud app, another HA instance — in seconds instead of waiting for the next 60-second poll. It is strictly receive-only: all commands go over REST, and a delta only tells the coordinator to re-read `/context`. See [ADR-019](decisions/019-opt-in-websocket-realtime-updates.md) for the full rationale.
+An accelerator over REST polling, enabled by default (options toggle `enable_websocket` is an opt-out). It surfaces out-of-band changes — physical remote, MELCloud app, another HA instance — in seconds instead of waiting for the next 60-second poll. It is strictly receive-only: all commands go over REST, and a delta only tells the coordinator to re-read `/context`. See [ADR-019](decisions/019-websocket-realtime-updates.md) for the full rationale.
 
 ```mermaid
 sequenceDiagram
@@ -662,7 +662,7 @@ sequenceDiagram
 - **ADR-012:** [ATW Entity Architecture](decisions/012-atw-entity-architecture.md)
 - **ADR-016:** [ATW Energy Monitoring Implementation](decisions/016-implement-atw-energy-monitoring.md)
 - **ADR-017:** [Migrate to Mobile BFF API](decisions/017-migrate-to-mobile-bff.md) (supersedes ADR-002)
-- **ADR-019:** [Real-Time WebSocket Updates](decisions/019-opt-in-websocket-realtime-updates.md) (supersedes ADR-007; amended to default on)
+- **ADR-019:** [Real-Time WebSocket Updates](decisions/019-websocket-realtime-updates.md) (supersedes ADR-007)
 - **ATA API Reference:** [ata-api-reference.md](api/ata-api-reference.md)
 - **ATW API Reference:** [atw-api-reference.md](api/atw-api-reference.md)
 - **Device Comparison:** [device-type-comparison.md](api/device-type-comparison.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 Visual architecture documentation for the MELCloud Home custom integration for Home Assistant.
 
-**Last Updated:** 2026-04-20
+**Last Updated:** 2026-07-19
 
 **Terminology:** This document uses **ATA** (Air-to-Air) and **ATW** (Air-to-Water) to refer to the two device types.
 
@@ -15,6 +15,7 @@ Visual architecture documentation for the MELCloud Home custom integration for H
 3. **Multi-Type Container** - `UserContext` holds both device types in parallel arrays
 4. **Device-Specific Methods** - Method names indicate which device type they control
 5. **Equal Device Type Support** - ATA and ATW devices have full feature parity in their respective domains
+6. **Push Accelerates, REST Decides** - The WebSocket listener only signals that state is stale; entity state always comes from the REST `/context` parser, and all writes go over REST (see [ADR-019](decisions/019-opt-in-websocket-realtime-updates.md))
 
 **API target:** MELCloud mobile API at `https://mobile.bff.melcloudhome.com` (see [ADR-017](decisions/017-migrate-to-mobile-bff.md)). Canonical endpoint/auth constants live in [`api/const_shared.py`](../custom_components/melcloudhome/api/const_shared.py).
 
@@ -37,6 +38,7 @@ graph LR
 
     subgraph "MELCloud Home Integration"
         Coordinator[Update Coordinator<br/>Polling & State Management]
+        WSListener[MELCloudHomeWebSocket<br/>Real-Time Delta Listener]
 
         subgraph "Control Client Layer"
             ControlATA[ATAControlClient<br/>Dedup, Validation & Debounce]
@@ -58,6 +60,10 @@ graph LR
         ATAAPI["PUT /monitor/ataunit/{id}<br/>(ATA Control)"]
         ATWAPI["PUT /monitor/atwunit/{id}<br/>(ATW Control)"]
         TelemetryAPI["GET /telemetry/...<br/>/report/v1/trendsummary<br/>(Energy/Telemetry)"]
+    end
+    subgraph "MELCloud WebSocket<br/>ws.melcloudhome.com"
+        WSHash["WS hash endpoint<br/>(Bearer → short-lived hash)"]
+        WSAPI["wss://?hash=...<br/>(server-push deltas only)"]
     end
     subgraph "Auth (OAuth 2.0 + PKCE)"
         IdP["IdentityServer<br/>auth.melcloudhome.com"]
@@ -86,6 +92,11 @@ graph LR
     Client --> ATAAPI
     Client --> ATWAPI
     Client --> TelemetryAPI
+
+    Coordinator -->|owns, entry-scoped task| WSListener
+    WSListener --> WSHash
+    WSAPI -->|unitStateChanged deltas| WSListener
+    WSListener -->|"on_delta → debounced refresh"| Coordinator
 ```
 
 **Key Points:**
@@ -96,6 +107,7 @@ graph LR
 - **Shared auth** — one OAuth session (access + refresh tokens) for all endpoints
 - **UserContext** (`/context`) returns both device types in one response
 - **Telemetry** is separate from state polling — `/telemetry/...` (30m energy, 60m flow/return) and `/report/v1/trendsummary` (30m ATA outdoor temp) each run on independent timers
+- **WebSocket listener** (default on) receives `unitStateChanged` deltas and triggers the debounced `/context` refresh — it never writes state and never sends commands; see [Real-Time WebSocket Updates](#real-time-websocket-updates-default-on)
 
 ---
 
@@ -307,6 +319,8 @@ sequenceDiagram
         Coord->>HA: Update state-backed entities
     end
 
+    Note over HA,Server: Real-time WebSocket deltas (default on) — out-of-band changes<br/>(remote, MELCloud app) trigger the same debounced /context refresh<br/>within ~2s instead of waiting for the next poll. Receive-only:<br/>commands never use the socket. See the WebSocket section below.
+
     Note over HA,Server: Independent telemetry timers (separate from state polling)
     loop Every 30 min — ATW energy
         APIClient->>Server: GET /telemetry/telemetry/energy/{id}
@@ -340,6 +354,7 @@ sequenceDiagram
 - **State polling**: Drives the 60-second `/context` refresh loop; dispatches updates to all platforms.
 - **Independent telemetry timers**: Separate 30-minute energy timer, 30-minute ATA outdoor-temperature timer (via `/report/v1/trendsummary`), and 60-minute ATW flow/return telemetry timer.
 - **Re-auth ladder** (`_run_with_reauth`, guarded by `_reauth_lock`): retry-once → refresh_token → full login → `ConfigEntryAuthFailed` (triggers HA repair UI) if all fail. This is the single place in the integration that runs re-login on auth failure.
+- **WebSocket lifecycle**: `_async_setup_websocket` launches `MELCloudHomeWebSocket` as an entry-scoped background task when enabled (default on, `enable_websocket` option); `_on_ws_delta` feeds each delta into the same debounced refresh the control clients use. HA cancels the task on entry unload/reload.
 
 ---
 
@@ -367,7 +382,7 @@ graph TD
     style ControlATW fill:#f0ffe1,stroke:#7cb342
     style APIClient fill:#e1f5ff,stroke:#039be5
 
-    note0["Coordinator:<br/>- State polling (60s)<br/>- Telemetry timers (30m / 60m)<br/>- Re-auth ladder via _run_with_reauth"]
+    note0["Coordinator:<br/>- State polling (60s)<br/>- Telemetry timers (30m / 60m)<br/>- Re-auth ladder via _run_with_reauth<br/>- WebSocket listener lifecycle (default on)"]
     note1["Control Layer:<br/>- Deduplication<br/>- HA validation<br/>- Debounced refresh<br/>- Delegates via execute_with_retry"]
     note2["API Layer:<br/>- HTTP/Bearer auth<br/>- Proactive token refresh<br/>- Device facades"]
 
@@ -612,9 +627,9 @@ Energy data is polled on its own 30-minute timer (`UPDATE_INTERVAL_ENERGY`), ind
 
 ---
 
-## Real-Time WebSocket Updates (Opt-In)
+## Real-Time WebSocket Updates (Default On)
 
-An opt-in accelerator over REST polling (options toggle `enable_websocket`, default off, experimental). It surfaces out-of-band changes — physical remote, MELCloud app, another HA instance — in seconds instead of waiting for the next 60-second poll. See [ADR-019](decisions/019-opt-in-websocket-realtime-updates.md) for the full rationale.
+An accelerator over REST polling, enabled by default (options toggle `enable_websocket` is an opt-out — see the ADR-019 amendment). It surfaces out-of-band changes — physical remote, MELCloud app, another HA instance — in seconds instead of waiting for the next 60-second poll. It is strictly receive-only: all commands go over REST, and a delta only tells the coordinator to re-read `/context`. See [ADR-019](decisions/019-opt-in-websocket-realtime-updates.md) for the full rationale.
 
 ```mermaid
 sequenceDiagram
@@ -634,9 +649,10 @@ sequenceDiagram
 **Key points:**
 
 - **REST stays the source of truth.** Delta frames are never applied to entity state — they only trigger the existing debounced coordinator refresh. Frames are partial and inconsistently typed, so entity state always comes from the proven REST parser (ADR-019).
-- **Best-effort by design.** Polling continues regardless of socket health; entities never go unavailable because of WebSocket state. Failures back off exponentially (5s → 300s, jittered, reset only after a session that survived ≥60s) and the integration degrades to plain polling.
+- **Best-effort by design.** Polling continues regardless of socket health; entities never go unavailable because of WebSocket state. Failures back off exponentially (5s → 300s, jittered, reset only after a session that connected and survived ≥60s) and the integration degrades to plain polling.
+- **A safety net for silent write drops.** MELCloud returns 200 and silently ignores PUTs that fail validation; the delta-triggered refresh snaps HA back to the server's actual state within ~2s instead of at the next 60s poll.
 - **Normal churn:** the server drops every connection at a hard 2-hour AWS API Gateway cap; reconnection is routine. Lost/restored transitions log at INFO.
-- **Lifecycle:** the listener is HA-agnostic; the coordinator launches it as an entry-scoped background task, so HA cancels it on entry unload/reload. Disabled in debug/mock mode.
+- **Lifecycle:** the listener is HA-agnostic; the coordinator launches it as an entry-scoped background task, so HA cancels it on entry unload/reload. In debug/mock mode it connects to the mock server's WS endpoint (zero prod contact).
 
 ---
 
@@ -646,7 +662,7 @@ sequenceDiagram
 - **ADR-012:** [ATW Entity Architecture](decisions/012-atw-entity-architecture.md)
 - **ADR-016:** [ATW Energy Monitoring Implementation](decisions/016-implement-atw-energy-monitoring.md)
 - **ADR-017:** [Migrate to Mobile BFF API](decisions/017-migrate-to-mobile-bff.md) (supersedes ADR-002)
-- **ADR-019:** [Opt-In Real-Time WebSocket Updates](decisions/019-opt-in-websocket-realtime-updates.md) (supersedes ADR-007)
+- **ADR-019:** [Real-Time WebSocket Updates](decisions/019-opt-in-websocket-realtime-updates.md) (supersedes ADR-007; amended to default on)
 - **ATA API Reference:** [ata-api-reference.md](api/ata-api-reference.md)
 - **ATW API Reference:** [atw-api-reference.md](api/atw-api-reference.md)
 - **Device Comparison:** [device-type-comparison.md](api/device-type-comparison.md)

--- a/docs/decisions/007-defer-websocket-implementation.md
+++ b/docs/decisions/007-defer-websocket-implementation.md
@@ -1,6 +1,6 @@
 # ADR-007: Defer WebSocket Implementation to Post-v1.2
 
-**Status:** Superseded by [ADR-019](019-opt-in-websocket-realtime-updates.md)
+**Status:** Superseded by [ADR-019](019-websocket-realtime-updates.md)
 **Date:** 2025-11-17
 **Context:** Session 9 - v1.2 planning and scope refinement
 

--- a/docs/decisions/018-out-of-band-state-sync-limitation.md
+++ b/docs/decisions/018-out-of-band-state-sync-limitation.md
@@ -1,6 +1,6 @@
 # ADR-018: Out-of-Band State Sync Limitation and Deduplication Trade-off
 
-**Status:** Accepted (limitation documented) — resolved by [ADR-019](019-opt-in-websocket-realtime-updates.md) when the opt-in WebSocket is enabled; still applies to the default configuration
+**Status:** Accepted (limitation documented) — resolved by [ADR-019](019-opt-in-websocket-realtime-updates.md)'s WebSocket accelerator (default on since v2.4.0); still applies when the WebSocket toggle is turned off
 **Date:** 2026-06-14
 
 ## Context

--- a/docs/decisions/018-out-of-band-state-sync-limitation.md
+++ b/docs/decisions/018-out-of-band-state-sync-limitation.md
@@ -1,6 +1,6 @@
 # ADR-018: Out-of-Band State Sync Limitation and Deduplication Trade-off
 
-**Status:** Accepted (limitation documented) — resolved by [ADR-019](019-opt-in-websocket-realtime-updates.md)'s WebSocket accelerator (default on since v2.4.0); still applies when the WebSocket toggle is turned off
+**Status:** Accepted (limitation documented) — resolved by [ADR-019](019-websocket-realtime-updates.md)'s default-on WebSocket accelerator; still applies when the WebSocket toggle is turned off
 **Date:** 2026-06-14
 
 ## Context

--- a/docs/decisions/019-opt-in-websocket-realtime-updates.md
+++ b/docs/decisions/019-opt-in-websocket-realtime-updates.md
@@ -1,8 +1,8 @@
-# ADR-019: Opt-In Real-Time WebSocket Updates
+# ADR-019: Real-Time WebSocket Updates
 
-**Status:** Accepted
+**Status:** Accepted; amended 2026-07-19 — **default on** (originally opt-in, see Amendment)
 **Date:** 2026-07-19
-**Supersedes:** [ADR-007](007-defer-websocket-implementation.md) (deferral); resolves the structural limitation documented in [ADR-018](018-out-of-band-state-sync-limitation.md) when enabled
+**Supersedes:** [ADR-007](007-defer-websocket-implementation.md) (deferral); resolves the structural limitation documented in [ADR-018](018-out-of-band-state-sync-limitation.md) when enabled (the default)
 
 ## Context
 
@@ -34,8 +34,9 @@ arriving reliably for every unit. The one-device-only behavior observed in
 
 ## Decision
 
-Implement WebSocket support as an **opt-in accelerator over REST polling**
-(options-flow toggle `enable_websocket`, default off, labeled experimental):
+Implement WebSocket support as an **accelerator over REST polling**, controlled
+by the options-flow toggle `enable_websocket` (originally default off; default
+on since the Amendment below — `DEFAULT_ENABLE_WEBSOCKET` in `const.py`):
 
 1. **REST stays the source of truth.** A delta frame is never applied to
    entity state. It only triggers the existing debounced coordinator refresh
@@ -86,20 +87,49 @@ The listener (`api/websocket.py`) is deliberately HA-agnostic: one
 long-running `run()` coroutine plus a delta callback. The coordinator owns it,
 launching it via `entry.async_create_background_task`, so HA cancels it
 automatically on entry unload/reload — no manual cancel bookkeeping.
-It is disabled in debug/mock mode.
+In debug/mock mode the listener connects to the mock server's WS endpoint
+(PR #181) instead of production, so the dev environment and e2e tests
+exercise the real code path with zero prod contact.
 
 ## Consequences
 
-- With the toggle on, the ADR-018 stale window shrinks from ≤ 60 s to roughly
-  the debounce delay plus one REST poll — which also defuses the dedup
-  command-drop scenario in practice. ADR-018's limitation still applies to
-  the default (off) configuration.
+- With the socket running, the ADR-018 stale window shrinks from ≤ 60 s to
+  roughly the debounce delay plus one REST poll — which also defuses the dedup
+  command-drop scenario in practice. ADR-018's limitation still applies when
+  the toggle is turned off.
 - The integration requires HA ≥ 2025.8.0 (`OptionsFlowWithReload`, new in
   2025.8; entry-scoped background tasks have been available since ~2023.4).
 - One extra long-lived connection and a hash fetch per (re)connect; steady
   state adds no REST traffic beyond the refreshes that real changes trigger.
-- The mock server does not yet expose a WS endpoint; local dev/e2e coverage
-  of the socket is planned separately (#180).
+
+## Amendment (2026-07-19): default on
+
+The original decision shipped the toggle default-off ("opt-in, experimental").
+Amended the same cycle, before any release carried it: `enable_websocket` now
+**defaults on** and the toggle is an opt-out.
+
+Rationale:
+
+- **A default-off accelerator produces no evidence and little value.** Few
+  users change experimental toggles, so the v2.4.0 beta would have soaked the
+  socket on approximately zero installations, and the out-of-band staleness
+  fix (ADR-018) would reach almost nobody.
+- **The failure mode is the feature's own design.** Any socket failure
+  degrades to exactly the polling behavior a default-off user would have had;
+  entities never become unavailable because of WebSocket state. The blast
+  radius of "default on and broken" is "default off".
+- **The evidence base already exceeds what opt-in soak would gather:** a
+  ~22.6h continuous probe (759 messages, 0 errors, 99.9% uptime), a ~12.5h
+  production soak covering the ATW device type and guest-account path (130
+  heat-pump deltas), plus multi-week dogfooding on two production instances
+  covering the owner+ATA path.
+- **The remaining unknown is fleet-scale server behavior** (hash-endpoint
+  rate limits, connection caps across many accounts) — which only a
+  default-on population can reveal, and which the backoff design (5s→300s,
+  jittered, connected-session-gated reset) is built to absorb.
+
+The opt-out toggle, INFO-level connect/lost logging, and the planned
+connectivity diagnostics remain the observability and escape hatches.
 
 ## References
 

--- a/docs/decisions/019-websocket-realtime-updates.md
+++ b/docs/decisions/019-websocket-realtime-updates.md
@@ -1,6 +1,6 @@
 # ADR-019: Real-Time WebSocket Updates
 
-**Status:** Accepted; amended 2026-07-19 — **default on** (originally opt-in, see Amendment)
+**Status:** Accepted
 **Date:** 2026-07-19
 **Supersedes:** [ADR-007](007-defer-websocket-implementation.md) (deferral); resolves the structural limitation documented in [ADR-018](018-out-of-band-state-sync-limitation.md) when enabled (the default)
 
@@ -34,9 +34,9 @@ arriving reliably for every unit. The one-device-only behavior observed in
 
 ## Decision
 
-Implement WebSocket support as an **accelerator over REST polling**, controlled
-by the options-flow toggle `enable_websocket` (originally default off; default
-on since the Amendment below — `DEFAULT_ENABLE_WEBSOCKET` in `const.py`):
+Implement WebSocket support as an **accelerator over REST polling**, enabled
+by default (`DEFAULT_ENABLE_WEBSOCKET` in `const.py`; the options-flow toggle
+`enable_websocket` is an opt-out):
 
 1. **REST stays the source of truth.** A delta frame is never applied to
    entity state. It only triggers the existing debounced coordinator refresh
@@ -102,34 +102,28 @@ exercise the real code path with zero prod contact.
 - One extra long-lived connection and a hash fetch per (re)connect; steady
   state adds no REST traffic beyond the refreshes that real changes trigger.
 
-## Amendment (2026-07-19): default on
-
-The original decision shipped the toggle default-off ("opt-in, experimental").
-Amended the same cycle, before any release carried it: `enable_websocket` now
-**defaults on** and the toggle is an opt-out.
-
-Rationale:
+### Why default on rather than opt-in
 
 - **A default-off accelerator produces no evidence and little value.** Few
-  users change experimental toggles, so the v2.4.0 beta would have soaked the
-  socket on approximately zero installations, and the out-of-band staleness
-  fix (ADR-018) would reach almost nobody.
+  users change optional toggles, so the socket would soak on approximately
+  zero installations and the out-of-band staleness fix (ADR-018) would reach
+  almost nobody.
 - **The failure mode is the feature's own design.** Any socket failure
   degrades to exactly the polling behavior a default-off user would have had;
   entities never become unavailable because of WebSocket state. The blast
   radius of "default on and broken" is "default off".
-- **The evidence base already exceeds what opt-in soak would gather:** a
-  ~22.6h continuous probe (759 messages, 0 errors, 99.9% uptime), a ~12.5h
-  production soak covering the ATW device type and guest-account path (130
-  heat-pump deltas), plus multi-week dogfooding on two production instances
-  covering the owner+ATA path.
+- **The pre-release evidence base is strong:** a ~22.6h continuous probe
+  (759 messages, 0 errors, 99.9% uptime), a ~12.5h production soak covering
+  the ATW device type and guest-account path (130 heat-pump deltas), plus
+  multi-week dogfooding on two production instances covering the owner+ATA
+  path.
 - **The remaining unknown is fleet-scale server behavior** (hash-endpoint
   rate limits, connection caps across many accounts) — which only a
   default-on population can reveal, and which the backoff design (5s→300s,
   jittered, connected-session-gated reset) is built to absorb.
 
 The opt-out toggle, INFO-level connect/lost logging, and the planned
-connectivity diagnostics remain the observability and escape hatches.
+connectivity diagnostics are the observability and escape hatches.
 
 ## References
 

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -169,6 +169,61 @@ async def test_options_flow_change_reloads_entry(
             mock_reload.assert_called_once_with(entry.entry_id)
 
 
+@pytest.mark.asyncio
+async def test_websocket_runs_by_default(hass: HomeAssistant) -> None:
+    """An entry with no options starts the WebSocket accelerator (default on).
+
+    Observed at the API boundary: the listener's first act is fetching the WS
+    hash from the client.
+    """
+    with patch(MOCK_CLIENT_PATH) as mock_client:
+        client = mock_client.return_value
+        client.login = AsyncMock()
+        client.close = AsyncMock()
+        client.get_user_context = AsyncMock(return_value=_create_mock_user_context())
+        # Fail the hash fetch so the listener parks in backoff instead of
+        # flailing against the mock; the await itself proves it started.
+        client.async_get_ws_hash = AsyncMock(side_effect=RuntimeError("stop"))
+        type(client).is_authenticated = PropertyMock(return_value=True)
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        client.async_get_ws_hash.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_websocket_opt_out_respected(hass: HomeAssistant) -> None:
+    """An explicit enable_websocket=False keeps the listener off."""
+    from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET
+
+    with patch(MOCK_CLIENT_PATH) as mock_client:
+        client = mock_client.return_value
+        client.login = AsyncMock()
+        client.close = AsyncMock()
+        client.get_user_context = AsyncMock(return_value=_create_mock_user_context())
+        client.async_get_ws_hash = AsyncMock()
+        type(client).is_authenticated = PropertyMock(return_value=True)
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            options={CONF_ENABLE_WEBSOCKET: False},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        client.async_get_ws_hash.assert_not_awaited()
+
+
 def _create_mock_unit(unit_id: str, name: str) -> MagicMock:
     """Create a mock ATA unit."""
     unit = MagicMock()


### PR DESCRIPTION
## Summary

Enables the real-time WebSocket accelerator (#176/#181) by default and integrates it properly into the architecture docs and README ahead of the v2.4.0 beta.

## Key changes

- **Default on**: `DEFAULT_ENABLE_WEBSOCKET = True` drives both the coordinator gate and the options-flow default; the toggle is an opt-out and an explicit off is respected. Two integration tests lock the semantics.
- **Option strings** rewritten for non-technical users ("Real-time updates", described in terms of the remote control and app).
- **ADR-019** decides default-on directly, with rationale (default-off soaks nowhere; failure degrades to plain polling; strong pre-release evidence); file renamed to drop "opt-in". ADR-007/018 statuses updated and the missing ADR-018/019 docs index entries added.
- **architecture.md**: WebSocket woven into the system diagram, key principles, control flow, and coordinator responsibilities (was just a tacked-on section).
- **README**: user-facing "Real-Time Updates" section (what it is, how to verify, how to opt out), plus fixes the stated HA minimum (2024.11.0 → actual 2025.8.0 floor).

## Testing

31 websocket unit / 178 integration / 14 e2e tests pass; ruff, mypy, pre-commit, zizmor clean; all mermaid blocks validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
