### PR TITLE
fix: always create ATW flow/return temperature sensors

### DIFF
--- a/custom_components/melcloudhome/sensor_atw.py
+++ b/custom_components/melcloudhome/sensor_atw.py
@@ -70,22 +70,7 @@ class ATWSensorEntityDescription(SensorEntityDescription):  # type: ignore[misc]
 
 
 def _reports_telemetry(measure: str) -> Callable[[AirToWaterUnit], bool]:
-    """Build a check for whether a unit reports a given telemetry measure.
-
-    Used for BOTH creation and availability on the telemetry sensors, which is a
-    compromise worth spelling out. The telemetry API exposes no capability flag,
-    so "has this measure ever arrived" is the only signal available for "does this
-    heat pump have this sensor" - and it is not a stable property, so it breaks the
-    rule in should_create_fn's docstring.
-
-    The alternative is creating all of them for every unit. Rejected because the one
-    real ATW unit we have a recording for returns data for flowTemperature and
-    returnTemperature but an empty series for the zone1 and boiler variants over the
-    same window - so 4 of 6 would be permanently unavailable on that hardware, and
-    entities are far easier to create than to withdraw.
-
-    ponytail: replace with a real capability check if the API ever grows one.
-    """
+    """Availability only - never entity creation (a failed poll must not drop it)."""
     return lambda unit: unit.telemetry.get(measure) is not None
 
 
@@ -98,7 +83,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.room_temperature_zone1,
-        should_create_fn=lambda unit: True,
         available_fn=lambda unit: unit.room_temperature_zone1 is not None,
     ),
     # Zone 2 room temperature (only if device has zone 2)
@@ -120,7 +104,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.tank_water_temperature,
-        should_create_fn=lambda unit: True,
         available_fn=lambda unit: unit.tank_water_temperature is not None,
     ),
     # Outdoor temperature (from settings response)
@@ -153,7 +136,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("flow_temperature"),
-        should_create_fn=_reports_telemetry("flow_temperature"),
         available_fn=_reports_telemetry("flow_temperature"),
     ),
     ATWSensorEntityDescription(
@@ -163,7 +145,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("return_temperature"),
-        should_create_fn=_reports_telemetry("return_temperature"),
         available_fn=_reports_telemetry("return_temperature"),
     ),
     ATWSensorEntityDescription(
@@ -173,7 +154,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("flow_temperature_zone1"),
-        should_create_fn=_reports_telemetry("flow_temperature_zone1"),
         available_fn=_reports_telemetry("flow_temperature_zone1"),
     ),
     ATWSensorEntityDescription(
@@ -183,7 +163,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("return_temperature_zone1"),
-        should_create_fn=_reports_telemetry("return_temperature_zone1"),
         available_fn=_reports_telemetry("return_temperature_zone1"),
     ),
     # Zone 2 telemetry (flow/return temperatures)
@@ -214,7 +193,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("flow_temperature_boiler"),
-        should_create_fn=_reports_telemetry("flow_temperature_boiler"),
         available_fn=_reports_telemetry("flow_temperature_boiler"),
     ),
     ATWSensorEntityDescription(
@@ -224,7 +202,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("return_temperature_boiler"),
-        should_create_fn=_reports_telemetry("return_temperature_boiler"),
         available_fn=_reports_telemetry("return_temperature_boiler"),
     ),
     # WiFi signal strength - diagnostic sensor for connectivity troubleshooting
@@ -238,7 +215,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         entity_category=EntityCategory.DIAGNOSTIC,
         value_fn=lambda unit: unit.rssi,
-        should_create_fn=lambda unit: True,
         available_fn=lambda unit: unit.rssi is not None,
     ),
     # Energy monitoring sensors

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -164,6 +164,8 @@ For each heat pump system, the following entities are created:
 - **Flow Temperature Boiler**: `sensor.melcloudhome_{short_id}_flow_temperature_boiler`
 - **Return Temperature Boiler**: `sensor.melcloudhome_{short_id}_return_temperature_boiler`
 
