### PR TITLE
fix: use context-sourced rssi for ATW wifi_signal sensor

### DIFF
--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -62,7 +62,6 @@ ATW_TELEMETRY_MEASURES = [
     "return_temperature_zone1",
     "flow_temperature_boiler",
     "return_temperature_boiler",
-    "rssi",  # WiFi signal strength in dBm
 ]
 
 # ATW telemetry measures for Zone 2 devices only

--- a/custom_components/melcloudhome/sensor_atw.py
+++ b/custom_components/melcloudhome/sensor_atw.py
@@ -218,9 +218,9 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda unit: unit.telemetry.get("rssi"),
+        value_fn=lambda unit: unit.rssi,
         should_create_fn=lambda unit: True,
-        available_fn=lambda unit: unit.telemetry.get("rssi") is not None,
+        available_fn=lambda unit: unit.rssi is not None,
     ),
     # Energy monitoring sensors
     # Created if device has energy capability (measured or estimated), even if no initial data

--- a/docs/api/atw-api-reference.md
+++ b/docs/api/atw-api-reference.md
@@ -222,6 +222,8 @@ Returns complete user context including all buildings, devices, current states, 
 
 **Note:** This endpoint is **shared** between ATA and ATW devices.
 
+**RSSI:** The unit object carries a top-level `rssi` field (dBm), refreshed on every `/context` poll (~60s) — same as ATA. This is a faster-updating duplicate of the `rssi` measure also available via telemetry (Section 8); prefer this field over telemetry polling for WiFi signal strength.
+
 ### Response Structure
 ```json
 {
@@ -246,6 +248,7 @@ Returns complete user context including all buildings, devices, current states, 
           "macAddress": "AABBCCDDEEFF",
           "timeZone": "Europe/Madrid",
           "ftcModel": 3,
+          "rssi": -54,
           "isConnected": true,
           "isInError": false,
           "settings": [...],
@@ -556,7 +559,7 @@ GET /telemetry/telemetry/actual/{unitId}?from=2026-01-18T16:00&to=2026-01-18T20:
 
 **Polling Recommendations:**
 - **Temperature measures:** Poll every 60 minutes (changes slowly)
-- **RSSI:** Poll every 60 minutes (diagnostic only)
+- **RSSI:** Don't poll this endpoint for RSSI — use the `rssi` field on `/context` instead (Section 2), which refreshes every ~60s instead of hourly
 - Use 4-hour lookback window for recent data
 
 ---

--- a/docs/api/device-type-comparison.md
+++ b/docs/api/device-type-comparison.md
@@ -219,6 +219,8 @@ Increments:    0.5°C or 1°C (if hasHalfDegrees)
 
 ## Telemetry Measures
 
+**Note:** `rssi` is listed below because it's technically exposed as a telemetry measure for both device types, but both also carry a top-level `rssi` field on `/context` that refreshes every ~60s (vs this endpoint's hourly cadence) — that's the field the integration actually uses, not telemetry polling.
+
 ### Air-to-Air Measures
 
 **3 primary measures:**

--- a/docs/api/melcloudhome-telemetry-endpoints.md
+++ b/docs/api/melcloudhome-telemetry-endpoints.md
@@ -16,16 +16,16 @@ This is a **complete API reference** documenting all read-only (GET) telemetry a
 
 **Currently Implemented:**
 - Energy consumption telemetry (Section 3) - Used for energy monitoring sensors in ATA devices
-- WiFi RSSI for ATA devices (sourced from UserContext, not telemetry polling endpoint)
+- WiFi RSSI for ATA and ATW devices (sourced from UserContext, not the telemetry polling endpoint)
 
 **Reference Only (Not Implemented):**
-- Actual telemetry data polling (Section 1) - Flow/return temps for ATW, RSSI via polling endpoint
+- Actual telemetry data polling (Section 1) - Flow/return temps for ATW
 - Operation mode history (Section 4) - Historical operation tracking
 - Error log endpoint (Section 2) - Device error history
 - Report types (Section 5) - Historical reporting features
 
 **Why not implemented?**
-- UserContext already provides current temperatures (zone, tank) and RSSI for ATA
+- UserContext already provides current temperatures (zone, tank) and RSSI for both ATA and ATW — the `rssi` measure exposed by this telemetry endpoint (Section 1) is a slower-refreshing duplicate of the same field
 - Telemetry polling requires separate API call per measure per device (significant API load)
 - Energy monitoring is the high-value use case and is implemented
 - Additional sensors (flow/return temps for ATW) can be added in future releases if users request them
@@ -330,11 +330,11 @@ GET /monitor/ataunit/{id}/errorlog
 
 ### Wi-Fi Signal Monitoring
 ```python
-# Track connectivity
-GET /telemetry/telemetry/actual/{id}?from={now-1h}&to={now}&measure=rssi
+# Prefer the context poll — refreshes every ~60s vs this endpoint's hourly cadence
+GET /context  # unit.rssi, for both ATA and ATW
 
-# Create HA sensor for RSSI
-# Alert on weak signal
+# Only fall back to telemetry polling if a historical RSSI trend is needed
+GET /telemetry/telemetry/actual/{id}?from={now-1h}&to={now}&measure=rssi
 ```
 
 ### Operation Mode Tracking

--- a/tests/integration/test_sensor_atw.py
+++ b/tests/integration/test_sensor_atw.py
@@ -340,7 +340,7 @@ async def test_atw_outdoor_temperature_not_created_when_none(
 
 @pytest.mark.asyncio
 async def test_atw_rssi_sensor_created(hass: HomeAssistant) -> None:
-    """Test ATW WiFi signal (RSSI) sensor is created (starts unavailable until telemetry fetched)."""
+    """Test ATW WiFi signal sensor uses RSSI from the current unit context."""
     mock_unit = create_mock_atw_unit()
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
@@ -349,7 +349,6 @@ async def test_atw_rssi_sensor_created(hass: HomeAssistant) -> None:
 
     wifi_state = hass.states.get("sensor.melcloudhome_0efc_9abc_wifi_signal")
     assert wifi_state is not None
-    # Sensor starts unavailable (no telemetry fetched yet - that happens on schedule)
-    assert wifi_state.state == "unavailable"
+    assert wifi_state.state == "-50"
     assert wifi_state.attributes["unit_of_measurement"] == "dBm"
     assert wifi_state.attributes["device_class"] == "signal_strength"


### PR DESCRIPTION
## Summary

- Read the ATW WiFi signal from the current unit context instead of hourly telemetry
- Use the same context value when determining sensor availability
- Update the integration test to verify the context RSSI is exposed immediately

## Why

The ATW model already receives `unit.rssi` from the coordinator's 60-second
context refresh. The sensor was instead reading the telemetry dictionary,
which updates on a slower cadence and could leave the displayed signal
stale or unavailable.

Fixes #198

## Validation

- `ruff check` / `ruff format --check` / `mypy` / pre-commit — all pass
- `tests/integration/test_sensor_atw.py::test_atw_rssi_sensor_created` — pass
- Verified against a real captured `/context` response (VCR cassette) — ATW
  units do carry a top-level `rssi` field on the context poll, not just telemetry
- Soak-tested on production against real ATW hardware

## Docs

Corrected `docs/api/atw-api-reference.md`, `docs/api/device-type-comparison.md`,
and `docs/api/melcloudhome-telemetry-endpoints.md`, which documented ATW `rssi`
as telemetry-only — verified against a real `/context` capture that it's also
exposed there, same as ATA.