### PR TITLE
docs: use placeholder IDs in example and mock fixture

### DIFF
--- a/docs/archive/research/websocket-research-defer.md
+++ b/docs/archive/research/websocket-research-defer.md
@@ -199,8 +199,12 @@ wss://ws.melcloudhome.com/?hash={hash}
 ## Documentation for Future Reference
 
 ### Working cURL Command
+
+The `hash` query parameter is the per-account WebSocket token returned by the
+token endpoint — supply your own; the placeholder below is not a real value.
+
 ```bash
-curl 'wss://ws.melcloudhome.com/?hash=0125be99-65cb-4c97-a705-24794d6774b7' \
+curl 'wss://ws.melcloudhome.com/?hash=<your-ws-hash>' \
   -H 'Upgrade: websocket' \
   -H 'Origin: https://melcloudhome.com' \
   -H 'Connection: Upgrade' \

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -253,7 +253,7 @@ class MockMELCloudServer:
                 "ftc_model": 4,  # API internal value, mapping to physical FTC controller unknown
                 "outdoor_temperature": 7.5,
             },
-            "aed2afac-01a5-4c4c-8d58-95989aa1c71e": {
+            "aed21234-5678-9abc-def0-123456789abc": {
                 "name": "Dual Zone Heat Pump",
                 "power": True,
                 "operation_mode": "Heating",
@@ -301,7 +301,7 @@ class MockMELCloudServer:
                 "name": "Shared Building",
                 "timezone": "Europe/Madrid",
                 "ata_unit_ids": [],
-                "atw_unit_ids": ["aed2afac-01a5-4c4c-8d58-95989aa1c71e"],
+                "atw_unit_ids": ["aed21234-5678-9abc-def0-123456789abc"],
             },
         }
 


### PR DESCRIPTION
Small follow-up tidy-up: use placeholder identifiers in an archived research example (`websocket-research-defer.md`) and the "Dual Zone Heat Pump" mock fixture (`mock_melcloud_server.py`), matching the placeholder style used elsewhere in the repo.

Docs/tooling only, no behaviour change. `make test-api` green (316 passed); mock-server tests green.
