### PR TITLE
fix: pre-release review fixes for real-time updates

### DIFF
--- a/custom_components/melcloudhome/api/websocket.py
+++ b/custom_components/melcloudhome/api/websocket.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING
 
 import aiohttp
 
+from .auth import _redact_url
+
 if TYPE_CHECKING:
     from .client import MELCloudHomeClient
 
@@ -43,6 +45,15 @@ _HEARTBEAT = 30
 # backoff forever — each cycle costing a hash fetch and possibly a token
 # refresh.
 _STABLE_SESSION_SECS = 60
+
+
+def _sanitize(value: object) -> str:
+    """Strip CR/LF from server-supplied strings so they can't forge log lines.
+
+    Unconditional on purpose: CodeQL only recognizes unconditional barriers.
+    """
+    return str(value).replace("\r", "").replace("\n", " ")
+
 
 # Callback invoked for each unit that reports a state change:
 # (unit_id, [changed setting names]).
@@ -110,7 +121,10 @@ class MELCloudHomeWebSocket:
                 raise
             except Exception as err:
                 # Best-effort listener: any failure just backs off and retries.
-                _LOGGER.debug("WebSocket session ended: %s", err)
+                # Redact: a WSServerHandshakeError stringifies with the full
+                # request URL, including ?hash=<credential> (the leak class
+                # #183 fixed on the tracer path).
+                _LOGGER.debug("WebSocket session ended: %s", _redact_url(err))
 
             was_connected = self._connected
             if self._connected:
@@ -176,16 +190,20 @@ class MELCloudHomeWebSocket:
             if item.get("messageType") != "unitStateChanged":
                 continue
             data = item.get("Data") or item.get("data") or {}
+            if not isinstance(data, dict):
+                # One malformed frame must not tear down the whole session.
+                continue
             unit_id = data.get("id")
             if not unit_id:
                 continue
+            settings = data.get("settings")
             names = [
-                s["name"]
-                for s in data.get("settings", [])
+                _sanitize(s["name"])
+                for s in (settings if isinstance(settings, list) else [])
                 if isinstance(s, dict) and s.get("name")
             ]
             try:
-                await self._on_delta(str(unit_id), names)
+                await self._on_delta(_sanitize(unit_id), names)
             except Exception:
                 # A misbehaving handler must never kill the listen loop.
                 _LOGGER.debug("WebSocket delta handler failed", exc_info=True)

