### PR TITLE
feat: real-time updates observability (connectivity sensor + diagnostics)

### DIFF
--- a/custom_components/melcloudhome/api/websocket.py
+++ b/custom_components/melcloudhome/api/websocket.py
@@ -67,11 +67,23 @@ class MELCloudHomeWebSocket:
         self._closing = False
         self._connected = False
         self._ever_connected = False
+        self._reconnect_count = 0
+        self._backoff = _INITIAL_BACKOFF
 
     @property
     def connected(self) -> bool:
         """Whether a WebSocket session is currently established."""
         return self._connected
+
+    @property
+    def reconnect_count(self) -> int:
+        """How many sessions have ended and gone into reconnect."""
+        return self._reconnect_count
+
+    @property
+    def current_backoff(self) -> float:
+        """Delay (seconds, pre-jitter) before the next reconnect attempt."""
+        return self._backoff
 
     def _set_connected(self, connected: bool) -> None:
         """Update connection state and notify the owner, swallowing errors."""
@@ -90,7 +102,6 @@ class MELCloudHomeWebSocket:
 
     async def run(self) -> None:
         """Connect, listen, and reconnect until stopped or cancelled."""
-        backoff = _INITIAL_BACKOFF
         while not self._closing:
             started = time.monotonic()
             try:
@@ -115,14 +126,15 @@ class MELCloudHomeWebSocket:
             # keep escalating, and so must a hash endpoint that hangs past the
             # threshold before failing — elapsed time alone proves nothing.
             if was_connected and time.monotonic() - started >= _STABLE_SESSION_SECS:
-                backoff = _INITIAL_BACKOFF
+                self._backoff = _INITIAL_BACKOFF
 
             if self._closing:
                 break
+            self._reconnect_count += 1
             # Jitter the sleep so a MELCloud outage doesn't have every
             # installation reconnecting on the same schedule.
-            await asyncio.sleep(backoff * random.uniform(0.8, 1.2))
-            backoff = min(backoff * 2, _MAX_BACKOFF)
+            await asyncio.sleep(self._backoff * random.uniform(0.8, 1.2))
+            self._backoff = min(self._backoff * 2, _MAX_BACKOFF)
 
     async def _connect_once(self) -> None:
         """Open one WebSocket session and pump messages until it closes."""

--- a/custom_components/melcloudhome/api/websocket.py
+++ b/custom_components/melcloudhome/api/websocket.py
@@ -47,18 +47,42 @@ _STABLE_SESSION_SECS = 60
 # Callback invoked for each unit that reports a state change:
 # (unit_id, [changed setting names]).
 DeltaHandler = Callable[[str, list[str]], Awaitable[None]]
+# Sync callback invoked when the connection state flips (True = connected).
+StateHandler = Callable[[bool], None]
 
 
 class MELCloudHomeWebSocket:
     """Resilient MELCloud Home WebSocket listener."""
 
-    def __init__(self, client: MELCloudHomeClient, on_delta: DeltaHandler) -> None:
+    def __init__(
+        self,
+        client: MELCloudHomeClient,
+        on_delta: DeltaHandler,
+        on_state_change: StateHandler | None = None,
+    ) -> None:
         """Initialise with an authenticated client and a delta callback."""
         self._client = client
         self._on_delta = on_delta
+        self._on_state_change = on_state_change
         self._closing = False
         self._connected = False
         self._ever_connected = False
+
+    @property
+    def connected(self) -> bool:
+        """Whether a WebSocket session is currently established."""
+        return self._connected
+
+    def _set_connected(self, connected: bool) -> None:
+        """Update connection state and notify the owner, swallowing errors."""
+        self._connected = connected
+        if self._on_state_change is None:
+            return
+        try:
+            self._on_state_change(connected)
+        except Exception:
+            # A misbehaving state callback must never kill the listener.
+            _LOGGER.debug("WebSocket state callback failed", exc_info=True)
 
     def stop(self) -> None:
         """Signal the run loop to exit (the owner also cancels the task)."""
@@ -79,7 +103,7 @@ class MELCloudHomeWebSocket:
 
             was_connected = self._connected
             if self._connected:
-                self._connected = False
+                self._set_connected(False)
                 if not self._closing:
                     _LOGGER.info(
                         "WebSocket connection lost; reconnecting"
@@ -112,7 +136,7 @@ class MELCloudHomeWebSocket:
                 "WebSocket %s",
                 "connection restored" if self._ever_connected else "connected",
             )
-            self._connected = True
+            self._set_connected(True)
             self._ever_connected = True
             async for msg in ws:
                 if msg.type == aiohttp.WSMsgType.TEXT:

