### PR TITLE
ci: test the declared HA floor + fix retry_after floor violation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,16 @@ jobs:
       - name: Type check
         run: make type-check
 
+  test-floor:
+    name: Integration Tests (HA floor)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run integration tests on the hacs.json HA floor
+        run: make test-integration-floor
+
   test:
     name: Run All Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ make zizmor                      # Security scan workflows (run before pushing w
 make test-build                  # Build Docker test images (after dep changes)
 make test-api                    # API unit tests (VCR, no Docker)
 make test-integration            # Integration tests (Docker, mocked API)
+make test-integration-floor      # Same suite on the hacs.json HA floor
 make test-e2e                    # E2E tests (Docker, mock server)
 make test                        # All tests with coverage
 ```

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,16 @@ test-integration: test-ensure-images  ## Integration tests only
 		         --cov-report=term-missing"
 	docker compose -f docker-compose.test.yml down
 
+# phcc 0.13.269 pins homeassistant==2025.8.0 — the hacs.json floor. pycares<5
+# because that HA's aiodns 3.5.0 breaks against pycares 5.x. Bump BOTH the pin
+# here and hacs.json together when raising the floor.
+test-integration-floor: test-ensure-images  ## Integration tests on the hacs.json HA floor
+	docker compose -f docker-compose.test.yml up --no-build -d melcloud-mock
+	docker compose -f docker-compose.test.yml run --rm integration-tests \
+		sh -c "uv pip install 'pytest-homeassistant-custom-component==0.13.269' 'pycares<5' && \
+		       uv run pytest tests/integration/ -q --no-cov"
+	docker compose -f docker-compose.test.yml down
+
 test-e2e: test-ensure-images  ## E2E tests only
 	@rm -f .coverage coverage.xml
 	docker compose -f docker-compose.test.yml up --no-build -d melcloud-mock

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
@@ -36,6 +37,13 @@ if TYPE_CHECKING:
     from homeassistant.helpers.event import CALLBACK_TYPE
 
 _LOGGER = logging.getLogger(__name__)
+
+# UpdateFailed grew retry_after in HA 2025.12 (core #153550); the hacs.json
+# floor is 2025.8, so older cores get a plain UpdateFailed and retry at the
+# coordinator's regular cadence instead of our escalating outage backoff.
+_UPDATE_FAILED_HAS_RETRY_AFTER = (
+    "retry_after" in inspect.signature(UpdateFailed.__init__).parameters
+)
 
 
 class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
@@ -153,7 +161,9 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             _LOGGER.warning(
                 "MELCloud service unavailable, retrying in %ds", retry_after
             )
-            raise UpdateFailed(str(err), retry_after=retry_after) from err
+            if _UPDATE_FAILED_HAS_RETRY_AFTER:
+                raise UpdateFailed(str(err), retry_after=retry_after) from err
+            raise UpdateFailed(str(err)) from err
 
         self._outage_retry_count = 0
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -116,6 +116,14 @@ async def test_set_temperature(hass, setup_integration):
 
 **Coverage:** Config flow, entity platforms, coordinator, service calls
 
+**HA version coverage:** CI runs this tier twice — once against current HA
+(`make test`, latest `pytest-homeassistant-custom-component`) and once against the
+declared `hacs.json` floor (`make test-integration-floor`, phcc `0.13.269` =
+HA 2025.8.0). The floor pin lives in the Makefile and must be bumped together with
+any `hacs.json` floor raise — a stale pin silently keeps testing the old floor.
+Versions between the two endpoints are deliberately untested (two-point trade-off,
+not a full matrix).
+
 ---
 
 ### Tier 3: **Manual Testing** (Production HA) ✅

--- a/tests/integration/test_coordinator_retry.py
+++ b/tests/integration/test_coordinator_retry.py
@@ -202,6 +202,10 @@ async def test_outage_backoff_escalates(coordinator, hass):
     """Test retry_after escalates on consecutive outages."""
     from homeassistant.helpers.update_coordinator import UpdateFailed
 
+    from custom_components.melcloudhome.coordinator import (
+        _UPDATE_FAILED_HAS_RETRY_AFTER,
+    )
+
     # Ensure client looks unauthenticated so login is attempted
     coordinator.client._auth._authenticated = False
     coordinator.client._auth._access_token = None
@@ -214,9 +218,14 @@ async def test_outage_backoff_escalates(coordinator, hass):
         try:
             await coordinator._async_update_data()
         except UpdateFailed as err:
-            retry_values.append(err.retry_after)
+            retry_values.append(getattr(err, "retry_after", None))
 
-    assert retry_values == [120, 240, 480, 900, 900]
+    if _UPDATE_FAILED_HAS_RETRY_AFTER:
+        assert retry_values == [120, 240, 480, 900, 900]
+    else:
+        # HA < 2025.12: outages still raise UpdateFailed (no TypeError),
+        # just without the escalating retry hint.
+        assert retry_values == [None] * 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes out backlog task 3 (CI floor check) — and the check immediately paid for itself by catching a real bug.

## The bug

`UpdateFailed(retry_after=...)` only exists since HA 2025.12 (home-assistant/core#153550). Our declared hacs.json floor is 2025.8.0, so any user on HA 2025.8–2025.11 hits a `TypeError` instead of graceful outage backoff whenever MELCloud returns 5xx. Fixed with a module-level capability check: older cores get a plain `UpdateFailed` and retry at the coordinator's regular cadence; 2025.12+ keeps the escalating `retry_after` hint.

## The CI job

New `make test-integration-floor` target runs the full integration suite against `pytest-homeassistant-custom-component==0.13.269`, which pins exactly `homeassistant==2025.8.0` (plus `pycares<5`, since that HA's aiodns 3.5.0 breaks against pycares 5.x). Wired into `test.yml` as a separate job, so the floor claim is now continuously exercised. The Makefile comment notes the pin must move together with any future hacs.json floor bump.

## Testing

Watched the floor run fail (2 tests, `TypeError: unexpected keyword argument 'retry_after'`), applied the guard, floor run now green (178 passed). Current-HA suite unaffected (17 retry tests + 304 api tests pass). The backoff tests now assert both behaviors: escalating values on 2025.12+, plain `UpdateFailed` (no crash) below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
