### PR TITLE
chore: correct DEV-SETUP mock devices; make the mock emit ATA protection modes

### DIFF
--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -68,12 +68,12 @@ The "Connect to Mock Server" checkbox connects to the mock server instead of pro
 
 ### Mock Server Test Devices
 
-The mock server provides three pre-configured test devices:
+The mock server provides four pre-configured test devices, defined inline in `tools/mock_melcloud_server.py`:
 
 **ATA Devices (Air-to-Air Heat Pumps):**
 
-1. **Living Room**
-   - UUID: `0efc1234-5678-9abc-def0-123456787db`
+1. **Living Room AC**
+   - UUID: `0efc1234-5678-9abc-def0-1234567887db`
    - Entity prefix: `melcloudhome_0efc_87db`
    - Example entity: `climate.melcloudhome_0efc_87db_climate`
    - Model: MSZ-AP35VG
@@ -82,17 +82,17 @@ The mock server provides three pre-configured test devices:
    - Vane control: Horizontal and Vertical
    - Current: 20°C → Target: 22°C
 
-2. **Bedroom**
+2. **Bedroom AC**
    - UUID: `bf8d5678-90ab-cdef-0123-456789ab5119`
    - Entity prefix: `melcloudhome_bf8d_5119`
    - Example entity: `climate.melcloudhome_bf8d_5119_climate`
    - Model: MSZ-LN25VG
-   - Same capabilities as Living Room
+   - Same capabilities as Living Room AC
    - Current: 18°C → Target: 20°C
 
-**ATW Device (Air-to-Water Heat Pump / Ecodan):**
+**ATW Devices (Air-to-Water Heat Pumps / Ecodan):**
 
-3. **Ecodan System**
+3. **House Heat Pump**
    - UUID: `bf2d256c-42ac-4799-a6d8-c6ab433e5666`
    - Entity prefix: `melcloudhome_bf2d_5666`
    - Example entities:
@@ -105,10 +105,21 @@ The mock server provides three pre-configured test devices:
    - Outside temperature: 5°C
    - 3-way valve: Zone heating mode
 
+4. **Dual Zone Heat Pump**
+   - UUID: `aed21234-5678-9abc-def0-123456789abc`
+   - Entity prefix: `melcloudhome_aed2_9abc`
+   - Mock device (ftcModel: 5), two heating zones (`hasZone2: true`)
+   - Zone 1: Target 19°C, Current 21°C — Zone 2: Target 21°C, Current 21°C
+   - Hot water tank: Target 40°C, Current 40°C
+   - Outside temperature: 3°C
+
+Devices 1–3 belong to the owned building "My Home" (`Europe/London`). Device 4 sits in the guest building "Shared Building" (`Europe/Madrid`), so it exercises the shared-access code path — the same topology as a real account with guest access to someone else's building.
+
 **Customizing Mock Data:**
 
-To modify device characteristics or add new devices:
-1. Edit `mock-server/data/*.json` files
+Device definitions live inline in `tools/mock_melcloud_server.py` — `_init_ata_devices()` / `_init_atw_devices()` for the devices themselves, and `_init_buildings()` / `_init_guest_buildings()` for which building each one belongs to. To modify device characteristics or add new devices:
+
+1. Edit `tools/mock_melcloud_server.py`
 2. Rebuild mock server: `make dev-rebuild`
 3. Restart environment: `make dev-restart`
 

--- a/docs/api/ata-api-reference.md
+++ b/docs/api/ata-api-reference.md
@@ -5,8 +5,8 @@
 > - For Air-to-Water heat pumps, see [atw-api-reference.md](atw-api-reference.md)
 > - For device type comparison, see [device-type-comparison.md](device-type-comparison.md)
 
-**Document Version:** 1.6
-**Last Updated:** 2026-07-20
+**Document Version:** 1.7
+**Last Updated:** 2026-07-27
 **Device Type:** Air-to-Air Air Conditioning Units
 **Method:** Passive UI observation; some sections verified by driven capture — see per-section evidence notes
 
