### PR TITLE
fix: don't let a missing reading suppress sensor creation

### DIFF
--- a/custom_components/melcloudhome/sensor.py
+++ b/custom_components/melcloudhome/sensor.py
@@ -47,13 +47,7 @@ async def async_setup_entry(
                 unit.outdoor_temperature,
             )
             for description in ATA_SENSOR_TYPES:
-                # Use should_create_fn if defined, otherwise use available_fn
-                create_check = (
-                    description.should_create_fn
-                    if description.should_create_fn
-                    else description.available_fn
-                )
-                if create_check(unit):
+                if description.should_create_fn(unit):
                     entities.append(
                         ATASensor(coordinator, unit, building, entry, description)
                     )

--- a/custom_components/melcloudhome/sensor_ata.py
+++ b/custom_components/melcloudhome/sensor_ata.py
@@ -40,8 +40,13 @@ class ATASensorEntityDescription(SensorEntityDescription):  # type: ignore[misc]
     available_fn: Callable[[AirToAirUnit], bool] = lambda x: True
     """Function to determine if sensor is available."""
 
-    should_create_fn: Callable[[AirToAirUnit], bool] | None = None
-    """Function to determine if sensor should be created. If None, uses available_fn."""
+    should_create_fn: Callable[[AirToAirUnit], bool] = lambda x: True
+    """Whether to create the sensor at all.
+
+    Must test something stable about the unit (a capability, a model trait) - never
+    a value that comes and goes, because creation is only evaluated once at setup.
+    Use available_fn for anything transient.
+    """
 
     attributes_fn: Callable[[AirToAirUnit], dict[str, Any]] | None = None
     """Function to extract extra state attributes from unit data."""

--- a/custom_components/melcloudhome/sensor_atw.py
+++ b/custom_components/melcloudhome/sensor_atw.py
@@ -60,8 +60,33 @@ class ATWSensorEntityDescription(SensorEntityDescription):  # type: ignore[misc]
     available_fn: Callable[[AirToWaterUnit], bool] = lambda x: True
     """Function to determine if sensor is available."""
 
-    should_create_fn: Callable[[AirToWaterUnit], bool] | None = None
-    """Function to determine if sensor should be created. If None, uses available_fn."""
+    should_create_fn: Callable[[AirToWaterUnit], bool] = lambda x: True
+    """Whether to create the sensor at all.
+
+    Must test something stable about the unit (a capability, a model trait) - never
+    a value that comes and goes, because creation is only evaluated once at setup.
+    Use available_fn for anything transient.
+    """
+
+
+def _reports_telemetry(measure: str) -> Callable[[AirToWaterUnit], bool]:
+    """Build a check for whether a unit reports a given telemetry measure.
+
+    Used for BOTH creation and availability on the telemetry sensors, which is a
+    compromise worth spelling out. The telemetry API exposes no capability flag,
+    so "has this measure ever arrived" is the only signal available for "does this
+    heat pump have this sensor" - and it is not a stable property, so it breaks the
+    rule in should_create_fn's docstring.
+
+    The alternative is creating all of them for every unit. Rejected because the one
+    real ATW unit we have a recording for returns data for flowTemperature and
+    returnTemperature but an empty series for the zone1 and boiler variants over the
+    same window - so 4 of 6 would be permanently unavailable on that hardware, and
+    entities are far easier to create than to withdraw.
+
+    ponytail: replace with a real capability check if the API ever grows one.
+    """
+    return lambda unit: unit.telemetry.get(measure) is not None
 
 
 ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
@@ -128,7 +153,8 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("flow_temperature"),
-        available_fn=lambda unit: unit.telemetry.get("flow_temperature") is not None,
+        should_create_fn=_reports_telemetry("flow_temperature"),
+        available_fn=_reports_telemetry("flow_temperature"),
     ),
     ATWSensorEntityDescription(
         key="return_temperature",
@@ -137,7 +163,8 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("return_temperature"),
-        available_fn=lambda unit: unit.telemetry.get("return_temperature") is not None,
+        should_create_fn=_reports_telemetry("return_temperature"),
+        available_fn=_reports_telemetry("return_temperature"),
     ),
     ATWSensorEntityDescription(
         key="flow_temperature_zone1",
@@ -146,9 +173,8 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("flow_temperature_zone1"),
-        available_fn=lambda unit: (
-            unit.telemetry.get("flow_temperature_zone1") is not None
-        ),
+        should_create_fn=_reports_telemetry("flow_temperature_zone1"),
+        available_fn=_reports_telemetry("flow_temperature_zone1"),
     ),
     ATWSensorEntityDescription(
         key="return_temperature_zone1",
@@ -157,9 +183,8 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("return_temperature_zone1"),
-        available_fn=lambda unit: (
-            unit.telemetry.get("return_temperature_zone1") is not None
-        ),
+        should_create_fn=_reports_telemetry("return_temperature_zone1"),
+        available_fn=_reports_telemetry("return_temperature_zone1"),
     ),
     # Zone 2 telemetry (flow/return temperatures)
     ATWSensorEntityDescription(
@@ -170,9 +195,7 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("flow_temperature_zone2"),
         should_create_fn=lambda unit: unit.has_zone2,
-        available_fn=lambda unit: (
-            unit.telemetry.get("flow_temperature_zone2") is not None
-        ),
+        available_fn=_reports_telemetry("flow_temperature_zone2"),
     ),
     ATWSensorEntityDescription(
         key="return_temperature_zone2",
@@ -182,9 +205,7 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("return_temperature_zone2"),
         should_create_fn=lambda unit: unit.has_zone2,
-        available_fn=lambda unit: (
-            unit.telemetry.get("return_temperature_zone2") is not None
-        ),
+        available_fn=_reports_telemetry("return_temperature_zone2"),
     ),
     ATWSensorEntityDescription(
         key="flow_temperature_boiler",
@@ -193,9 +214,8 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("flow_temperature_boiler"),
-        available_fn=lambda unit: (
-            unit.telemetry.get("flow_temperature_boiler") is not None
-        ),
+        should_create_fn=_reports_telemetry("flow_temperature_boiler"),
+        available_fn=_reports_telemetry("flow_temperature_boiler"),
     ),
     ATWSensorEntityDescription(
         key="return_temperature_boiler",
@@ -204,9 +224,8 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("return_temperature_boiler"),
-        available_fn=lambda unit: (
-            unit.telemetry.get("return_temperature_boiler") is not None
-        ),
+        should_create_fn=_reports_telemetry("return_temperature_boiler"),
+        available_fn=_reports_telemetry("return_temperature_boiler"),
     ),
     # WiFi signal strength - diagnostic sensor for connectivity troubleshooting
     # Shows received signal strength indication (RSSI) in dBm