--- a/custom_components/melcloudhome/binary_sensor.py
+++ b/custom_components/melcloudhome/binary_sensor.py
@@ -33,6 +33,10 @@ from .coordinator import MELCloudHomeCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+# Shared by entity creation and the opt-out orphan cleanup below — if these
+# drift apart the cleanup silently stops matching.
+_WS_UNIQUE_ID_SUFFIX = "_realtime_updates"
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -70,7 +74,7 @@ async def async_setup_entry(
     # Account-level real-time updates connectivity sensor (one per entry).
     # When opted out, drop any entity left over from a previously-enabled run
     # so it doesn't linger in the registry as a restored/unavailable orphan.
-    ws_unique_id = f"{entry.entry_id}_realtime_updates"
+    ws_unique_id = f"{entry.entry_id}{_WS_UNIQUE_ID_SUFFIX}"
     if coordinator.ws_enabled:
         async_add_entities([WebSocketConnectivitySensor(coordinator, entry)])
     else:
@@ -78,6 +82,9 @@ async def async_setup_entry(
         stale = registry.async_get_entity_id("binary_sensor", DOMAIN, ws_unique_id)
         if stale:
             registry.async_remove(stale)
+        # The "MELCloud Home" service device deliberately stays registered:
+        # it is removed with the config entry, and deleting it here would
+        # churn the registry on every opt-out/opt-in toggle.
 
 
 class WebSocketConnectivitySensor(
@@ -100,7 +107,7 @@ class WebSocketConnectivitySensor(
     ) -> None:
         """Initialize the connectivity sensor."""
         super().__init__(coordinator)
-        self._attr_unique_id = f"{entry.entry_id}_realtime_updates"
+        self._attr_unique_id = f"{entry.entry_id}{_WS_UNIQUE_ID_SUFFIX}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry.entry_id)},
             name="MELCloud Home",

--- a/custom_components/melcloudhome/control_client_base.py
+++ b/custom_components/melcloudhome/control_client_base.py
@@ -48,3 +48,13 @@ class ControlClientBase:
             await self._async_request_refresh()  # type: ignore[attr-defined]
 
         self._refresh_debounce_task = self._hass.async_create_task(_delayed_refresh())
+
+    def cancel_pending_refresh(self) -> None:
+        """Cancel any pending debounced refresh (call on shutdown).
+
+        A refresh queued <=2s before unload must not fire after the client
+        session is closed — it would resurrect a fresh ClientSession that
+        nothing ever closes.
+        """
+        if self._refresh_debounce_task and not self._refresh_debounce_task.done():
+            self._refresh_debounce_task.cancel()

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -496,6 +496,9 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
 
     async def async_shutdown(self) -> None:
         """Shutdown the coordinator."""
+        await super().async_shutdown()
+        self.control_client_ata.cancel_pending_refresh()
+        self.control_client_atw.cancel_pending_refresh()
         if self._cancel_energy_updates:
             self._cancel_energy_updates()
         if self._cancel_telemetry_updates:

--- a/tests/api/test_mock_ws_server.py
+++ b/tests/api/test_mock_ws_server.py
@@ -149,28 +149,28 @@ async def test_atw_put_emits_assumed_shape_delta(mock_client):
 
 async def test_control_reject_hash(mock_client):
     client, _ = mock_client
-    await client.post("/_mock/ws", json={"action": "reject-hash"})
+    await client.post("/_mock/ws", json={"action": "reject-hash"}, headers=BEARER)
     with pytest.raises(aiohttp.WSServerHandshakeError) as err:
         await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
     assert err.value.status == 403
-    await client.post("/_mock/ws", json={"action": "clear"})
+    await client.post("/_mock/ws", json={"action": "clear"}, headers=BEARER)
     ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")  # works again
     await ws.close()
 
 
 async def test_control_accept_then_close(mock_client):
     client, _ = mock_client
-    await client.post("/_mock/ws", json={"action": "accept-then-close"})
+    await client.post("/_mock/ws", json={"action": "accept-then-close"}, headers=BEARER)
     ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")  # 101 succeeds...
     msg = await ws.receive(timeout=2)  # ...then server closes immediately
     assert msg.type == aiohttp.WSMsgType.CLOSE
-    await client.post("/_mock/ws", json={"action": "clear"})
+    await client.post("/_mock/ws", json={"action": "clear"}, headers=BEARER)
 
 
 async def test_control_close_now(mock_client):
     client, server = mock_client
     ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
-    await client.post("/_mock/ws", json={"action": "close-now"})
+    await client.post("/_mock/ws", json={"action": "close-now"}, headers=BEARER)
     msg = await ws.receive(timeout=2)
     assert msg.type == aiohttp.WSMsgType.CLOSE
     assert server.ws_clients == set()
@@ -190,6 +190,7 @@ async def test_control_emit_delta_passive_push(mock_client):
                 {"name": "ActualFanSpeed", "value": "2"},  # string, per capture
             ],
         },
+        headers=BEARER,
     )
     frame = await ws.receive_json(timeout=2)
     by_name = {s["name"]: s["value"] for s in frame[0]["Data"]["settings"]}
@@ -200,22 +201,29 @@ async def test_control_emit_delta_passive_push(mock_client):
 
 async def test_control_unknown_action_400(mock_client):
     client, _ = mock_client
-    resp = await client.post("/_mock/ws", json={"action": "explode"})
+    resp = await client.post("/_mock/ws", json={"action": "explode"}, headers=BEARER)
     assert resp.status == 400