@@ -1046,6 +1046,7 @@ Two sources feed this section: a passive 2026-07-11 HAR review of the web app (d
 | 1.4 | 2026-07-20 | Added Scenes section and legacy-web Trend Summary variant, sourced from 2026-07-11 web-app HAR capture |
 | 1.5 | 2026-07-20 | Added Schedules section (cloud-schedule CRUD), sourced from 2026-07-11 web-app HAR capture |
 | 1.6 | 2026-07-20 | Schedules section rewritten with confirmed data from a live driven capture: day-number encoding and int-typed mode/fan/vane fields moved from inferred to confirmed; documented the Update (PUT) endpoint and its distinct nested body shape |
+| 1.7 | 2026-07-27 | Flagged the mobile-BFF `/monitor/holidaymode` route as reported-but-unverified rather than confirmed, as no capture artifact backs it |
 
 **Data Collection Session:** 2025-11-16
 **Equipment:** Mitsubishi Electric air conditioning system

--- a/tests/api/test_mock_ws_server.py
+++ b/tests/api/test_mock_ws_server.py
@@ -68,7 +68,7 @@ async def test_ws_inbound_frames_ignored_and_disconnect_cleans_up(mock_client):
     assert server.ws_clients == set()
 
 
-ATA_ID = "0efc1234-5678-9abc-def0-123456787db"  # Living Room AC (seeded)
+ATA_ID = "0efc1234-5678-9abc-def0-1234567887db"  # Living Room AC (seeded)
 
 
 async def test_put_emits_typed_delta_to_all_sockets(mock_client):

--- a/tests/api/test_rate_limiting_e2e.py
+++ b/tests/api/test_rate_limiting_e2e.py
@@ -29,7 +29,7 @@ class TestRateLimitingE2E:
         Requires: make dev-up (mock server with rate limiting enabled)
 
         Mock server devices:
-        - ATA 1: 0efc1234-5678-9abc-def0-123456787db (Living Room AC)
+        - ATA 1: 0efc1234-5678-9abc-def0-1234567887db (Living Room AC)
         - ATA 2: bf8d5678-90ab-cdef-0123-456789ab5119 (Bedroom AC)
         - ATW 1: bf2d256c-42ac-4799-a6d8-c6ab433e5666 (House Heat Pump)
         """

--- a/tests/integration/test_binary_sensor_ata.py
+++ b/tests/integration/test_binary_sensor_ata.py
@@ -157,10 +157,16 @@ async def test_connection_sensor_always_available(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.asyncio
-async def test_frost_protection_only_created_when_configured(
+async def test_frost_protection_created_when_api_reports_object(
     hass: HomeAssistant,
 ) -> None:
-    """Test frost protection sensor is only created for units with the mode ever set."""
+    """Test frost protection sensor is created only when the API reports the object.
+
+    Every real ATA unit carries a frostProtection object as a server-side default,
+    so in practice this sensor is created for all of them - it is not gated on the
+    owner having ever configured the mode. Overheat protection and holiday mode are
+    the ones the API leaves null until first configured.
+    """
     unit_with_frost = create_mock_ata_unit(
         unit_id="aaaa1234-5678-9abc-def0-123456789999",
         name="Unit With Frost",

--- a/tests/integration/test_outdoor_temperature_sensor.py
+++ b/tests/integration/test_outdoor_temperature_sensor.py
@@ -19,7 +19,7 @@ from .conftest import (
 )
 
 # Test device UUIDs (match mock server IDs)
-LIVING_ROOM_ID = "0efc1234-5678-9abc-def0-123456787db"  # Has outdoor sensor
+LIVING_ROOM_ID = "0efc1234-5678-9abc-def0-1234567887db"  # Has outdoor sensor
 BEDROOM_ID = "5b3e4321-8765-cba9-fed0-abcdef987a9b"  # No outdoor sensor
 STUDY_ID = "a1b2c3d4-e5f6-7890-abcd-ef0123456789"  # Has outdoor sensor (2nd unit)
 TEST_BUILDING_ID = "building-test-id"

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -201,7 +201,7 @@ class MockMELCloudServer:
         Note: Using UUIDs for cleaner entity names (e.g., "MELCloudHome 0efc 76db")
         """
         return {
-            "0efc1234-5678-9abc-def0-123456787db": {
+            "0efc1234-5678-9abc-def0-1234567887db": {
                 "name": "Living Room AC",
                 "power": True,
                 "operation_mode": "Heat",
@@ -282,7 +282,7 @@ class MockMELCloudServer:
                 "name": "My Home",
                 "timezone": "Europe/London",
                 "ata_unit_ids": [
-                    "0efc1234-5678-9abc-def0-123456787db",
+                    "0efc1234-5678-9abc-def0-1234567887db",
                     "bf8d5678-90ab-cdef-0123-456789ab5119",
                 ],
                 "atw_unit_ids": ["bf2d256c-42ac-4799-a6d8-c6ab433e5666"],
@@ -1177,7 +1177,7 @@ class MockMELCloudServer:
             current += timedelta(minutes=10)
 
         # Check if device has outdoor sensor (Living Room AC has it, Bedroom doesn't)
-        has_outdoor_sensor = unit_id == "0efc1234-5678-9abc-def0-123456787db"
+        has_outdoor_sensor = unit_id == "0efc1234-5678-9abc-def0-1234567887db"
 
         datasets = [
             {

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -212,6 +212,26 @@ class MockMELCloudServer:
                 "vane_horizontal_direction": "Auto",
                 "in_standby_mode": False,
                 "is_in_error": False,
+                # All three configured, so the full set of protection-mode
+                # entities is exercised in the dev environment.
+                "frost_protection": {
+                    "active": False,
+                    "enabled": True,
+                    "min": 10,
+                    "max": 12,
+                },
+                "overheat_protection": {
+                    "active": False,
+                    "enabled": False,
+                    "min": 35,
+                    "max": 37,
+                },
+                "holiday_mode": {
+                    "enabled": True,
+                    "active": False,
+                    "startDate": "2026-07-20T18:30:53.79",
+                    "endDate": "2026-07-22T12:00:00",
+                },
             },
             "bf8d5678-90ab-cdef-0123-456789ab5119": {
                 "name": "Bedroom AC",
@@ -224,6 +244,18 @@ class MockMELCloudServer:
                 "vane_horizontal_direction": "Centre",
                 "in_standby_mode": False,
                 "is_in_error": False,
+                # Frost protection only, at the server-side default the real API
+                # returns for every ATA unit whether or not it was ever set up.
+                # Overheat and holiday mode stay null, so this unit covers the
+                # "entity not created" path.
+                "frost_protection": {
+                    "active": False,
+                    "enabled": False,
+                    "min": 10,
+                    "max": 12,
+                },
+                "overheat_protection": None,
+                "holiday_mode": None,
             },
         }
 
@@ -272,6 +304,20 @@ class MockMELCloudServer:
                 "ftc_model": 5,
                 "outdoor_temperature": 3.0,
             },
+        }
+
+    def _ata_protection_modes(self, unit_id: str) -> dict[str, Any]:
+        """Return the unit-level protection-mode objects for an ATA unit.
+
+        These sit alongside "settings" and "capabilities" in the real /context
+        payload, not inside them, and are null until the mode has been configured
+        (except frostProtection, which the API defaults on every unit).
+        """
+        state = self.ata_states[unit_id]
+        return {
+            "frostProtection": state.get("frost_protection"),
+            "overheatProtection": state.get("overheat_protection"),
+            "holidayMode": state.get("holiday_mode"),
         }
 
     def _init_buildings(self) -> dict[str, dict[str, Any]]:
@@ -594,6 +640,7 @@ class MockMELCloudServer:
                         "settings": self._build_ata_settings(unit_id),
                         "capabilities": self._get_ata_capabilities(),
                         "schedule": [],
+                        **self._ata_protection_modes(unit_id),
                     }
                 )
 