--- a/custom_components/melcloudhome/binary_sensor.py
+++ b/custom_components/melcloudhome/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -66,9 +67,17 @@ async def async_setup_entry(
     _LOGGER.debug("Created %d binary sensor entities", len(entities))
     async_add_entities(entities)
 
-    # Account-level real-time updates connectivity sensor (one per entry)
+    # Account-level real-time updates connectivity sensor (one per entry).
+    # When opted out, drop any entity left over from a previously-enabled run
+    # so it doesn't linger in the registry as a restored/unavailable orphan.
+    ws_unique_id = f"{entry.entry_id}_realtime_updates"
     if coordinator.ws_enabled:
         async_add_entities([WebSocketConnectivitySensor(coordinator, entry)])
+    else:
+        registry = er.async_get(hass)
+        stale = registry.async_get_entity_id("binary_sensor", DOMAIN, ws_unique_id)
+        if stale:
+            registry.async_remove(stale)
 
 
 class WebSocketConnectivitySensor(

--- a/custom_components/melcloudhome/binary_sensor.py
+++ b/custom_components/melcloudhome/binary_sensor.py
@@ -6,10 +6,18 @@ Platform entry point that sets up both ATA and ATW binary sensor entities.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .binary_sensor_ata import (
     ATA_BINARY_SENSOR_TYPES,
@@ -57,3 +65,51 @@ async def async_setup_entry(
 
     _LOGGER.debug("Created %d binary sensor entities", len(entities))
     async_add_entities(entities)
+
+    # Account-level real-time updates connectivity sensor (one per entry)
+    if coordinator.ws_enabled:
+        async_add_entities([WebSocketConnectivitySensor(coordinator, entry)])
+
+
+class WebSocketConnectivitySensor(
+    CoordinatorEntity[MELCloudHomeCoordinator],  # type: ignore[misc]
+    BinarySensorEntity,  # type: ignore[misc]
+):
+    """Reports whether the real-time WebSocket connection is up.
+
+    Account-level (one per config entry), attached to a service device.
+    Always available: it reports connectivity itself.
+    """
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "realtime_updates"
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self, coordinator: MELCloudHomeCoordinator, entry: ConfigEntry
+    ) -> None:
+        """Initialize the connectivity sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_realtime_updates"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name="MELCloud Home",
+            manufacturer="Mitsubishi Electric",
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the WebSocket is connected."""
+        return bool(self.coordinator.ws_connected)
+
+    @property
+    def available(self) -> bool:
+        """Always available — this entity reports connectivity itself."""
+        return True
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the timestamp of the last received delta."""
+        return {"last_delta_at": self.coordinator.ws_last_delta_at}

--- a/custom_components/melcloudhome/binary_sensor.py
+++ b/custom_components/melcloudhome/binary_sensor.py
@@ -111,5 +111,6 @@ class WebSocketConnectivitySensor(
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose the timestamp of the last received delta."""
-        return {"last_delta_at": self.coordinator.ws_last_delta_at}
+        """Expose the timestamp of the last received delta (ISO 8601)."""
+        last = self.coordinator.ws_last_delta_at
+        return {"last_delta_at": last.isoformat() if last else None}

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -73,6 +73,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         # Real-time WebSocket listener (default-on accelerator — issue #174)
         self._websocket: MELCloudHomeWebSocket | None = None
         self._ws_task: asyncio.Task[None] | None = None
+        self.ws_last_delta_at: datetime | None = None
         # Re-authentication lock to prevent concurrent re-auth attempts
         self._reauth_lock = asyncio.Lock()
 
@@ -424,7 +425,11 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         if not self._websocket_enabled() or self._config_entry is None:
             return
 
-        self._websocket = MELCloudHomeWebSocket(self.client, on_delta=self._on_ws_delta)
+        self._websocket = MELCloudHomeWebSocket(
+            self.client,
+            on_delta=self._on_ws_delta,
+            on_state_change=self._on_ws_state_change,
+        )
         # Entry-scoped: HA cancels the task on entry unload/reload, so
         # shutdown needs no manual cancel bookkeeping.
         self._ws_task = self._config_entry.async_create_background_task(
@@ -435,7 +440,22 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
     async def _on_ws_delta(self, unit_id: str, changed: list[str]) -> None:
         """Handle a pushed per-unit state change by refreshing (debounced)."""
         _LOGGER.debug("WebSocket delta for %s: %s", unit_id, changed)
+        self.ws_last_delta_at = datetime.now(UTC)
         await self.async_request_refresh_debounced()
+
+    def _on_ws_state_change(self, connected: bool) -> None:
+        """Push the new WebSocket connection state to entities."""
+        self.async_update_listeners()
+
+    @property
+    def ws_enabled(self) -> bool:
+        """Whether the WebSocket accelerator is enabled for this entry."""
+        return self._websocket_enabled()
+
+    @property
+    def ws_connected(self) -> bool:
+        """Whether the WebSocket is currently connected."""
+        return self._websocket is not None and self._websocket.connected
 
     def get_unit_energy(self, unit_id: str) -> float | None:
         """Get cached energy data for a unit (in kWh).

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -457,6 +457,22 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         """Whether the WebSocket is currently connected."""
         return self._websocket is not None and self._websocket.connected
 
+    def ws_diagnostics(self) -> dict[str, Any]:
+        """WebSocket state for the diagnostics dump (no credentials)."""
+        return {
+            "enabled": self.ws_enabled,
+            "connected": self.ws_connected,
+            "last_delta_at": self.ws_last_delta_at.isoformat()
+            if self.ws_last_delta_at
+            else None,
+            "reconnect_count": self._websocket.reconnect_count
+            if self._websocket
+            else 0,
+            "current_backoff": self._websocket.current_backoff
+            if self._websocket
+            else None,
+        }
+
     def get_unit_energy(self, unit_id: str) -> float | None:
         """Get cached energy data for a unit (in kWh).
 

--- a/custom_components/melcloudhome/diagnostics.py
+++ b/custom_components/melcloudhome/diagnostics.py
@@ -54,6 +54,7 @@ async def async_get_config_entry_diagnostics(
             if coordinator.update_interval
             else None,
         },
+        "websocket": coordinator.ws_diagnostics(),
         "entities": entity_data,
     }
 

--- a/custom_components/melcloudhome/translations/de.json
+++ b/custom_components/melcloudhome/translations/de.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Verbindungsstatus"
       },
+      "realtime_updates": {
+        "name": "Echtzeit-Updates"
+      },
       "forced_dhw_active": {
         "name": "Erzwungenes Warmwasser aktiv"
       }

--- a/custom_components/melcloudhome/translations/el.json
+++ b/custom_components/melcloudhome/translations/el.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Κατάσταση σύνδεσης"
       },
+      "realtime_updates": {
+        "name": "Ενημερώσεις σε πραγματικό χρόνο"
+      },
       "forced_dhw_active": {
         "name": "Αναγκαστική ΖΝΧ ενεργή"
       }

--- a/custom_components/melcloudhome/translations/en.json
+++ b/custom_components/melcloudhome/translations/en.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Connection state"
       },