+
+
+async def test_control_requires_bearer(mock_client):
+    """The fault-injection endpoint is not auth-exempt (LAN-peer hardening)."""
+    client, _ = mock_client
+    resp = await client.post("/_mock/ws", json={"action": "status"})
+    assert resp.status == 401
 
 
 async def test_control_emit_delta_missing_fields_400(mock_client):
     client, _ = mock_client
-    resp = await client.post("/_mock/ws", json={"action": "emit-delta"})
+    resp = await client.post("/_mock/ws", json={"action": "emit-delta"}, headers=BEARER)
     assert resp.status == 400
 
 
 async def test_control_status_reports_client_count(mock_client):
     client, _ = mock_client
-    resp = await client.post("/_mock/ws", json={"action": "status"})
+    resp = await client.post("/_mock/ws", json={"action": "status"}, headers=BEARER)
     assert (await resp.json())["clients"] == 0
     ws = await client.ws_connect(f"/ws?hash={MOCK_WS_HASH}")
-    resp = await client.post("/_mock/ws", json={"action": "status"})
+    resp = await client.post("/_mock/ws", json={"action": "status"}, headers=BEARER)
     assert (await resp.json())["clients"] == 1
     await ws.close()
 

--- a/tests/api/test_websocket.py
+++ b/tests/api/test_websocket.py
@@ -172,6 +172,36 @@ class TestHandleText:
         await ws._handle_text(_delta_frame("unit-5", [{"name": "Power"}]))
         on_delta.assert_awaited_once()
 
+    async def test_non_dict_data_is_skipped(self) -> None:
+        """One malformed frame must not tear down the whole session."""
+        ws, on_delta = _make_ws()
+        for bad_data in (["a", "list"], "a string", 42):
+            raw = json.dumps([{"messageType": "unitStateChanged", "Data": bad_data}])
+            # Must not raise — an AttributeError here would unwind
+            # _connect_once and force a full disconnect/reconnect cycle.
+            await ws._handle_text(raw)
+        on_delta.assert_not_awaited()
+
+    async def test_non_list_settings_is_tolerated(self) -> None:
+        ws, on_delta = _make_ws()
+        raw = json.dumps(
+            [
+                {
+                    "messageType": "unitStateChanged",
+                    "Data": {"id": "unit-6", "settings": "Power"},
+                }
+            ]
+        )
+        await ws._handle_text(raw)
+        on_delta.assert_awaited_once_with("unit-6", [])
+
+    async def test_server_strings_are_stripped_of_newlines(self) -> None:
+        """CR/LF in server-supplied strings can't forge downstream log lines."""
+        ws, on_delta = _make_ws()
+        raw = _delta_frame("unit\n7", [{"name": "Power\r\nFAKE"}])
+        await ws._handle_text(raw)
+        on_delta.assert_awaited_once_with("unit 7", ["Power FAKE"])
+
 
 # --------------------------------------------------------------------------- #
 # Connect + receive (_connect_once)
@@ -480,6 +510,32 @@ class TestRunLoop:
         lost = [r for r in caplog.records if "connection lost" in r.getMessage()]
         assert len(lost) == 1
         assert lost[0].levelname == "INFO"
+
+    async def test_session_error_log_redacts_hash(self, mocker, caplog) -> None:
+        """Handshake failures stringify with the full WS URL — redact the hash.
+
+        aiohttp's WSServerHandshakeError inherits ClientResponseError.__str__,
+        which embeds the request URL including ?hash=<credential>.
+        """
+        mocker.patch("asyncio.sleep", new_callable=AsyncMock)
+        ws, _ = _make_ws()
+        attempts: list[int] = []
+
+        async def fake_connect() -> None:
+            if attempts:
+                ws.stop()
+                return
+            attempts.append(1)
+            raise RuntimeError(
+                "500, message='x', url='wss://ws.example/?hash=SECRET-HASH'"
+            )
+
+        ws._connect_once = fake_connect  # type: ignore[method-assign]
+        with caplog.at_level("DEBUG"):
+            await ws.run()
+
+        assert "SECRET-HASH" not in caplog.text
+        assert "hash=***REDACTED***" in caplog.text
 
     async def test_cancellation_propagates(self) -> None:
         ws, _ = _make_ws()

