### PR TITLE
chore: release v2.4.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Real-time updates**: changes made with the physical remote, the MELCloud Home app, or a schedule now appear in Home Assistant within a few seconds instead of up to a minute. Enabled by default with automatic fallback to regular polling if the connection drops, so devices keep working and never show as unavailable because of it. Turn it off any time via Settings → Devices & Services → MELCloud Home → Configure. Contributed by @mrdjtoto, from protocol investigation through implementation. (#176, #185)
-- "Real-time updates" connectivity sensor (diagnostic) showing whether the live connection is currently active, so you can tell at a glance that real-time updates are working. (#187)
-- The diagnostics download now includes a real-time connection section to make support requests easier to investigate. (#187)
+- **Real-time updates**: changes made with the remote control, the MELCloud Home app, or a schedule now appear in Home Assistant within seconds instead of up to a minute. On by default with nothing to set up; if the connection drops, the integration falls back to regular polling automatically. Contributed by @mrdjtoto. (#176, #185)
+- "Real-time updates" sensor showing whether the live connection is active. (#187)
 
 ### Changed
 
-- Minimum supported Home Assistant version is now 2025.8.0. If you're on an older Home Assistant, HACS will not offer this update — upgrade Home Assistant first. (#185)
-
-### Fixed
-
-- Pre-release hardening of real-time updates: removing or reloading the integration could leave a background connection running, and an unexpected message from the cloud could interrupt live updates. Both fixed before release.
-
-### Security
-
-- Debug logs redact the real-time connection URL so the connection credential never appears in log files. (#183)
+- Requires Home Assistant 2025.8.0 or newer. On older versions, HACS will not offer this update — upgrade Home Assistant first. (#185)
 
 
 ## [2.3.5] - 2026-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.0] - 2026-07-20
+
+### Added
+
+- **Real-time updates**: changes made with the physical remote, the MELCloud Home app, or a schedule now appear in Home Assistant within a few seconds instead of up to a minute. Enabled by default with automatic fallback to regular polling if the connection drops, so devices keep working and never show as unavailable because of it. Turn it off any time via Settings → Devices & Services → MELCloud Home → Configure. Contributed by @mrdjtoto, from protocol investigation through implementation. (#176, #185)
+- "Real-time updates" connectivity sensor (diagnostic) showing whether the live connection is currently active, so you can tell at a glance that real-time updates are working. (#187)
+- The diagnostics download now includes a real-time connection section to make support requests easier to investigate. (#187)
+
+### Changed
+
+- Minimum supported Home Assistant version is now 2025.8.0. If you're on an older Home Assistant, HACS will not offer this update — upgrade Home Assistant first. (#185)
+
+### Fixed
+
+- Pre-release hardening of real-time updates: removing or reloading the integration could leave a background connection running, and an unexpected message from the cloud could interrupt live updates. Both fixed before release.
+
+### Security
+
+- Debug logs redact the real-time connection URL so the connection credential never appears in log files. (#183)
+
+
 ## [2.3.5] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Home Assistant custom integration for **MELCloud Home**.
 
 ## What's New in v2.4.0
 
-**Real-time updates** - changes made with the remote control or the MELCloud Home app now appear in Home Assistant within seconds, instead of up to a minute. Enabled by default with automatic fallback to regular polling, so there's nothing to set up - see [Real-Time Updates](#real-time-updates) for details. Contributed by [@mrdjtoto](https://github.com/mrdjtoto), from protocol investigation through implementation.
+**Real-time updates** - changes made with the remote control or the MELCloud Home app now appear in Home Assistant within seconds, instead of up to a minute. Enabled by default with automatic fallback to regular polling, so there's nothing to set up - see [Real-Time Updates](#real-time-updates) for details. Contributed by [@mrdjtoto](https://github.com/mrdjtoto).
 
 **Requires Home Assistant 2025.8.0 or newer.** If you're on an older version, HACS will not offer this update.
 
@@ -96,17 +96,13 @@ Enter your MELCloud Home credentials (email and password). Your devices will be 
 
 ## Real-Time Updates
 
-Changes made outside Home Assistant — the physical remote, the MELCloud Home app, a schedule — normally take up to 60 seconds to appear (the polling interval). Real-time updates shrink that to a couple of seconds: the integration listens on a MELCloud WebSocket and refreshes a device as soon as the cloud reports a change.
+Changes made with the remote control, the MELCloud Home app, or a schedule appear in Home Assistant within seconds — no more waiting for the next poll.
 
-**On by default.** There is nothing to set up. It is safe by design:
+It's on by default and there's nothing to set up. If the connection ever drops, the integration automatically falls back to regular 60-second polling, so your devices keep working either way.
 
-- The socket is receive-only — all control commands use the same cloud API as before
-- If the connection drops, the integration falls back to normal 60-second polling automatically; your devices keep working and never show as unavailable because of it
-- Reconnection is automatic (the MELCloud server routinely recycles connections about every 2 hours — this is normal)
+**To turn it off:** Settings → Devices & Services → MELCloud Home → **Configure** → switch off "Real-time updates".
 
-**How to tell it's working:** changes made on the remote or in the MELCloud app show up in Home Assistant within a few seconds. The log (Settings → System → Logs) shows `WebSocket connected` when it starts and `WebSocket connection lost; reconnecting (polling continues meanwhile)` if it drops.
-
-**How to turn it off:** Settings → Devices & Services → MELCloud Home → Configure → switch off "Real-time updates" → Submit. The integration then uses 60-second polling only.
+The "Real-time updates" sensor (under the MELCloud Home service device, Diagnostic section) shows whether the live connection is currently active.
 
 ## Important Notes
 

--- a/custom_components/melcloudhome/manifest.json
+++ b/custom_components/melcloudhome/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.melcloudhome"
   ],
   "requirements": [],
-  "version": "2.3.5"
+  "version": "2.4.0"
 }


### PR DESCRIPTION
Release PR for v2.4.0 — real-time updates via WebSocket, on by default, plus a connectivity sensor and a new HA 2025.8.0 minimum. See the CHANGELOG entry in this diff for the user-facing summary.

Changes: `manifest.json` 2.3.5 → 2.4.0, CHANGELOG entry, and an end-user trim of the README real-time sections.

After merge: tag `v2.4.0-beta.1` to publish via the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