+      "realtime_updates": {
+        "name": "Real-time updates"
+      },
       "forced_dhw_active": {
         "name": "Forced DHW active"
       }

--- a/custom_components/melcloudhome/translations/es.json
+++ b/custom_components/melcloudhome/translations/es.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Estado de conexión"
       },
+      "realtime_updates": {
+        "name": "Actualizaciones en tiempo real"
+      },
       "forced_dhw_active": {
         "name": "ACS forzado activo"
       }

--- a/custom_components/melcloudhome/translations/fi.json
+++ b/custom_components/melcloudhome/translations/fi.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Yhteystila"
       },
+      "realtime_updates": {
+        "name": "Reaaliaikaiset päivitykset"
+      },
       "forced_dhw_active": {
         "name": "Pakotettu käyttövesitila aktiivinen"
       }

--- a/custom_components/melcloudhome/translations/fr.json
+++ b/custom_components/melcloudhome/translations/fr.json
@@ -98,6 +98,9 @@
       "connection_state": {
         "name": "État connexion"
       },
+      "realtime_updates": {
+        "name": "Mises à jour en temps réel"
+      },
       "forced_dhw_active": {
         "name": "ECS forcée active"
       }

--- a/custom_components/melcloudhome/translations/it.json
+++ b/custom_components/melcloudhome/translations/it.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Stato connessione"
       },
+      "realtime_updates": {
+        "name": "Aggiornamenti in tempo reale"
+      },
       "forced_dhw_active": {
         "name": "ACS forzata attiva"
       }

--- a/custom_components/melcloudhome/translations/nl.json
+++ b/custom_components/melcloudhome/translations/nl.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Verbindingsstatus"
       },
+      "realtime_updates": {
+        "name": "Realtime updates"
+      },
       "forced_dhw_active": {
         "name": "Geforceerd WW actief"
       }

--- a/custom_components/melcloudhome/translations/pt.json
+++ b/custom_components/melcloudhome/translations/pt.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Estado da ligação"
       },
+      "realtime_updates": {
+        "name": "Atualizações em tempo real"
+      },
       "forced_dhw_active": {
         "name": "AQS forçada ativa"
       }

--- a/custom_components/melcloudhome/translations/sv.json
+++ b/custom_components/melcloudhome/translations/sv.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Anslutningsstatus"
       },
+      "realtime_updates": {
+        "name": "Realtidsuppdateringar"
+      },
       "forced_dhw_active": {
         "name": "Forcerat varmvatten aktivt"
       }