+All of these except the Zone 2 pair are created for every heat pump. Not every controller model reports every measure — the telemetry API simply returns no data for a sensor the hardware doesn't have — so any of them may sit permanently `unavailable`. That is expected.
+
 **Purpose:** Monitor heating system efficiency and performance
 
 - Flow vs return delta indicates heat transfer efficiency

--- a/tests/integration/test_sensor_atw.py
+++ b/tests/integration/test_sensor_atw.py
@@ -352,3 +352,33 @@ async def test_atw_rssi_sensor_created(hass: HomeAssistant) -> None:
     assert wifi_state.state == "-50"
     assert wifi_state.attributes["unit_of_measurement"] == "dBm"
     assert wifi_state.attributes["device_class"] == "signal_strength"
+
+
+@pytest.mark.asyncio
+async def test_telemetry_sensors_created_without_telemetry_data(
+    hass: HomeAssistant,
+) -> None:
+    """Test flow/return sensors exist even when no telemetry has arrived.
+
+    Regression test: creation used to be gated on the measure already being present,
+    so a failed telemetry poll at setup dropped the sensor until the next reload.
+    """
+    unit = create_mock_atw_unit()
+    assert not unit.telemetry, "expected a mock ATW unit to start with no telemetry"
+    mock_context = create_mock_atw_user_context(
+        [create_mock_atw_building(units=[unit])]
+    )
+    await setup_atw_integration_custom(hass, mock_context)
+
+    for measure in (
+        "flow_temperature",
+        "return_temperature",
+        "flow_temperature_zone1",
+        "return_temperature_zone1",
+        "flow_temperature_boiler",
+        "return_temperature_boiler",
+    ):
+        entity_id = f"sensor.melcloudhome_0efc_9abc_{measure}"
+        state = hass.states.get(entity_id)
+        assert state is not None, f"{entity_id} was not created"
+        assert state.state == "unavailable"


### PR DESCRIPTION
The six non-Zone-2 ATW flow/return temperature sensors were created only if their telemetry measure had already arrived by the time the sensor platform set up. Telemetry is a separate per-measure poll — each measure is its own request, wrapped in its own `try`/`except` — and creation is evaluated exactly once, so a transient error at startup dropped that sensor for the **entire session**: absent rather than unavailable, and back only after reloading the integration. They are now always created, and report `unavailable` until a reading arrives. This reverses the ATW half of #219, which made the same gate explicit rather than removing it. The Zone 2 pair is unchanged — `has_zone2` is a stable capability and a legitimate creation gate.

**Trade-off accepted:** on a controller that never reports a measure, the entity now sits permanently `unavailable`. The one ATW unit I have a recording for returns an empty series for four of the six measures over an identical window. That is still the better failure: an unavailable entity is visible and can be hidden or deleted, whereas an absent one is silent — an automation referencing it fails with "entity not found", and recovering it requires already knowing that a reload brings it back. Not verified on ATW hardware; guest access to the one unit has lapsed.

Also in here: drops three `should_create_fn=lambda unit: True` that only restated the field default; shortens the `_reports_telemetry` docstring now that it serves availability alone; adds a note to `docs/entities.md` that any of these sensors may sit permanently unavailable on hardware that does not report that measure, generalising the existing boiler-specific caveat a few lines below it.

The shortened docstring also removes a `ponytail:` deferral marker recording that the telemetry API exposes no capability flag to gate on. That is still true — there is no flag to gate on, which is why creation is now unconditional.

**Verification:** `make pre-commit` clean, `make test-integration` 202 passed. The new regression test fails without the source change: none of the six entities exist.

Out of scope here: all 16 `available_fn` values in `sensor_atw.py` are exactly `value_fn(...) is not None`. A follow-up PR removes them, so those sensors report `unknown` rather than `unavailable` when a reading is missing — which also supersedes the `unavailable` wording above and the note added to `docs/entities.md`.