--- a/tests/api/test_websocket_e2e.py
+++ b/tests/api/test_websocket_e2e.py
@@ -17,11 +17,17 @@ from custom_components.melcloudhome.api.client import MELCloudHomeClient
 from custom_components.melcloudhome.api.const_shared import MOCK_BASE_URL
 from custom_components.melcloudhome.api.websocket import MELCloudHomeWebSocket
 
+# The control endpoint requires a bearer like every other mock endpoint
+# (any value passes — the mock only checks the scheme).
+_BEARER = {"Authorization": "Bearer mock-token"}
+
 
 async def _ws_control(action: str) -> None:
     async with (
         aiohttp.ClientSession() as session,
-        session.post(f"{MOCK_BASE_URL}/_mock/ws", json={"action": action}) as resp,
+        session.post(
+            f"{MOCK_BASE_URL}/_mock/ws", json={"action": action}, headers=_BEARER
+        ) as resp,
     ):
         assert resp.status == 200
 
@@ -29,7 +35,9 @@ async def _ws_control(action: str) -> None:
 async def _ws_client_count() -> int:
     async with (
         aiohttp.ClientSession() as session,
-        session.post(f"{MOCK_BASE_URL}/_mock/ws", json={"action": "status"}) as resp,
+        session.post(
+            f"{MOCK_BASE_URL}/_mock/ws", json={"action": "status"}, headers=_BEARER
+        ) as resp,
     ):
         return int((await resp.json())["clients"])
 