--- a/custom_components/melcloudhome/translations/th.json
+++ b/custom_components/melcloudhome/translations/th.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "สถานะการเชื่อมต่อ"
       },
+      "realtime_updates": {
+        "name": "การอัปเดตแบบเรียลไทม์"
+      },
       "forced_dhw_active": {
         "name": "การบังคับน้ำร้อนกำลังทำงาน"
       }

--- a/custom_components/melcloudhome/translations/tr.json
+++ b/custom_components/melcloudhome/translations/tr.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Bağlantı durumu"
       },
+      "realtime_updates": {
+        "name": "Gerçek zamanlı güncellemeler"
+      },
       "forced_dhw_active": {
         "name": "Forced DHW aktif"
       }

--- a/custom_components/melcloudhome/translations/vi.json
+++ b/custom_components/melcloudhome/translations/vi.json
@@ -157,6 +157,9 @@
       "connection_state": {
         "name": "Trạng thái kết nối"
       },
+      "realtime_updates": {
+        "name": "Cập nhật theo thời gian thực"
+      },
       "forced_dhw_active": {
         "name": "DHW bắt buộc đang hoạt động"
       }

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -223,6 +223,20 @@ For each heat pump system, the following entities are created:
 
 ---
 
+## Account-Level Entities
+
+One per MELCloud Home account (config entry), attached to a "MELCloud Home" service device:
+
+- **Real-time updates**: `binary_sensor.melcloud_home_real_time_updates` — diagnostic
+  connectivity sensor reporting whether the real-time WebSocket connection is up
+  (`on` = connected). The `last_delta_at` attribute holds the timestamp of the last
+  push update received. Only created when real-time updates are enabled (the default);
+  polling continues either way, so a disconnected socket means slower updates, not
+  missing data. Not created when real-time updates are switched off in the
+  integration options.
+
+---
+
 ## Understanding ATW Operation (3-Way Valve)
 
 Your heat pump uses a 3-way valve that can only heat ONE target at a time (zones OR DHW tank, never both). This affects what you'll see in Home Assistant.

--- a/tests/api/test_translations.py
+++ b/tests/api/test_translations.py
@@ -1,0 +1,41 @@
+"""Translation file parity checks.
+
+Every translation file must expose exactly the same keys as en.json —
+a missing key silently falls back to the raw key in the HA UI for that
+language. Lives in the api tier because it needs neither HA nor Docker.
+"""
+
+import json
+from pathlib import Path
+
+TRANSLATIONS_DIR = (
+    Path(__file__).parents[2] / "custom_components" / "melcloudhome" / "translations"
+)
+
+
+def _key_paths(obj: object, prefix: str = "") -> set[str]:
+    """Flatten a translations dict to dotted key paths (leaves excluded)."""
+    if not isinstance(obj, dict):
+        return set()
+    paths = set()
+    for key, value in obj.items():
+        path = f"{prefix}.{key}" if prefix else key
+        paths.add(path)
+        paths |= _key_paths(value, path)
+    return paths
+
+
+def test_all_translation_files_match_english_keys() -> None:
+    english = _key_paths(
+        json.loads((TRANSLATIONS_DIR / "en.json").read_text(encoding="utf-8"))
+    )
+    assert english, "en.json produced no keys — wrong path?"
+
+    for file in sorted(TRANSLATIONS_DIR.glob("*.json")):
+        if file.name == "en.json":
+            continue
+        keys = _key_paths(json.loads(file.read_text(encoding="utf-8")))
+        missing = english - keys
+        extra = keys - english
+        assert not missing, f"{file.name} missing keys: {sorted(missing)}"
+        assert not extra, f"{file.name} extra keys: {sorted(extra)}"

--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -271,6 +271,29 @@ class TestConnectionState:
         assert boom.call_count == 2  # both edges attempted
 
 
+class TestReconnectDiagnostics:
+    async def test_reconnect_count_and_backoff_escalate(self, mocker) -> None:
+        """Failed sessions bump reconnect_count and escalate current_backoff."""
+        client = MagicMock()
+        client.async_get_ws_hash = AsyncMock(side_effect=RuntimeError("down"))
+        ws = MELCloudHomeWebSocket(client, AsyncMock())
+        assert ws.reconnect_count == 0
+        assert ws.current_backoff == _INITIAL_BACKOFF
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(delay: float) -> None:
+            sleeps.append(delay)
+            if len(sleeps) >= 2:
+                ws.stop()
+
+        mocker.patch("asyncio.sleep", new=fake_sleep)
+        await ws.run()
+
+        assert ws.reconnect_count == 2
+        assert ws.current_backoff == _INITIAL_BACKOFF * 4
+
+
 # --------------------------------------------------------------------------- #
 # Reconnect loop (run / stop)
 # --------------------------------------------------------------------------- #