@@ -300,13 +319,7 @@ def _create_sensors_for_unit(
     """
     entities = []
     for description in descriptions:
-        # Use should_create_fn if defined, otherwise use available_fn
-        create_check: Callable[[AirToWaterUnit], bool] = (
-            description.should_create_fn
-            if description.should_create_fn
-            else description.available_fn
-        )
-        if create_check(unit):
+        if description.should_create_fn(unit):
             entities.append(ATWSensor(coordinator, unit, building, entry, description))
     return entities
 

--- a/tests/integration/test_sensor_ata.py
+++ b/tests/integration/test_sensor_ata.py
@@ -269,3 +269,28 @@ async def test_holiday_mode_date_sensors(hass: HomeAssistant) -> None:
     assert start_state.state == "2026-07-20T18:30:53.79"
     assert end_state is not None
     assert end_state.state == "2026-07-22T12:00:00"
+
+
+@pytest.mark.asyncio
+async def test_sensors_created_when_values_absent_at_setup(hass: HomeAssistant) -> None:
+    """Test room temperature and wifi signal survive a setup with no readings.
+
+    Regression test. Creation used to fall back to available_fn when a description
+    had no should_create_fn, so a unit reporting no room temperature or RSSI at the
+    moment of setup - an offline unit during a Home Assistant restart - permanently
+    lost those entities until the integration was reloaded. available_fn is meant to
+    render an entity unavailable, not to suppress its creation.
+    """
+    unit = create_mock_ata_unit(room_temperature=None, rssi=None)
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[unit])]
+    )
+    await setup_ata_integration_custom(hass, mock_context)
+
+    for entity_id in (
+        "sensor.melcloudhome_a1b2_9abc_room_temperature",
+        "sensor.melcloudhome_a1b2_9abc_wifi_signal",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None, f"{entity_id} was not created"
+        assert state.state == "unavailable"


### PR DESCRIPTION
`should_create_fn` decides whether an entity is constructed at setup; `available_fn` decides whether an existing entity can report a value. The ATA and ATW sensor setup loops conflated them, falling back to `available_fn` when a description declared no `should_create_fn`. Because `available_fn` is a transient value check — and creation is only ever evaluated once — a unit reporting nothing at the moment of setup lost those entities entirely, and they stayed missing until the integration was reloaded.

Concretely: **restart Home Assistant while an air conditioning unit is offline and its room temperature sensor is gone, not unavailable, until the next reload.**

#205 fixed exactly this pattern in `binary_sensor.py`. This is the remainder.

## ATA — behaviour change

`room_temperature` and `wifi_signal` are now always created, going unavailable when there is no reading. This matches Home Assistant core's own `melcloud_home` integration, which declares no creation gate on either sensor (`sensor.py:78-86`, `sensor.py:49-57`). Core would hit the same bug if it gated creation on transient values — its dynamic-add path only fires for newly-seen unit IDs, never re-evaluating creation for known units.

## ATW — no behaviour change, but the gate is now deliberate

The eight telemetry sensors keep a creation gate, stated explicitly through a new `_reports_telemetry()` helper instead of being inherited by accident.

The telemetry API exposes no capability flag, so "has this measure ever arrived" is the only available proxy for "does this heat pump physically have this sensor". That breaks the rule the fix establishes, so the helper's docstring records why creating them unconditionally was rejected: the one real ATW unit we have a recording for returns data for `flowTemperature` and `returnTemperature` but **empty series for the zone1 and boiler variants over the identical time window** — so four of six would be permanently unavailable on that hardware, and entities are far easier to create than to withdraw. There is a `ponytail:` marker naming the upgrade path if the API ever grows a real flag.

`_reports_telemetry` also replaces six multi-line lambdas that duplicated the same expression already present in `available_fn`.

## Verification

- `make pre-commit` clean, `make test-api` 321 passed, `make test-integration` 201 passed
- **The regression test was verified to fail without the fix.** With the `custom_components/` change stashed and the test kept, `test_sensors_created_when_values_absent_at_setup` fails because neither entity is created.
- Not verified on ATW hardware — guest access to an ATW device has lapsed. The ATW half is a no-op refactor for that reason; the behaviour change is confined to ATA, where there is real hardware to check against.

## Not in scope

Core's `available`-versus-`unknown` divergence. The `entity-unavailable` quality-scale rule says a successful fetch with a missing field should surface as state `unknown`, not `unavailable`; we use `available_fn` for this throughout, on both device types. Real, pre-existing, and much wider than this fix.