--- a/tests/integration/test_binary_sensor_ws.py
+++ b/tests/integration/test_binary_sensor_ws.py
@@ -7,6 +7,7 @@ behavior through hass.states only; the client is mocked at the API boundary.
 Run with: make test-integration
 """
 
+import asyncio
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
@@ -20,6 +21,7 @@ from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET, DOMAIN
 
 from .conftest import (
     MOCK_CLIENT_PATH,
+    OpenFakeWS,
     create_mock_atw_user_context,
     setup_atw_integration_custom,
     wire_connected_ws,
@@ -105,6 +107,16 @@ async def test_ws_sensor_removed_on_opt_out_no_orphan(hass: HomeAssistant) -> No
         assert hass.states.get(WS_ENTITY_ID) is None
         assert registry.async_get(WS_ENTITY_ID) is None
 
+        # Opt back in and reload — the sensor must come back.
+        hass.config_entries.async_update_entry(
+            entry, options={CONF_ENABLE_WEBSOCKET: True}
+        )
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.states.get(WS_ENTITY_ID) is not None
+        assert registry.async_get(WS_ENTITY_ID) is not None
+
 
 @pytest.mark.asyncio
 async def test_ws_sensor_on_when_connected_and_tracks_deltas(
@@ -130,3 +142,111 @@ async def test_ws_sensor_on_when_connected_and_tracks_deltas(
     last_delta_at = state.attributes["last_delta_at"]
     assert isinstance(last_delta_at, str)
     assert datetime.fromisoformat(last_delta_at)
+
+
+@pytest.mark.asyncio
+async def test_ws_delta_triggers_debounced_refresh(hass: HomeAssistant) -> None:
+    """The headline seam: a pushed delta causes a real coordinator refresh.
+
+    Regression guard for the flagship v2.4.0 behavior — without it, a break in
+    the delta -> debounced-refresh wiring would silently degrade real-time
+    updates back to 60s polling with every other test still green.
+    """
+    _entry, mock_client = await setup_atw_integration_custom(
+        hass,
+        create_mock_atw_user_context(),
+        configure_client=lambda client: wire_connected_ws(
+            client, [ws_text_frame("unit-1")]
+        ),
+    )
+    # Let the delta's debounced refresh (2s) run to completion.
+    await hass.async_block_till_done()
+
+    # Setup itself polls /context exactly once; the delta's debounced refresh
+    # is the second call.
+    assert mock_client.get_user_context.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_ws_sensor_flips_off_when_socket_drops(hass: HomeAssistant) -> None:
+    """A dropped socket flips the sensor OFF via the listener notification."""
+
+    class ClosingFakeWS(OpenFakeWS):
+        """Yields its frames, then closes instead of staying open."""
+
+        async def __anext__(self):
+            if self._frames:
+                return self._frames.pop(0)
+            raise StopAsyncIteration
+
+    def wire(client: MagicMock) -> None:
+        wire_connected_ws(client, [])
+        session = MagicMock()
+        # First session delivers one delta then closes; the reconnect attempt
+        # fails so the listener stays down for the rest of the test.
+        session.ws_connect = MagicMock(
+            side_effect=[
+                ClosingFakeWS([ws_text_frame("unit-1")]),
+                RuntimeError("down"),
+                RuntimeError("down"),
+            ]
+        )
+        client.async_ws_session = AsyncMock(return_value=session)
+
+    await setup_atw_integration_custom(
+        hass, create_mock_atw_user_context(), configure_client=wire
+    )
+
+    # The connect -> delta -> drop cycle involves no timers, but runs in a
+    # background task; poll until the drop has propagated to the entity.
+    state = None
+    for _ in range(100):
+        await hass.async_block_till_done()
+        state = hass.states.get(WS_ENTITY_ID)
+        if state and state.attributes["last_delta_at"] and state.state == STATE_OFF:
+            break
+        await asyncio.sleep(0.01)
+
+    assert state is not None
+    # last_delta_at proves it connected and delivered before dropping — the
+    # sensor being OFF is the drop, not a never-connected listener.
+    assert state.attributes["last_delta_at"] is not None
+    assert state.state == STATE_OFF
+
+
+@pytest.mark.asyncio
+async def test_unload_cancels_pending_debounced_refresh(hass: HomeAssistant) -> None:
+    """A delta received just before unload must not refresh after unload.
+
+    Regression: the pending 2s debounce task survived unload, fired against a
+    closed client session, and resurrected a fresh ClientSession that nothing
+    ever closed.
+    """
+    fake = OpenFakeWS([ws_text_frame("unit-1")])
+
+    def wire(client: MagicMock) -> None:
+        wire_connected_ws(client, [])
+        session = MagicMock()
+        session.ws_connect = MagicMock(return_value=fake)
+        client.async_ws_session = AsyncMock(return_value=session)
+
+    entry, mock_client = await setup_atw_integration_custom(
+        hass, create_mock_atw_user_context(), configure_client=wire
+    )
+
+    # Wait until the listener consumed the frame (the debounce is now pending)
+    # without block_till_done, which would wait out the debounce itself.
+    for _ in range(100):
+        if not fake._frames:
+            break
+        await asyncio.sleep(0.01)
+    for _ in range(5):
+        await asyncio.sleep(0)  # let the delta handler queue the debounce task
+
+    # Unload before the 2s debounce fires, then wait past its deadline.
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    baseline = mock_client.get_user_context.await_count
+    await asyncio.sleep(2.5)
+    await hass.async_block_till_done()
+
+    assert mock_client.get_user_context.await_count == baseline

--- a/tests/integration/test_coordinator_retry.py
+++ b/tests/integration/test_coordinator_retry.py
@@ -1,4 +1,12 @@
-"""Tests for coordinator retry logic on session expiry."""
+"""Tests for coordinator retry logic on session expiry.
+
+Deliberately white-box (documented exemption from the "test through
+hass.states/hass.services only" rule): retry/backoff behavior — the
+``retry_after`` values passed to ``UpdateFailed`` and the re-auth sequencing
+inside ``_execute_with_retry`` — is not observable through the public entity
+surface, and a black-box equivalent would mean flaky time-travel assertions.
+Do not cite this file as precedent for entity or coordinator-state tests.
+"""
 
 import asyncio
 import contextlib

--- a/tools/anonymize_har.py
+++ b/tools/anonymize_har.py
@@ -26,6 +26,10 @@ from typing import Any, cast
 # login/logout redirect URLs — in entries[] URLs/headers, in queryString[]
 # name/value pairs, and in pages[].title.
 SENSITIVE_PARAMS = {
+    # WebSocket credential (?hash=<per-user uuid>). The generic UUID pass
+    # happens to catch today's format; scrub it explicitly so a format
+    # change (base64/hex) can't slip through.
+    "hash",
     "sid",
     "nonce",
     "state",

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -154,7 +154,6 @@ AUTH_EXEMPT_PATHS = {
     "/connect/token",
     "/ws",
     "/ws/",
-    "/_mock/ws",
 }
 
 
@@ -432,7 +431,12 @@ class MockMELCloudServer:
                 self.ws_clients.discard(ws)
 
     async def handle_ws_control(self, request: web.Request) -> web.Response:
-        """POST /_mock/ws - test-only fault injection (auth-exempt)."""
+        """POST /_mock/ws - test-only fault injection (bearer-checked).
+
+        Requires the mock bearer like every other endpoint: the server binds
+        0.0.0.0 for Docker, so an unauthenticated control endpoint would let
+        any LAN peer inject faults when the mock runs outside a container.
+        """
         body = await request.json()
         action = body.get("action")
         if action == "close-now":


### PR DESCRIPTION
Fixes everything actionable from the v2.4.0 pre-release review (three parallel review passes over `v2.3.5..c801ba7`: core integration code, security, tests/CI).

## Security

- **Complete the #183 hash redaction.** `WSServerHandshakeError` stringifies with the full request URL including `?hash=<credential>`, so a failed handshake with debug logging enabled leaked the hash — exactly the support path where users paste logs into issues. The session-ended debug log now routes through the existing `_redact_url`.
- Strip CR/LF from server-supplied strings (unit IDs, setting names) before they reach log lines (unconditional sanitizer, per the CodeQL py/log-injection history).
- `anonymize_har.py` now scrubs the `hash` query param explicitly instead of relying on the generic UUID pass surviving a format change.

## Correctness

- **Cancel pending debounced refreshes on coordinator shutdown** (and call `super().async_shutdown()`). A WS delta ≤2s before unload left an orphan task that fired against the closed client and resurrected a fresh `ClientSession` nothing ever closed. Machine-timing reachable now that deltas arrive out-of-band and the options toggle reloads the entry.
- **Tolerate malformed WS frames.** A non-dict `Data` or non-list `settings` no longer escapes `_handle_text` and tears down the whole session for one bad frame.
- Hoist the connectivity sensor's unique-ID suffix into one constant (setup and entity built it independently; drift would silently break the opt-out orphan cleanup) and document that the service device deliberately survives opt-out.

## New regression tests

- **The headline seam:** WS delta → debounced `/context` refresh actually fires (previously only verified manually on prod; a wiring break would have shipped silently as 60s polling with CI green).
- Unload cancels the pending debounce (no post-unload refresh).
- Sensor flips OFF when the socket drops (proven via `last_delta_at` that it connected first).
- Re-opt-in after opt-out recreates the sensor through a real reload.
- Hash redaction on the session-ended log path; malformed-frame tolerance; CR/LF stripping.

Follow-up commit: `/_mock/ws` now requires the mock bearer (callers updated, 401 regression test), and `test_coordinator_retry`'s white-box approach is a documented exemption in its module docstring. Only remaining backlog item from the review: the floor-job runtime-install trade-off (accepted, documented in the Makefile).

Test results: 69 API WS/auth tests + 312 full API suite + 187 Docker integration tests all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