--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -234,6 +234,44 @@ class TestConnectOnce:
 
 
 # --------------------------------------------------------------------------- #
+# Connection state surface (connected / on_state_change)
+# --------------------------------------------------------------------------- #
+class TestConnectionState:
+    def _client_with_ws(self, messages: list[object]) -> MagicMock:
+        session = MagicMock()
+        session.ws_connect = MagicMock(return_value=_FakeWS(messages))
+        client = MagicMock()
+        client.async_get_ws_hash = AsyncMock(return_value="HASH123")
+        client.async_ws_session = AsyncMock(return_value=session)
+        return client
+
+    async def test_connected_flips_and_callback_fires(self, mocker) -> None:
+        """connected tracks the session; on_state_change fires on both edges."""
+        client = self._client_with_ws([_msg(aiohttp.WSMsgType.CLOSE)])
+        states: list[bool] = []
+        ws = MELCloudHomeWebSocket(client, AsyncMock(), on_state_change=states.append)
+        assert ws.connected is False
+
+        # First backoff sleep stops the loop: exactly one session runs.
+        mocker.patch("asyncio.sleep", new=AsyncMock(side_effect=lambda *_: ws.stop()))
+        await ws.run()
+
+        assert states == [True, False]
+        assert ws.connected is False
+
+    async def test_state_callback_exception_does_not_kill_loop(self, mocker) -> None:
+        """A misbehaving state callback must not crash the listener."""
+        client = self._client_with_ws([_msg(aiohttp.WSMsgType.CLOSE)])
+        boom = MagicMock(side_effect=RuntimeError("callback boom"))
+        ws = MELCloudHomeWebSocket(client, AsyncMock(), on_state_change=boom)
+
+        mocker.patch("asyncio.sleep", new=AsyncMock(side_effect=lambda *_: ws.stop()))
+        await ws.run()  # must not raise
+
+        assert boom.call_count == 2  # both edges attempted
+
+
+# --------------------------------------------------------------------------- #
 # Reconnect loop (run / stop)
 # --------------------------------------------------------------------------- #
 class TestRunLoop:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,10 +3,13 @@
 These fixtures require pytest-homeassistant-custom-component.
 """
 
+import asyncio
+import json
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
+import aiohttp
 import pytest
 
 if TYPE_CHECKING:
@@ -388,6 +391,7 @@ async def setup_ata_integration_custom(
     mock_context: Any,
     *,
     configure_client: Callable[..., None] | None = None,
+    options: dict[str, Any] | None = None,
 ) -> "tuple[MockConfigEntry, Any]":
     """Set up ATA integration with a custom mock context.
 