@@ -638,6 +685,7 @@ class MockMELCloudServer:
                         "settings": self._build_ata_settings(unit_id),
                         "capabilities": self._get_ata_capabilities(),
                         "schedule": [],
+                        **self._ata_protection_modes(unit_id),
                     }
                 )
 


### PR DESCRIPTION
Follow-up cleanup from #205 and #207. 

## `DEV-SETUP.md` — "Mock Server Test Devices" was wrong in four ways

The section is meant to tell a developer what they'll see in the HA UI after connecting to the mock server. It didn't:

- **Device count.** Claimed three devices; `tools/mock_melcloud_server.py` defines four. Adds the missing Dual Zone Heat Pump, and notes it belongs to the guest building (served under `guestBuildings` in `/context`) so it exercises the shared-access path — the same topology as a real account with guest access.
- **Device names didn't match the mock.** A developer looking for "Ecodan System" in the UI would find "House Heat Pump". Headings now match the names the mock actually reports.
- **Customizing instructions pointed at a path that has never existed** (`mock-server/data/*.json`). Now points at `tools/mock_melcloud_server.py` and names the four init methods that own device and building definitions.
- **Living Room UUID was malformed** — 11 hex characters in the final group instead of 12. Padded to a valid 12. The derived entity prefix (`melcloudhome_0efc_87db`) is unchanged, so no existing dev entity registry is affected. The same literal appears in three test files (`test_mock_ws_server.py`, `test_rate_limiting_e2e.py`, `test_outdoor_temperature_sensor.py`), which is why they show in the diff.

## Test rename

`test_frost_protection_only_created_when_configured` → `test_frost_protection_created_when_api_reports_object`.

The assertion was always correct; the name carried a premise that #205's review corrected. Every ATA unit gets a `frostProtection` object as a server-side default, so the entity is created whenever the API reports the object — it is not gated on the owner ever having configured the mode. Overheat protection and holiday mode are the genuinely null-until-configured ones.

## Missing document-history row

`docs/api/ata-api-reference.md` gained an evidence note in #205 without a corresponding `Document History` row. Adds `1.7` and bumps the header.

## Verification

`make pre-commit` clean. `make test-api` 321 passed. `make test-integration` 200 passed (Docker images rebuilt first, since the mock server UUID changed).

---

## The mock server now emits the ATA protection-mode objects

Deploying `main` to the dev stack showed that **#205's nine new entities could not be exercised locally at all**. `frostProtection`, `overheatProtection` and `holidayMode` appeared zero times in `tools/mock_melcloud_server.py`, so the integration set up cleanly and created none of them — there were no fields to gate on. #205's own tests pass because they build unit contexts directly rather than going through the mock, and `make test-e2e` never touched this either.

The objects sit alongside `settings` and `capabilities` at unit level, matching the real `/context` payload, and are emitted from one helper shared by the owned-building and guest-building builders.

Values follow what real hardware returns:

- **Living Room AC** has all three configured, so the full set of entities appears.
- **Bedroom AC** has only `frostProtection`, at the server-side default the API reports for every ATA unit whether or not the owner ever set it up, with the other two null. That covers the not-created path.

Verified in the dev environment: **12 protection-mode entities** now appear — nine on Living Room AC, three (frost only) on Bedroom AC — and the sensor platform count goes from 36 to 44. That is the first time #205's entities have been seen outside a unit test.

