### PR TITLE
chore: ignore Claude Code local state in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,25 @@
 # Environment
 .env
-.claude/settings.local.json
 CLAUDE.local.md
 
 # Internal development documentation
 _claude/
+
+# Claude Code local state. Per-machine runtime files and scratch state - none of
+# it is shareable, and some (agent registry, mailbox, scheduled tasks) holds
+# absolute paths or session data. Committed configuration under .claude/ that IS
+# shared, such as settings.json, is deliberately not listed here.
+.claude/settings.local.json
+.claude/scheduled_tasks.json
+.claude/scheduled_tasks.lock
+.claude/routines/.state/
+.claude/worktrees/
+.claude/checkpoints/
+.claude/mailbox/
+.claude/agent-registry.json
+.claude/agent-memory-local/
+.claude/first-run
+.claude/assistant-daemon-state.json
 
 # Home Assistant Configuration (not part of HACS distribution)
 automations.yaml


### PR DESCRIPTION
These patterns only ever lived in `.git/info/exclude`, which Claude Code writes automatically under a `# claude-code-runtime` marker. That file is per-clone and never committed, so on a fresh clone — or for anyone else running Claude Code against this repo — none of this runtime state was ignored. It would show up untracked, with a real chance of being committed by a `git add -A`. Some of it (`agent-registry.json`, `mailbox/`, `scheduled_tasks.json`) holds absolute paths and session data.

Moving the patterns into `.gitignore` makes the rules travel with the repo.

Committed configuration under `.claude/` that IS meant to be shared — `settings.json` and anything else checked in deliberately — is not listed, so this only affects local scratch state.

Verified: `make pre-commit` clean, and the new patterns confirmed to match by creating throwaway files under `.claude/` and checking `git check-ignore`.