@@ -395,5 +399,56 @@ async def setup_ata_integration_custom(
     assert on calls after setup. Use configure_client for pre-setup mock wiring.
     """
     return await _setup_integration_custom(
-        hass, mock_context, configure_client=configure_client
+        hass, mock_context, configure_client=configure_client, options=options
     )
+
+
+# =============================================================================
+# WebSocket test fakes (shared by binary sensor + diagnostics tests)
+# =============================================================================
+
+
+class OpenFakeWS:
+    """Fake aiohttp WebSocket: yields queued frames, then stays open."""
+
+    def __init__(self, frames: list[Any]) -> None:
+        self._frames = list(frames)
+
+    async def __aenter__(self) -> "OpenFakeWS":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    def __aiter__(self) -> "OpenFakeWS":
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._frames:
+            return self._frames.pop(0)
+        await asyncio.Event().wait()  # block until the task is cancelled
+        raise StopAsyncIteration
+
+
+def ws_text_frame(unit_id: str) -> MagicMock:
+    """Build a TEXT frame carrying one unitStateChanged delta."""
+    msg = MagicMock()
+    msg.type = aiohttp.WSMsgType.TEXT
+    msg.data = json.dumps(
+        [
+            {
+                "messageType": "unitStateChanged",
+                "Data": {"id": unit_id, "settings": [{"name": "Power"}]},
+            }
+        ]
+    )
+    return msg
+
+
+def wire_connected_ws(client: MagicMock, frames: list[Any]) -> None:
+    """Make the mocked client's WS path connect successfully."""
+    session = MagicMock()
+    session.ws_connect = MagicMock(return_value=OpenFakeWS(frames))
+    client.async_get_ws_hash = AsyncMock(return_value="HASH123")
+    client.async_ws_session = AsyncMock(return_value=session)
+    type(client).ws_host = "wss://example.invalid"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -252,6 +252,7 @@ async def _setup_integration_custom(
     mock_context: Any,
     *,
     configure_client: Callable[..., None] | None = None,
+    options: dict[str, Any] | None = None,
 ) -> "tuple[MockConfigEntry, Any]":
     from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
     from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -271,6 +272,7 @@ async def _setup_integration_custom(
         entry = MockConfigEntry(
             domain=DOMAIN,
             data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            options=options or {},
             unique_id="test@example.com",
         )
         entry.add_to_hass(hass)
@@ -285,6 +287,7 @@ async def setup_atw_integration_custom(
     mock_context: Any,
     *,
     configure_client: Callable[..., None] | None = None,
+    options: dict[str, Any] | None = None,
 ) -> "tuple[MockConfigEntry, Any]":
     """Set up ATW integration with a custom mock context.
 
@@ -292,7 +295,7 @@ async def setup_atw_integration_custom(
     assert on calls after setup. Use configure_client for pre-setup mock wiring.
     """
     return await _setup_integration_custom(
-        hass, mock_context, configure_client=configure_client
+        hass, mock_context, configure_client=configure_client, options=options
     )
 
 

--- a/tests/integration/test_binary_sensor_ws.py
+++ b/tests/integration/test_binary_sensor_ws.py
@@ -7,6 +7,7 @@ behavior through hass.states only; the client is mocked at the API boundary.
 Run with: make test-integration
 """
 
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -82,4 +83,8 @@ async def test_ws_sensor_on_when_connected_and_tracks_deltas(
     state = hass.states.get(WS_ENTITY_ID)
     assert state is not None
     assert state.state == STATE_ON
-    assert state.attributes["last_delta_at"] is not None
+    # Exposed as an ISO 8601 string (consistent with the diagnostics section),
+    # not a raw datetime object.
+    last_delta_at = state.attributes["last_delta_at"]
+    assert isinstance(last_delta_at, str)
+    assert datetime.fromisoformat(last_delta_at)

--- a/tests/integration/test_binary_sensor_ws.py
+++ b/tests/integration/test_binary_sensor_ws.py
@@ -7,11 +7,8 @@ behavior through hass.states only; the client is mocked at the API boundary.
 Run with: make test-integration
 """
 
-import asyncio
-import json
 from unittest.mock import AsyncMock, MagicMock
 
-import aiohttp
 import pytest
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -22,54 +19,11 @@ from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET
 from .conftest import (
     create_mock_atw_user_context,
     setup_atw_integration_custom,
+    wire_connected_ws,
+    ws_text_frame,
 )
 
 WS_ENTITY_ID = "binary_sensor.melcloud_home_real_time_updates"
-
-
-class _OpenWS:
-    """Fake aiohttp WebSocket: yields queued frames, then stays open."""
-
-    def __init__(self, frames: list[object]) -> None:
-        self._frames = list(frames)
-
-    async def __aenter__(self) -> "_OpenWS":
-        return self
-
-    async def __aexit__(self, *_exc: object) -> bool:
-        return False
-
-    def __aiter__(self) -> "_OpenWS":
-        return self
-
-    async def __anext__(self) -> object:
-        if self._frames:
-            return self._frames.pop(0)
-        await asyncio.Event().wait()  # block until the task is cancelled
-        raise StopAsyncIteration
-
-
-def _text_frame(unit_id: str) -> MagicMock:
-    msg = MagicMock()
-    msg.type = aiohttp.WSMsgType.TEXT
-    msg.data = json.dumps(
-        [
-            {
-                "messageType": "unitStateChanged",
-                "Data": {"id": unit_id, "settings": [{"name": "Power"}]},
-            }
-        ]
-    )
-    return msg
-
-
-def _wire_connected_ws(client: MagicMock, frames: list[object]) -> None:
-    """Make the mocked client's WS path connect successfully."""
-    session = MagicMock()
-    session.ws_connect = MagicMock(return_value=_OpenWS(frames))
-    client.async_get_ws_hash = AsyncMock(return_value="HASH123")
-    client.async_ws_session = AsyncMock(return_value=session)
-    type(client).ws_host = "wss://example.invalid"
 
 
 @pytest.mark.asyncio
@@ -117,8 +71,8 @@ async def test_ws_sensor_on_when_connected_and_tracks_deltas(
     await setup_atw_integration_custom(
         hass,
         create_mock_atw_user_context(),
-        configure_client=lambda client: _wire_connected_ws(
-            client, [_text_frame("unit-1")]
+        configure_client=lambda client: wire_connected_ws(
+            client, [ws_text_frame("unit-1")]
         ),
     )
     # Let the listener task connect, consume the frame, and let the

--- a/tests/integration/test_binary_sensor_ws.py
+++ b/tests/integration/test_binary_sensor_ws.py
@@ -8,16 +8,18 @@ Run with: make test-integration
 """
 
 from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET
+from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET, DOMAIN
 
 from .conftest import (
+    MOCK_CLIENT_PATH,
     create_mock_atw_user_context,
     setup_atw_integration_custom,
     wire_connected_ws,
@@ -62,6 +64,46 @@ async def test_ws_sensor_absent_when_opted_out(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get(WS_ENTITY_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_ws_sensor_removed_on_opt_out_no_orphan(hass: HomeAssistant) -> None:
+    """Opting out after it was created removes the entity (no restored orphan).
+
+    Regression: a conditionally-created entity left in the registry surfaces as
+    a `restored`/`unavailable` orphan on reload. Opt-out must clean it up.
+    """
+    with patch(MOCK_CLIENT_PATH) as mock_client_class:
+        client = mock_client_class.return_value
+        client.login = AsyncMock()
+        client.close = AsyncMock()
+        client.get_user_context = AsyncMock(return_value=create_mock_atw_user_context())
+        client.async_get_ws_hash = AsyncMock(side_effect=RuntimeError("down"))
+        type(client).is_authenticated = PropertyMock(return_value=True)
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+
+        # Enabled (default): entity created and registered.
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert hass.states.get(WS_ENTITY_ID) is not None
+        registry = er.async_get(hass)
+        assert registry.async_get(WS_ENTITY_ID) is not None
+
+        # Opt out and reload — entity must be gone from states AND registry.
+        hass.config_entries.async_update_entry(
+            entry, options={CONF_ENABLE_WEBSOCKET: False}
+        )
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.states.get(WS_ENTITY_ID) is None
+        assert registry.async_get(WS_ENTITY_ID) is None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_binary_sensor_ws.py
+++ b/tests/integration/test_binary_sensor_ws.py
@@ -1,0 +1,131 @@
+"""Tests for the account-level real-time updates connectivity binary sensor.
+
+One diagnostic binary sensor per config entry reports whether the WebSocket
+accelerator is connected, with a ``last_delta_at`` attribute. Tests observe
+behavior through hass.states only; the client is mocked at the API boundary.
+
+Run with: make test-integration
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET
+
+from .conftest import (
+    create_mock_atw_user_context,
+    setup_atw_integration_custom,
+)
+
+WS_ENTITY_ID = "binary_sensor.melcloud_home_real_time_updates"
+
+
+class _OpenWS:
+    """Fake aiohttp WebSocket: yields queued frames, then stays open."""
+
+    def __init__(self, frames: list[object]) -> None:
+        self._frames = list(frames)
+
+    async def __aenter__(self) -> "_OpenWS":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> bool:
+        return False
+
+    def __aiter__(self) -> "_OpenWS":
+        return self
+
+    async def __anext__(self) -> object:
+        if self._frames:
+            return self._frames.pop(0)
+        await asyncio.Event().wait()  # block until the task is cancelled
+        raise StopAsyncIteration
+
+
+def _text_frame(unit_id: str) -> MagicMock:
+    msg = MagicMock()
+    msg.type = aiohttp.WSMsgType.TEXT
+    msg.data = json.dumps(
+        [
+            {
+                "messageType": "unitStateChanged",
+                "Data": {"id": unit_id, "settings": [{"name": "Power"}]},
+            }
+        ]
+    )
+    return msg
+
+
+def _wire_connected_ws(client: MagicMock, frames: list[object]) -> None:
+    """Make the mocked client's WS path connect successfully."""
+    session = MagicMock()
+    session.ws_connect = MagicMock(return_value=_OpenWS(frames))
+    client.async_get_ws_hash = AsyncMock(return_value="HASH123")
+    client.async_ws_session = AsyncMock(return_value=session)
+    type(client).ws_host = "wss://example.invalid"
+
+
+@pytest.mark.asyncio
+async def test_ws_sensor_off_when_listener_cannot_connect(
+    hass: HomeAssistant,
+) -> None:
+    """Default-on entry creates the sensor; unconnected listener reads off."""
+
+    def fail_hash(client: MagicMock) -> None:
+        client.async_get_ws_hash = AsyncMock(side_effect=RuntimeError("down"))
+
+    await setup_atw_integration_custom(
+        hass, create_mock_atw_user_context(), configure_client=fail_hash
+    )
+
+    state = hass.states.get(WS_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.attributes["device_class"] == "connectivity"
+    assert state.attributes["last_delta_at"] is None
+
+    registry = er.async_get(hass)
+    entity = registry.async_get(WS_ENTITY_ID)
+    assert entity is not None
+    assert entity.entity_category == er.EntityCategory.DIAGNOSTIC
+
+
+@pytest.mark.asyncio
+async def test_ws_sensor_absent_when_opted_out(hass: HomeAssistant) -> None:
+    """Opting out of real-time updates creates no connectivity sensor."""
+    await setup_atw_integration_custom(
+        hass,
+        create_mock_atw_user_context(),
+        options={CONF_ENABLE_WEBSOCKET: False},
+    )
+
+    assert hass.states.get(WS_ENTITY_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_ws_sensor_on_when_connected_and_tracks_deltas(
+    hass: HomeAssistant,
+) -> None:
+    """A live socket reads on; a received delta stamps last_delta_at."""
+    await setup_atw_integration_custom(
+        hass,
+        create_mock_atw_user_context(),
+        configure_client=lambda client: _wire_connected_ws(
+            client, [_text_frame("unit-1")]
+        ),
+    )
+    # Let the listener task connect, consume the frame, and let the
+    # debounced refresh from the delta run to completion.
+    await hass.async_block_till_done()
+
+    state = hass.states.get(WS_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes["last_delta_at"] is not None

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -26,7 +26,51 @@ from .conftest import (
     create_mock_ata_unit,
     create_mock_ata_user_context,
     setup_ata_integration_custom,
+    wire_connected_ws,
+    ws_text_frame,
 )
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_includes_websocket_state(hass: HomeAssistant) -> None:
+    """A connected socket reports its full state; the hash never leaks."""
+    entry, _ = await setup_ata_integration_custom(
+        hass,
+        create_mock_ata_user_context(),
+        configure_client=lambda client: wire_connected_ws(
+            client, [ws_text_frame("unit-1")]
+        ),
+    )
+    await hass.async_block_till_done()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    ws = diagnostics["websocket"]
+    assert ws["enabled"] is True
+    assert ws["connected"] is True
+    assert ws["last_delta_at"] is not None
+    assert ws["reconnect_count"] == 0
+    assert ws["current_backoff"] is not None
+    # The WS hash credential must never appear anywhere in the dump.
+    assert "HASH123" not in json.dumps(diagnostics, default=str)
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_websocket_disabled(hass: HomeAssistant) -> None:
+    """Opted-out entries still report the section, marked disabled."""
+    from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET
+
+    entry, _ = await setup_ata_integration_custom(
+        hass,
+        create_mock_ata_user_context(),
+        options={CONF_ENABLE_WEBSOCKET: False},
+    )
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    ws = diagnostics["websocket"]
+    assert ws["enabled"] is False
+    assert ws["connected"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Real-time updates observability for the v2.4.0 beta (backlog tasks 1 + 2), plus follow-ups surfaced by a real dev-container test.

## What

**Connectivity sensor** — one account-level diagnostic `binary_sensor.melcloud_home_real_time_updates` per config entry (connectivity device class, diagnostic category, attached to a new "MELCloud Home" service device) reporting whether the real-time WebSocket connection is up. A `last_delta_at` attribute stamps the most recent push update, exposed as an ISO 8601 string so HA renders it as a friendly localized timestamp.

**Diagnostics** — the config-entry diagnostics dump gains a `websocket` section: `enabled`, `connected`, `last_delta_at`, `reconnect_count`, `current_backoff`. The `hash` credential is never stored on the listener or coordinator, and a test asserts it cannot appear anywhere in the dump.

**Lifecycle** — the sensor is created only when real-time updates are enabled (the default). Opting out removes it from the entity registry so it doesn't linger as a `restored`/`unavailable` orphan.

## How

The listener (`api/websocket.py`) gains a `connected` property, an optional `on_state_change` sync callback (fired on both connection edges, guarded so a misbehaving callback can't kill the listen loop), and `reconnect_count` / `current_backoff` tracking — it stays HA-agnostic. The coordinator bridges state flips to entities via `async_update_listeners()`, stamps `ws_last_delta_at` on each delta, and assembles the diagnostics section in `ws_diagnostics()`.

Entity name strings ("Real-time updates", reusing the per-language labels from #185) added to all 13 translation files, plus a new parity test (`tests/api/test_translations.py`) that fails if any translation file's key set drifts from `en.json`.

## Testing

TDD throughout (every test watched failing first). Unit: connection-state surface, callback-exception guard, reconnect/backoff counters. Integration (through `hass.states` / the diagnostics API only): sensor created and `off` when the listener can't connect, absent when opted out, `on` with an ISO `last_delta_at` after a delta over a fake socket, orphan removed on the enabled→disabled reload; diagnostics section populated when connected, disabled when opted out, hash absent from the serialized dump.

Full suites green: api + integration (current HA) + integration (2025.8.0 floor). `/security-review` run on the observability code (clean).

**Real-environment verification:** deployed the branch to the local dev HA container and exercised the actual "Download diagnostics" button + the live dashboard entity end-to-end — confirmed the whole dump serializes through HA's real JSON encoder, `last_delta_at` populates on a mock-emitted delta, connectivity flips live, the hash is absent, and opt-out removes the entity cleanly.

## Known / accepted

Opting out removes the entity, so a hand-pinned dashboard card for it will show "Entity not found" (the auto-generated device page just omits it). Accepted for a diagnostic entity — see the always-present-status-sensor alternative if this ever needs to change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
