### PR TITLE
docs: use self-evidently-fake stand-in IDs in docs and dev tools

### DIFF
--- a/docs/api/ata-api-reference.md
+++ b/docs/api/ata-api-reference.md
@@ -677,7 +677,7 @@ Returns historical temperature data for chart display. Used by integration to fe
 **Example Request:**
 
 ```
-GET /report/v1/trendsummary?unitId=4c6fd61a-c825-4cb5-300e-3d0ba2c70c01&period=Daily&from=2026-02-02T12:30:00.0000000&to=2026-02-03T12:30:00.0000000
+GET /report/v1/trendsummary?unitId=aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825&period=Daily&from=2026-02-02T12:30:00.0000000&to=2026-02-03T12:30:00.0000000
 ```
 
 **Response:**
@@ -1049,4 +1049,4 @@ Two sources feed this section: a passive 2026-07-11 HAR review of the web app (d
 
 **Data Collection Session:** 2025-11-16
 **Equipment:** Mitsubishi Electric air conditioning system
-**Location:** Dining Room unit (4c6fd61a-c825-4cb5-300e-3d0ba2c70c01)
+**Location:** Dining Room unit (aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825)

--- a/docs/api/atw-api-reference.md
+++ b/docs/api/atw-api-reference.md
@@ -610,7 +610,7 @@ GET /telemetry/telemetry/energy/{unitId}?from=2026-01-16+20:00&to=2026-01-18+20:
 **Actual Response Format** (from VCR cassette):
 ```json
 {
-  "deviceId": "a3f61c8e-9b24-4d17-8e5a-6f2d91c47b30",
+  "deviceId": "aaaaaaaa-aaaa-aaaa-aaaa-a3f61c8e9b24",
   "measureData": [{
     "type": "intervalEnergyConsumed",
     "values": [

--- a/docs/api/melcloudhome-telemetry-endpoints.md
+++ b/docs/api/melcloudhome-telemetry-endpoints.md
@@ -60,7 +60,7 @@ Retrieves time-series data for various measurements over a specified time range.
 
 **Example Request:**
 ```
-GET /telemetry/telemetry/actual/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01?from=2025-11-16%2008:00&to=2025-11-16%2008:59&measure=room_temperature
+GET /telemetry/telemetry/actual/aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825?from=2025-11-16%2008:00&to=2025-11-16%2008:59&measure=room_temperature
 ```
 
 **Response Format:**
@@ -68,7 +68,7 @@ GET /telemetry/telemetry/actual/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01?from=2025-1
 {
   "measureData": [
     {
-      "deviceId": "4c6fd61a-c825-4cb5-300e-3d0ba2c70c01",
+      "deviceId": "aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825",
       "type": "roomTemperature",
       "values": [
         {
@@ -123,7 +123,7 @@ Retrieves operation mode changes over a specified time range.
 
 **Example Request:**
 ```
-GET /telemetry/telemetry/operationmode/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01?from=2025-11-16%2008:00&to=2025-11-16%2008:33
+GET /telemetry/telemetry/operationmode/aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825?from=2025-11-16%2008:00&to=2025-11-16%2008:33
 ```
 
 **Response Format:**
@@ -131,7 +131,7 @@ GET /telemetry/telemetry/operationmode/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01?from
 {
   "operationModeData": [
     {
-      "deviceId": "4c6fd61a-c825-4cb5-300e-3d0ba2c70c01",
+      "deviceId": "aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825",
       "values": [
         {
           "time": "2025-11-16 08:00:00.000000000",
@@ -172,13 +172,13 @@ Retrieves energy consumption data over a specified time range.
 
 **Example Request:**
 ```
-GET /telemetry/telemetry/energy/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01?from=2025-11-16%2000:00&to=2025-11-16%2023:59&interval=Hour&measure=cumulative_energy_consumed_since_last_upload
+GET /telemetry/telemetry/energy/aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825?from=2025-11-16%2000:00&to=2025-11-16%2023:59&interval=Hour&measure=cumulative_energy_consumed_since_last_upload
 ```
 
 **Response Format:**
 ```json
 {
-  "deviceId": "4c6fd61a-c825-4cb5-300e-3d0ba2c70c01",
+  "deviceId": "aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825",
   "measureData": [
     {
       "type": "cumulativeEnergyConsumedSinceLastUpload",
@@ -236,7 +236,7 @@ Retrieves error history for the specified unit.
 
 **Example Request:**
 ```
-GET /monitor/ataunit/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01/errorlog
+GET /monitor/ataunit/aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825/errorlog
 ```
 
 **Response Format (No Errors):**
@@ -278,12 +278,12 @@ The MELCloud Home UI provides 4 report types:
 - **Endpoint:** `/telemetry/telemetry/actual/{unit_id}`
 - **Measures:** `room_temperature`, `set_temperature`
 - **Time ranges:** Hour, Day, Week, Month
-- **URL:** `/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01/trendsummary`
+- **URL:** `/aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825/trendsummary`
 
 ### 2. ERROR LOG Report
 - **Endpoint:** `/monitor/ataunit/{unit_id}/errorlog`
 - **Shows:** Error code, start time, end time
-- **URL:** `/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01/uniterrorlog`
+- **URL:** `/aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825/uniterrorlog`
 
 ### 3. ENERGY Report
 - **Endpoint:** `/telemetry/telemetry/energy/{unit_id}`
@@ -504,4 +504,4 @@ async def safe_telemetry_fetch(session, unit_id, measure):
 
 **Discovery Session:** 2025-11-16
 **Equipment:** Mitsubishi Electric air conditioning system
-**Location:** Dining Room unit (4c6fd61a-c825-4cb5-300e-3d0ba2c70c01)
+**Location:** Dining Room unit (aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825)

--- a/docs/archive/research/ATW/user_context_ata_only_chrome_override.json
+++ b/docs/archive/research/ATW/user_context_ata_only_chrome_override.json
@@ -1,5 +1,5 @@
 {
-  "id": "e619c4a2-7db8-4f36-9a1e-52c8306fd914",
+  "id": "aaaaaaaa-aaaa-aaaa-aaaa-e619c4a27db8",
   "firstname": "John",
   "lastname": "Doe",
   "email": "user@example.com",

--- a/docs/archive/research/energy-monitoring-requirements.md
+++ b/docs/archive/research/energy-monitoring-requirements.md
@@ -42,13 +42,13 @@ MELCloud Home API provides energy consumption data via a telemetry endpoint. Thi
 
 **Example Request:**
 ```
-GET /api/telemetry/energy/4c6fd61a-c825-4cb5-300e-3d0ba2c70c01?from=2025-11-16%2000:00&to=2025-11-16%2023:59&interval=Hour&measure=cumulative_energy_consumed_since_last_upload
+GET /api/telemetry/energy/aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825?from=2025-11-16%2000:00&to=2025-11-16%2023:59&interval=Hour&measure=cumulative_energy_consumed_since_last_upload
 ```
 
 **Example Response:**
 ```json
 {
-  "deviceId": "4c6fd61a-c825-4cb5-300e-3d0ba2c70c01",
+  "deviceId": "aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825",
   "measureData": [
     {
       "type": "cumulativeEnergyConsumedSinceLastUpload",

--- a/docs/archive/research/websocket-research-defer.md
+++ b/docs/archive/research/websocket-research-defer.md
@@ -62,7 +62,7 @@ wss://ws.melcloudhome.com/?hash={hash}
   {
     "messageType": "unitStateChanged",
     "Data": {
-      "id": "40e80e68-f338-e41f-787d-40a7fbaf0624",
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-40e80e68f338",
       "unitType": "ata",
       "settings": [
         {"name": "Power", "value": "False"},

--- a/docs/decisions/008-energy-monitoring-architecture.md
+++ b/docs/decisions/008-energy-monitoring-architecture.md
@@ -36,13 +36,13 @@ GET /api/telemetry/energy/{unit_id}
 
 **Test Date:** 2025-11-19
 **Test Devices:**
-- Dining Room (4c6fd61a-c825-4cb5-300e-3d0ba2c70c01) ✅
-- Living Room (d22a6c27-1c6a-bf9f-dd1b-0bb2642a1112) ✅
+- Dining Room (aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825) ✅
+- Living Room (aaaaaaaa-aaaa-aaaa-aaaa-d22a6c271c6a) ✅
 
 **Sample Data:**
 ```json
 {
-  "deviceId": "4c6fd61a-c825-4cb5-300e-3d0ba2c70c01",
+  "deviceId": "aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825",
   "measureData": [{
     "type": "cumulativeEnergyConsumedSinceLastUpload",
     "values": [

--- a/docs/decisions/016-implement-atw-energy-monitoring.md
+++ b/docs/decisions/016-implement-atw-energy-monitoring.md
@@ -336,7 +336,7 @@ def _has_energy_production_capability(unit: AirToWaterUnit) -> bool:
 **Testing:**
 - API tests: `tests/api/test_energy_atw.py` (73 tests)
 - Integration tests: `tests/integration/test_sensor_atw.py` (123 tests)
-- Test device: Belgrade ERSC-VM2D (unit ID: `a3f61c8e-9b24-4d17-8e5a-6f2d91c47b30`)
+- Test device: Belgrade ERSC-VM2D (unit ID: `aaaaaaaa-aaaa-aaaa-aaaa-a3f61c8e9b24`)
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,16 @@ MOBILE_BFF_HOST = "mobile.bff.melcloudhome.com"
 # already-scrubbed ID into a different one. That makes the function
 # idempotent by construction - no "are we actually recording" gate needed,
 # and no cache to remember which values it has already emitted.
+#
+# Heads-up if you ever re-record against a live account: the placeholders
+# currently committed in tests/api/cassettes/ were produced by an earlier
+# derivation than the one below, so re-recording will emit *different*
+# placeholders for the same real IDs. Both are equally valid - they are
+# opaque stand-ins, nothing decodes them - but the *_unit_id fixtures at the
+# bottom of this file hardcode the committed values, so update them in the
+# same commit or VCR's URI matching will fail to find the interaction.
+# Deliberately not rewritten up front: it would churn every cassette to avoid
+# one self-announcing test failure.
 def pseudonymize_uuid(value: str) -> str:
     """Deterministically replace a UUID with a stable, self-evidently-fake placeholder."""
     lowered = value.lower()

--- a/tools/energy_monitoring_recorder.py
+++ b/tools/energy_monitoring_recorder.py
@@ -20,7 +20,7 @@ Usage:
     python energy_monitoring_recorder.py --duration 180
 
     # Focus on specific unit
-    python energy_monitoring_recorder.py --unit-id 4c6fd61a-c825-4cb5-300e-3d0ba2c70c01
+    python energy_monitoring_recorder.py --unit-id aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825
 
 Environment:
     MELCLOUD_USER - MELCloud email

--- a/tools/test_vane_positions.py
+++ b/tools/test_vane_positions.py
@@ -71,7 +71,7 @@ async def main() -> None:
 
     # Get unit ID from command line or use default
     unit_id = (
-        sys.argv[1] if len(sys.argv) > 1 else "4c6fd61a-c825-4cb5-300e-3d0ba2c70c01"
+        sys.argv[1] if len(sys.argv) > 1 else "aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825"
     )
 
     print("MELCloud Home Vane Position Test")


### PR DESCRIPTION
Five stand-in UUIDs in `docs/` and `tools/` were shaped like real device IDs, so a reader couldn't tell at a glance they were placeholders. That cost real time twice this week while verifying #206/#207 — checking whether a value was an actual leak. Reshapes them to the self-evidently-fake `aaaaaaaa-…` form already used by `tools/anonymize_har.py` and the VCR cassette scrub, keeping the first twelve digits of each old value so the rename stays traceable in review.

**Left alone deliberately:** the mock server's own IDs (`bf2d256c`, `bf8d5678`, `aed21234`, `0efc1234`) and the hand-made `bf8d5119` in `docs/entities.md`. Those are established dev fixtures wired into tests and documented entity prefixes; renaming them would churn tests for no gain.

## Also: a note next to `pseudonymize_uuid`, instead of regenerating the cassettes

The placeholders currently committed in `tests/api/cassettes/` are one hash step further on than `pseudonymize_uuid` emits from the original IDs — #206's regeneration ran over its own first-commit output rather than the originals. It makes no difference on replay, because the function correctly no-ops on anything already in placeholder shape, but a future re-record will emit different (equally valid) placeholders and the `*_unit_id` fixtures hardcode the committed ones.

I deliberately did **not** regenerate. The cost of the drift is a single test failure that announces itself at exactly the moment it matters, to someone who is already re-recording; the cost of the fix would be rewriting 800+ occurrences across every cassette for the second time in a week, making `git blame` and any future bisect over those files worse. So the quirk is documented where the next person will hit it, with the reasoning, so it doesn't get "fixed" by reflex later.

## Verification

`make pre-commit` clean. `make test-api` 321 passed.

Nothing in the shipped integration is touched. Beyond docs, the diff covers a comment in `tests/conftest.py`, a docstring example in `tools/energy_monitoring_recorder.py`, and one executable line — the fallback unit id in `tools/test_vane_positions.py:74`, used when the script is run with no argument. That value was already a placeholder, so running it with no argument fails against the API exactly as it did before; it now just looks like a placeholder.

