### PR TITLE
ci(zizmor): rename gh-token input to token

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
-          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Dependabot's zizmor-action 0.5.6 → 0.5.7 bump (#159) crossed the action renaming its `gh-token` input to `token`, so since June 29 the action has run unauthenticated — the runner warned `Unexpected input(s) 'gh-token'` on every run while the job stayed green, and zizmor's API-dependent audits silently degraded. One-word rename; local `zizmor --persona auditor` run is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)