### PR TITLE
fix(security): scrub session cookies from VCR cassettes

### DIFF
--- a/tests/api/cassettes/test_atw_device_with_cooling_capability.yaml
+++ b/tests/api/cassettes/test_atw_device_with_cooling_capability.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnVMQvzzV071XFGK1afMzUXEd06B9wUH70YX_p1V8C6CzjfBzfiMQeCahGrCuv_h9ZTQ7shPyH1rXQpe8mqP9Gyk41YjjuULcunW3lbeQukOS-9czVcz79lOoqTTnIFBDjJx6sA04vWAw2z6QvhhI7CwMdfjPvUGDXre6nMQbZgsUtklWsh0sf4h6UXaWnbkyJKpcpSpBlWa7h6z6D8wAg69rIcvICTx00rzQZJEhX9bfkJ3EHQm0d3u2BEWaBcMKk=N;
-        expires=Sun, 12 Apr 2026 13:40:56 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.o15KLSmDNbjFkDAVMUCulNKUb9IH6L2F05PsjqsOpjQ=N; expires=Sun,
-        12 Apr 2026 13:40:56 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWHviZdjoEEMuQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=2940f983-af4c-4060-a11e-8d1e72f51328; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115971563328647.ZGJiOTg4M2EtMDA3MC00YTE3LTg3ZTItOWExZDFmMDliN2FlZjgxOGFjZGItNDU2NS00MDhiLWE3NDEtNjBiMGYzNDI4YWYz;
-        Expires=Sun, 12-Apr-2026 13:30:56 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115971563328647.ZGJiOTg4M2EtMDA3MC00YTE3LTg3ZTItOWExZDFmMDliN2FlZjgxOGFjZGItNDU2NS00MDhiLWE3NDEtNjBiMGYzNDI4YWYz;
-        Expires=Sun, 12-Apr-2026 13:30:56 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=DeIr0ZTSOPLChkyW0p9bvD1iNmoKhrxQca2b_FsNHoI&amp;code_challenge_method=S256&amp;nonce=639115971563328647.ZGJiOTg4M2EtMDA3MC00YTE3LTg3ZTItOWExZDFmMDliN2FlZjgxOGFjZGItNDU2NS00MDhiLWE3NDEtNjBiMGYzNDI4YWYz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkmrDQ4JlVtvVmdP8dqds5q8d4kjubz8nNvb2ksjO2G7DynTak7n7pZNAEF2fx5yiEOer4XPUJfsu9RtdUyyaOqdCffI2a7H7rqPd3PvOui87j7VEHEaMHaD6ekKblAs_ntypYn7VIq5pL9gOxpvuVVAQcXGACSzS96k7fuOzC8Rc2UadrsKXv2b3C9nQwMeHRFPFNi4YDnhCOEg9OgFoiaMFfHx82ApDbsI4Mqv7LZqEhpk0KkUPf4PJZX_beHwj0WKEIK5oAS0IAiPfCp0GrPTno8vQsngudxPOZnuPazaXyoLe4Gd0WFixAmL8ja3h8FZL-nEkE0RLIjRncJzuSjmYLjvoHL1ImzjvZx6K9hHZgiefAMXr_iNNr6bqm8zAb4dcJIPYWfJ66L2-tbB8FBoD0TcHAKLmBrWvQO_KmJvMpRiEhWC17HhuPzodPQVWiWxTFt-ENH34HDNhnjJEb4U7GyYNbSf0K7Joj-DIZ9KAHl87tx88irWrGOMTNfVLuruLXadG0dPZyPS8c__rK66289qMwMI7nSemhrq4jYFeKq2i_0by8f7RWWp2n5tpYa8duTjYxBRs87bH6KgkEpADPmDgpreXGp-Qxrk2ztkacaF8JA31VG0iTPZM95JAT33Ngrc3LWNmhqhdWtoLop\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"2940f983-af4c-4060-a11e-8d1e72f51328\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-38dfcf6ef982\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=DeIr0ZTSOPLChkyW0p9bvD1iNmoKhrxQca2b_FsNHoI&amp;code_challenge_method=S256&amp;nonce=639115971563328647.ZGJiOTg4M2EtMDA3MC00YTE3LTg3ZTItOWExZDFmMDliN2FlZjgxOGFjZGItNDU2NS00MDhiLWE3NDEtNjBiMGYzNDI4YWYz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkmrDQ4JlVtvVmdP8dqds5q8d4kjubz8nNvb2ksjO2G7DynTak7n7pZNAEF2fx5yiEOer4XPUJfsu9RtdUyyaOqdCffI2a7H7rqPd3PvOui87j7VEHEaMHaD6ekKblAs_ntypYn7VIq5pL9gOxpvuVVAQcXGACSzS96k7fuOzC8Rc2UadrsKXv2b3C9nQwMeHRFPFNi4YDnhCOEg9OgFoiaMFfHx82ApDbsI4Mqv7LZqEhpk0KkUPf4PJZX_beHwj0WKEIK5oAS0IAiPfCp0GrPTno8vQsngudxPOZnuPazaXyoLe4Gd0WFixAmL8ja3h8FZL-nEkE0RLIjRncJzuSjmYLjvoHL1ImzjvZx6K9hHZgiefAMXr_iNNr6bqm8zAb4dcJIPYWfJ66L2-tbB8FBoD0TcHAKLmBrWvQO_KmJvMpRiEhWC17HhuPzodPQVWiWxTFt-ENH34HDNhnjJEb4U7GyYNbSf0K7Joj-DIZ9KAHl87tx88irWrGOMTNfVLuruLXadG0dPZyPS8c__rK66289qMwMI7nSemhrq4jYFeKq2i_0by8f7RWWp2n5tpYa8duTjYxBRs87bH6KgkEpADPmDgpreXGp-Qxrk2ztkacaF8JA31VG0iTPZM95JAT33Ngrc3LWNmhqhdWtoLop\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"2940f983-af4c-4060-a11e-8d1e72f51328\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-38dfcf6ef982\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=673c9690-6e5e-4760-b7c8-17b99ebe9919; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/KGGiHA/ZMDbkZKdf063b8/Bu+I9o1pyJoDVOhtMlIvV+72WM5qE5mc1zrixH+T8sHeoPBS2fmroL4WMv2EIhNcqIEJpInJCAVeYXYHBvVVdu7T3bvvpmkpKC9M8YjJIYPdtZDPPZLA7M7tzqvgTz7wrFwse+R8Nwjb7PoE/j4nDxVF9Z0nHV+dWabP+umMZevlTjUZ/IH1qfi1hvJIyP9SjrpBUOF7uErxnKukX8aUnwm70dYjP1oe6jTu4bXIJggHkG5JVvzKIkaO/M8SzNpfwwDYa0eKsDSv8T3HOURxge7k8DnrXiAAAA.H4sIAAAAAAAAAPu4JDB5o20XQ3i4SmjDnovulnqrI46G/OjnncfzuKsqbBoACIzIKyAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:25:57 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.o15KLSmDNbjFkDAVMUCulNKUb9IH6L2F05PsjqsOpjQ=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnVMQvzzV071XFGK1afMzUXEd06B9wUH70YX_p1V8C6CzjfBzfiMQeCahGrCuv_h9ZTQ7shPyH1rXQpe8mqP9Gyk41YjjuULcunW3lbeQukOS-9czVcz79lOoqTTnIFBDjJx6sA04vWAw2z6QvhhI7CwMdfjPvUGDXre6nMQbZgsUtklWsh0sf4h6UXaWnbkyJKpcpSpBlWa7h6z6D8wAg69rIcvICTx00rzQZJEhX9bfkJ3EHQm0d3u2BEWaBcMKk=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkK9dgAEtvUYMbupOjAIsNXQpC_P7YqDWrnyfJBscHMKSCdWI8aOB8EvDfppsuMH-r9XnHE9rJnrvBIsFWl7KFWpXkMEdsVM7rF6mUsFOvbyUhpl8A9S1LsvULCN7oRLRLM-IGq_WS7ZGZNhmaMyBRRHA8AmmUl3yDzsByOKDFwJRs5m3FrAIyv-5JX5wgu6f9HONd2smdYVKwakXnG1yG7qV4SZbZsm7GZVtHIXW4Li_32Whexln1YZuRm-oir4rOa2yZeFkEFsQ1_K5Y3Gniu0KUBGlRhP8AC2H1yu6Nyy3vMYwngzyL1eFY_EX0c73qOW_vEwuZzvL6aAbsUlBZJEsiAakjtYQSvPGDvlbtm-R7B4x3aAhIb215uIPwYWnYAhZa5Ui_v5bgOJzsLvkDGhf1RjvRvdS6tcAGbgtHmEPUUFC9Hnkaf4zQUCEx4Fk3OYZ5P14lt3jOPLnon1MeRlVxur26TnPGgHwmpg5ulpI7CRWQhfUpwHZU92UthqtrVfw2YNKon1ekuZMN6rarJ3ArTTaOWTnIG946WEFYLPu10226wIuCjal619WIhiE3dSY10FGuhLXiJyhS8SMuVO1qxs4qRL3SGbgklOFfNVVPunD7zVKzYq1E4ah3FiZRylO5FMQYtF1di-kpZh3SOmkUetKIXoWIzGfsUc_CeK4YIAMu3VlsrHYaUpHqXd3QfaCOpPxXNpbtpMZssAxH1J2xv7m-yague_QklW3L09rUCCTB6yQ8JoXJb9C_OqPqoe7i03NNt-d-z-sI3c_TT_YvUAu3bh_IKTT0m1ffzpiEM0CWXQQDQ8wxcj0NfhPzqCbUP7s18FEiGmj6Cc6lc1AKutlpouEMYHd8SsW8pWeJd84T5jJ_1Bj2qgRhkMhOvPyMqxm1p-WTGanglbjhWMWn-2txN1FPIkMQb_ZUHI2bPieO_IWEmsdhoWzNC3YxCSTpKuTbt_6Lmzeg_gBfu80JUT6Y3CDmE6dL2pT_skaxuW2M6Aj-ucfFaEw1mllUiFntbQbj6_oah0z04tYtZ11XXEy0K51Knw1nm7opxJiWgm9vTaCUKakc2PMl6Qv79i2nJMtoSZpSs1pSap_hi3FvoKnKIwUFSxFhpcbBNvila0DoQ8ryGV26z2YQ1amxb4ukTBIsu0iSygXxS_VMTfUl8EmnVQCbtnANUGlzpzfEtcF6HFH13VraPFMyFJcSA6UL3aofG9aFgiyxRV8YkPnu5S_Ac0nImweEoar-EqFrwMW6BTWrUvDdKXT9g1bPVIkFwnLOU-1ltM7Vw1sTvc-PDJW_bl1ZQYmf-bmo2vtOKFRH1wOQT07_MHtfLBqAW0qpKq-ucZjQEjRjHUqLADWj5iY3pfqbB7IyiYzNpJrMKnPYVN-AAS3v-I39ymjQ9w-Z5HVGSIOY-b5l-jxFidlRECHtj5fj7RKJc4sAAqOCuTfldwU1GBV6atXt2f0UUs6GagdTwGpVrfjCo46HOye0Dyn20dgUDKamPzGlJ8IRHerFe9eFsKKk61FqKtycJePmshmOc3x_V9xwwmYYF7Nmm9DmKawFolGO8FPRhIHU81d6MlLK2WuJxwITSGhr-sSQM02GienHSJ-HcWSWBvyGesVFjGY2_Y2umqMimOdykSUAAilyACi_w3KhgNeNKrzla8Qa5IsDc_TY5Qh8-qwil2iDym7WDECtpyH7CKhOnCt0vGrvP43a8JePqCm1jWw1AbL2h2UKCBk7-JsSEbO7Y8zp373J2xKiaxMRu7r5bQpFnMWlSx6LBFR37d3E4ntZSRnsdpDKUq0UXeaagZCfusV2l4_TDKpqifUfx19fGrdlOVnj0a7dJW1kXMIbIHGeSxwBs7wlPZL57C2K47LIHwt8-fxXBzVUGMNI5sxcHHkMsgjwrVSdSEgaueUymteeqRM2pdoDmSmanyPXH0rkbUc_bHZAojC1EHzHzSFlybcmu6yrXJYRhVX5b_ZY3X2oAfCjsUrMQ0irhezfKsLo78TDaZartNQrEmD4CBdECN18zV2l9zNeGIxB949smEZd3jxw3_DVB-Qnc-VcVn8Isj0o_xkOqcb-H64y6wPurVxqGQCjTvozgTw7CmzkFvrxnBwBtSODvt1_F-S_esKA94LDUhCTYnHhNUDCMOtHlDE2sfCXlRSiJaZV7uUqyV3Kugs0yYmH9HWWea-A9wGuA4Y-9tRF6Ixte1ajo49iidi5ttKSRPwPXu065ijOphgxcs7CkL6JErsb7Bk7Lp5rcmcbsGMb_B3z8C8I_17d1P8nZYb43NjW-DAHtpZ58ppXxUlNbINrWhPFgwpNH6f5xXhT2GyV55f6pzOMT0a9k2g8rJU7_vY5xygNyBpmfhyPkzxuGYUfnBae-Q_64f42Gy084WG1pqNS8XEtE19izxJu0OG8HLlKgnAKPX82d8RZCUGCIfqljXN0Uy-h9j8OQ_HD8eHv9a6wWnt6lPg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWH3g4HDoEEMOQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=489BB3C063B57FD349F654AF38FB45F3; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtknDK7mR6znEZR85Tpn6a8c2YLbufagOA0Z-75pCGsi0vfhMccTbqUQP41a_XckDG8Ie5CamtPJC36WmT6R_8MH2dg8XbUULZrpfovF-GBFg1MGIaZ0IVvoIElqnLXLkJkkZTKtNlkLc9I97PrAYi9mVOC7tr2knIvzsUV_0MFzsIZWyp69yL-zAPGGAVCaFgsCFfnBE2YGYBW8J30M-CaFlyq4Oj-laR4MC475tqIW7mSy5iqFt0WWbmAL5mg60adSlfZ5pn9FyULlMlYZ_-Vmy9mooJQrirccEs7VAXlzzknBn52G2hCGjYJptTwD3h293puV5AtB9YVx9FKum-VmddN6kexhEB_aXDjzqzRAsRgUGcOskj8eG_5_Qvd2zpL8QnKE_kzItUIZDmRhQi_v6xxtpLabtlsLNqfxUEhDp0vbc6CMo_GYHxK20gI6R7RN-jbg-GlV72imjxo9I4T0QGci0gnBmcSKV9w_DLKq1pLtxE_Ghw34_Q1wdrjXhgZjjXt_NhI9yKbyd90j5jcT_R58uzytVrkueZMU9M2uZ10dRy6_3nc2oEBIja1MQ_gn-P9UOy11oIkiS9UB9-xu5Ce5bICIItDcvpKD-uNkbWCvKi-qdJUoHc5rO1Yp7ys;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWH5hwmDoEEMrg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnEcWKK6Ru_qYK6t1GL0W1-xMuihsG3HB4YEqcsU2yalZCmX6744rEmAm3IYz3aXbDQA8zYWWk2e-QjIVpL4o8RZDiGnBAt8g9SzS2j9Pn1Rx9yFEVO02znKybBE3p8t-HZt7n7fQUje5ijTjK6LFxnm9822n8U89-0FDKvj_NWkb21XkrXyPTPXv1O3ujOcFPL4KBpHly6ixaHPbYpKstdMQddLvvqK3a_L7wiOFrt2yQmo1QoU8WJV8kjRGqexNnI_rminMYl6_CT3aTWUV5bqXlliEfmEypfXMUQUw_AhlkZZ5Xn5k3MJYbIq4WP3h1yO5emF802iPg67poDr-T7ohilVylBTLWu64Kq07rBgheuPLb0BA9Nrz2fM3j3imRAIF7l-eE2KpCIm9jH3Rc5LAZ16CxUJ7P8RD5mBpOEqkiOp7ySYHgxWG22G3K2_ZjIeasa1cOCVv5XYnsqn2M0kCkHKZV367FnrBjuMHaaLlf4dhHl9VCC0KY7zMWgVh5jK4NTQGkYVLq7IKHwVL1Gyb9yN0zLJU1QOy5UKUWtBvV7U3JMY1hLmvdajbISPfYW-95EpsxL-0XBbRt6p587R-v622BiSIwgYcB-IoqyGUh6Wan7blc7WAJB1_Dl7gGJbFgLnzQdIg0H0XjhVJPSJfFd5Bm-X-1sXHM-bW4BAw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWH9jk6DoEEMGg=
     status:

--- a/tests/api/cassettes/test_atw_device_with_energy_capabilities.yaml
+++ b/tests/api/cassettes/test_atw_device_with_energy_capabilities.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkMYpnOH_wmmEB2Xws-7gCAriyUCtYmJl1gNX-wrQ_LwZoft3yrF52PKaiI_Ge6hfhOzjf5EhqMz_7Yct3YzVV7aFi2zGKuvHKwRDSEzF14kDWhR4_G-VlrpfY08dGdloFnLOmDOT89gEc5ecrun2L5v74VzdtbrG2RutS-k3EDZwdooAe9En9mUk0Xa_OC1Gpu9_AlSWA3g7-kspwkfJRM0vaFt16FJMFftRxJaj9PGxtH4dx87n4Nys1gk3W-WrU=N;
-        expires=Sun, 12 Apr 2026 13:40:53 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.uSXrdLG9pNFHGg2xLS9hUqV8tKox1jF-7PL7SPHw5lY=N; expires=Sun,
-        12 Apr 2026 13:40:53 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWHTjcPDoEEMag=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=4d8e71df-a90c-4059-93a9-8c94dc180692; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115971535256899.NTQ5YWYwOGUtZTY4NC00NzBiLThkYjUtYmQ2YzdmMTEyNzI3ODcwZTc4ZjItYzliNC00MGI4LTk3MmEtZTlhZTgzZjBlMGM3;
-        Expires=Sun, 12-Apr-2026 13:30:53 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115971535256899.NTQ5YWYwOGUtZTY4NC00NzBiLThkYjUtYmQ2YzdmMTEyNzI3ODcwZTc4ZjItYzliNC00MGI4LTk3MmEtZTlhZTgzZjBlMGM3;
-        Expires=Sun, 12-Apr-2026 13:30:53 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=UcTtyiZABYMzWdYusEY9A-LnKYKNKccFxeiJG6YO2sc&amp;code_challenge_method=S256&amp;nonce=639115971535256899.NTQ5YWYwOGUtZTY4NC00NzBiLThkYjUtYmQ2YzdmMTEyNzI3ODcwZTc4ZjItYzliNC00MGI4LTk3MmEtZTlhZTgzZjBlMGM3&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnwtLtNOih6v_a_I0sd68z_mAldrmEEAsUncMJVn76zhh5Thdmp7HOIQIVk2SVjBK6yybbg8X2PGENm6S0wYGTIpgbdaITYp6VnGUBS9neLv8yOuwT_p-3zXtvum-lMSS7gGXGQgZclWDtOHUz3-AezDE9mj9q3cZRPLNVQ2Gcsd4aO0_oB_4gYM2nE4UBZLcOUi9k9JAswrQzuFO_GR5XRdJtSW0fOxNA1uv6VXwr6EYiBr5Mv3EjBult8zboljo0ToRMPLXiTORh_oZcW-_sazUSkFqW0jiuLyI3wyf88N7cpfDLGw8zXQAnNwa3PcUvWvhaqGzk-1AwE2nMiTp8hzlpKvALRmSnbGKfHb1qYX55x6HxZTLX9U00uRDTwk9me-VShnuALKToHKw2IE6-gHX7j0OhvlPV6IPeXz7lxmyzSQtciOs0BchY_cR6fJ8Rr9YmjkHQWXBztsifH4Z0kU_BpPlUpJ9z_MWU4yGhJRaPLXAi2YAqvc4w7s3U8EAKRdkbxk5AnLQE-y_ALHmRgmNr7P6GfPXgrJf9gpXc2wDTlDG8adcbOLoDUkN3EAEAArzu7Wp1ohmQU2Z3qCUWpBsFaFxXYu-h7DN4DpcL6MazKwniIF75drXhNAkaRhnY_frt2p18TA56ajKeZGS0G\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"4d8e71df-a90c-4059-93a9-8c94dc180692\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-c150558ac3f7\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=UcTtyiZABYMzWdYusEY9A-LnKYKNKccFxeiJG6YO2sc&amp;code_challenge_method=S256&amp;nonce=639115971535256899.NTQ5YWYwOGUtZTY4NC00NzBiLThkYjUtYmQ2YzdmMTEyNzI3ODcwZTc4ZjItYzliNC00MGI4LTk3MmEtZTlhZTgzZjBlMGM3&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnwtLtNOih6v_a_I0sd68z_mAldrmEEAsUncMJVn76zhh5Thdmp7HOIQIVk2SVjBK6yybbg8X2PGENm6S0wYGTIpgbdaITYp6VnGUBS9neLv8yOuwT_p-3zXtvum-lMSS7gGXGQgZclWDtOHUz3-AezDE9mj9q3cZRPLNVQ2Gcsd4aO0_oB_4gYM2nE4UBZLcOUi9k9JAswrQzuFO_GR5XRdJtSW0fOxNA1uv6VXwr6EYiBr5Mv3EjBult8zboljo0ToRMPLXiTORh_oZcW-_sazUSkFqW0jiuLyI3wyf88N7cpfDLGw8zXQAnNwa3PcUvWvhaqGzk-1AwE2nMiTp8hzlpKvALRmSnbGKfHb1qYX55x6HxZTLX9U00uRDTwk9me-VShnuALKToHKw2IE6-gHX7j0OhvlPV6IPeXz7lxmyzSQtciOs0BchY_cR6fJ8Rr9YmjkHQWXBztsifH4Z0kU_BpPlUpJ9z_MWU4yGhJRaPLXAi2YAqvc4w7s3U8EAKRdkbxk5AnLQE-y_ALHmRgmNr7P6GfPXgrJf9gpXc2wDTlDG8adcbOLoDUkN3EAEAArzu7Wp1ohmQU2Z3qCUWpBsFaFxXYu-h7DN4DpcL6MazKwniIF75drXhNAkaRhnY_frt2p18TA56ajKeZGS0G\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"4d8e71df-a90c-4059-93a9-8c94dc180692\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-c150558ac3f7\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=159c4401-041c-4724-9105-55e68a74cf2c; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/wYYHt9/cZBqasvvUH+4Mk+o7JFGolyGgxbi0zuEdSXDRxkSx70sy5fBUTXhNgN0aNg78+9xN5Qqk4BsBWnJMW5IXVBWSqq9tZOJOUzlsBFEftJ8PhsEooTKZwUgwjmeFx/Fb6o1xpfFyfLIIQ1Zp3OBolNypyjRZGApNgxjZavBsbv2c5fEfmDUw4qnI4A6YqMlgCo+Cu4OxOuBWgJHgResgpXYCXK4ydAltDa1FeD2WvjXynDDSeGNJn9nwzQHgMu5/CuEYBWxUU4dzxauTUQ30QRkxnUCUz+vWqcD5Wd9d16LEPf3iAAAA.H4sIAAAAAAAAAIufJV7cukmXM70m263Tb/IKptcHS9fcv2qdYF0hI9l34zgAr/UYgiAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:25:54 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.uSXrdLG9pNFHGg2xLS9hUqV8tKox1jF-7PL7SPHw5lY=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkMYpnOH_wmmEB2Xws-7gCAriyUCtYmJl1gNX-wrQ_LwZoft3yrF52PKaiI_Ge6hfhOzjf5EhqMz_7Yct3YzVV7aFi2zGKuvHKwRDSEzF14kDWhR4_G-VlrpfY08dGdloFnLOmDOT89gEc5ecrun2L5v74VzdtbrG2RutS-k3EDZwdooAe9En9mUk0Xa_OC1Gpu9_AlSWA3g7-kspwkfJRM0vaFt16FJMFftRxJaj9PGxtH4dx87n4Nys1gk3W-WrU=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtnrTXFwloxDOASWQuAo3NsRdCoSd0cxmgCHtut7NUif-q58NhGfmWPij5Cx6oUMcNPo4mcTeTMmIj0W3pI5nsYiy3Inb2RtR3So8aA-52BdNRwD8RrPkQDbjWFfCXFfGCcC2pWC-wPNir1V0ejcUWiDfYmHDgmU2Bs3aaVmpZqfSOSyjR886VY6gSKc9sXJVac59p2Eg3UiAW5q1lquGfKMQOIkBX_LqoZmnb3-PmDaxur6jKvo76aPJQQXXcXjn5FIuA6VdXMSTxQ1Z4IgcnKo0hY-y09sCo5e3SvQ23sTPZL3OTX3VpKF339Z19rxG3w56DsWrMKt1aID-6Ldc_z9OU3Nx-K0z69faI9olWFVFoAbriX6I1YLhlGHg3zzd4rbDzKqFzWBz0gpzxWtLi852JAteAnxkFTUpq0pcKX7IwgGZ4l7AwhNU1MbatN3I2cCnHhzj2YhDNNYtkGCIOtR5-aYib7tor8A9ONvn_djRxq-Ow9R2Q0KxmobzbTQkYrzn1IAz_dRPdHDeEu0YSpQx_Qhlagk98_CmpGxjsPWXP48WQfuEr9ewZAFPPE-ICdZGslGjrqJ9d2xqc2VYGLxD6ZQXUzVahC9Ak4V5hykQq8ll8OtetjrMMJO-buAq36txTT8uPmqOd6MDhxCDzouuB6uRhGqPK80VlfoLPOjHV_fDHEVODwTw48UgEAshwIynJrTS1cSg2DPWi5ZlOPvXXOdYJJVrVxldqFq9SJAzMgKu9F5XGw8lNLDqjAek5eh-cu85ILM3WclF-E2vYBk6eVCK2PC2TbNZGBAfcT2ojXBJK5vbwZMA7Z6yNxh-1IedCl-9VbCwc1laHcsX1aIvCULWsNDabDFQQnJK4WqlYssfqeCjmVKKTHfdztVK8LEC5fsIUe--C7Yf0UEXie8CxQhQbOIGsNz8lP2gX8tzyOOdtpOk2VX0ljTSgYwO2faVxHpx7wKmCMGPjX5koIxhImW4Yenjo81OCIC6ebAkdmTXjsk9AaABLobNGENUv2t0r8oRRn5nFMoHcDTimOZXLKjZRdKvGaf26UEmsBjhddBUddFzhE07y0i2WLTxci0w0Poklol0SHotDdGGIlYSAqRCu1AxHFHjiXXb1-euIjfRDxPjeSQecMJ97zZAUKNqylEd0HmQ_hknqcujm6xXUVVQsD5DRFht87CyZmODHd0SMjmwi8gyvEnqi3p91iSwIgt038771896Quh-oF_Ti-JJFPRT8ZR2ciaXVBn5chvfOh-F4rIbcGvrZb0Dx4p3JrQRxnxI6QWJ983SnDvHyTmcka8Yi0qDeL_9SlGgsWguwRlShCh3t8eIE1pdlztHEWZ-A1cYu5xheAc1xwVbp2okjGrd_ROBiEP8s1d2umxQb8eruoaJACKrdD9sVEAqLpdRtuI9pVZGPOft2VRuaPoGj5Pk2wPp_5vcZPUryWMKS5mWrbqXqDmEn_GTb4fq9c_Ql1QAYac52chKuQ7rU9DzL9Dx5b-cvkMzN-Oq4wrCO1cPbw1gpW-GZl6NhxajzeZZ47aZb_Ia2Zu2MoX85bpuzkCZtSVP2hmZ6yH3jI6uS4csiVeOa5C4xTlvqVliEbiZ3eAJEOJYjvIzp22DaNN_dDUzsoWJZczW03rXeDQCF7so6H8ab83ns64XlBIyG7HC-Uvgr-8oMmxSBGM3iidF1y7Y2o6Lf_hvt1CyUB1ER9Q0djsGbEGNtJNafWPSefyiN3Ne4dSLfeTQNs2NIu52pTSo9c5qzcYuPRE1-g-F5bw2rvYmVU3BbIFSEv2M1ah6Nklea_ltzTzBrxFeYq3vaFmbr8AVRd99sVCpp3kM1Zj-V7tHGaeY-WNQqVrTdODF7LGX5cHgByKRX0IkaV_Mf_IH9-G9J52DA-HznRAZlWOECNXcsYJaIzEVIUpd2o9IDZXXmxUuKcB15P5_RXAhrBQXtXhzvUIx8RjSvCdLFoDN3ZNjYnDPZz6EZU0KqtJguP9zxpgTRD-2j0pZVN7cN0v1F2wBbaw-d610BjIi2-Babqgl7WrJWTSZCjCGw8Q64r-WNx1BnMWSFjQPPNxfmnlqav7DMCCIqrvZZhI09vJUikf4Sc46BYv5eSyelzyfPzWQRhctlb41hUEbO4GzAMfmwIFzNpAZfCatPCi8EGNzXyD1UKQwuWg-FOTXv4N6Kyw_zEqqE-z0ZAmG86dNQjVHNEhZDsb_d1m3SUFqlODcXijDlLCIbNV8rLiupA9hydQ42OC9IEh0IboBkLG-P_ZN0I47mfme8pVczKlCiKWqZX6VdigXNfl_fPS-5ylShcBDmMdQAd9PfUMHaBM7eMHKDKZE_Lmezh2Aiqrijrq75_Sj9fyHugj_PqBxPmKmUDHetUWOJigwOK3OrcJIqcTeVQuXr6fgjlpGo7XXOPgc2_uM5-zax9yGdD_oDXN5d9E0l0S8bXs2dT579wWnr5gyZjaHkLVcGsZ1Q;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWHdiCljoEEMBQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=1A0DA79AAE882039BFA30FB5F917B812; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkP9GKhoHtSx-cTOEsfUBhc2aOwcYU7i9p4JptURjo-Z2vXxIIFckUZjvj3hesvANscrCfSOnXRWxzLGrgg5hYpvui_pGRpjl1tXv34XjVpznV7TA_FccWkPvfyBgh4eQ1wkzsvRUlaGsodrHTpH-USoXg4y_vXz3Q7AQHEvbm5vDOrzwQML9z567Qy514b9QxphH-DWb44CiV51qowi9SBS6pLG3m1WscG633T3pfNp5e1u_pC0dmjisbmas846ZU7eDL5IrlgXPLITHmsFs5xCYtTT0aIvKgf56QETV3TcvHf0-Ns0QQSCh7qevAunOTLMIaTk961BFKSUh1oUGFW3VJ1xoyNKLRPnwFzOWQFBfjIYYSvwyBnmXOMnFmJB6Rm-xeCi9O79X7u0dU7GX7ejwuyAy_1DCZlYHvTjmvq3-ce-gFSVgEUdeV2_iOabflSdJ9P0SQK8xvN41vmo-z-AUElxgM2Fq2K8wG16gEZcoKEbJJI3NE-CnufsjeyAUloBMsLiIizjCJj-ABX2c5e3Eb99AlANEalmldVahDTMz_fmk9m4PW4x0xKYnNWwoRbFdmw0a83sT9GpdHOkmwZp3obmSP4tfgZ-195ctf4gan526s8sDNogTCCvYaItdM;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWHfgNPDoEEMBA=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnCMcSlYD6XzJeuRls_lSkZ_J5VopKWbPyskWFzRJvOp03o3bbrVT1LUEySnWZUsqYhI3hzKyoTU0MoOzr4OY_C31XsrFP5A3S7h_GeqL8XhRCIkwFnsz0x4IXmFomZWW4unXyNCEdQabv0P3qXkqYu0X4Is8khTKMjq_eGTTT6O9pxGVafwpUFlZyvczRL11jiVTaXcQuqj90Hz1PcgnKC8dWoSjbMCECBw-Ox8KW5VaSB9isER2nlk1p89L0tBc4Ybgcc8g2a7W2wB6d4ZS0TSVw4ioi2laXYPpHGfn3-qTqM4uW--PX9W5OgDZ-cvrjWJnX-lVnZ_6pET7bdTzcxXxTM4OPBCCUd0IwI1OHowUqv5jAkbWxCRocXUONYGTgGjGeRzx_dK6I55l41XWyRSHu2_ADReZ_dZdFYviH1f1_rJe__aoMMIraMmj5rpZuHyiKjXC-0nBThXraGPdnKfBrZDBVlZTWuug01-LQie8WtfPIYZZwcxcBtnkRLOL84751LU4mQi4LON6kDToBKan_TdPaudjANXtSbfvKIgSGsEWH9JiKQggZf0AtTbAwbXkpdmf7hN1VLlIkQS0yVZ2tz58qrN2KltwrB9qiwFSGPxwSNF9us1hUAmxDJQJbVyXQcYH8s__8BKfaZu-b-Kmmxq8-DomF42UrEp1As2w;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWHigOtDoEEMpA=
     status:

--- a/tests/api/cassettes/test_atw_set_dhw_temperature.yaml
+++ b/tests/api/cassettes/test_atw_set_dhw_temperature.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtn3tP1LDeAdN9IoBHewnxc0IHtTZZeDXoVLtfgp-5VClvDDgkyUz8xSL9K6KwNYU6aMtoE1OIXgv-ubqz_-4PqQ_dfKNc_0MGRw-h_5VSko3a2F2Lu4-BpnR0wG5XyEIMpXDldp3768QdjRUzPlstg4F53e54iQwpw6EmYdthm2xrE8C-r6vvDB1-vTLWRJ6k2_UKSWT4nc0OcnEIwjjiqPdRWB0L0iNtsBGQHGPl4GW4Qm7GecLGvI-FwxeXT3P1Y=N;
-        expires=Sun, 12 Apr 2026 13:42:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.JjyBcrGQjghCzPAbh1S9g-ipqU6J2cgWL8NQU-Gg-6U=N; expires=Sun,
-        12 Apr 2026 13:42:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWRxii5DoEEM1A=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=72863923-632c-4b2f-9020-9780a57a716b; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972205999397.YTkxNDgxNGYtNjQ3Yi00NjBmLTg3ZmYtODVjNDViYTBjMWI0Zjk4ZDQyZjEtODlmYy00MWNjLTliZGMtMmMzNmY1ZmNjMDYy;
-        Expires=Sun, 12-Apr-2026 13:32:00 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972205999397.YTkxNDgxNGYtNjQ3Yi00NjBmLTg3ZmYtODVjNDViYTBjMWI0Zjk4ZDQyZjEtODlmYy00MWNjLTliZGMtMmMzNmY1ZmNjMDYy;
-        Expires=Sun, 12-Apr-2026 13:32:00 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=Mo2hYNVNH0Rj1FYrPiy0YtNr-XiyIjUcXE1r5YeJvbY&amp;code_challenge_method=S256&amp;nonce=639115972205999397.YTkxNDgxNGYtNjQ3Yi00NjBmLTg3ZmYtODVjNDViYTBjMWI0Zjk4ZDQyZjEtODlmYy00MWNjLTliZGMtMmMzNmY1ZmNjMDYy&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkvtPrylFdBV7vU2HsLZ2hXfhaykYG5KUk-mBST_h93Pfn5K45imIVokciUVyatLf0P12PoiaAc86RA4cDr5aDcCkcu7X19HuHKuuxP1PnmI8kTDot5Q0iPBdwklW1aQY0zJJvkiSAO7QKHs86pz9WzDOnWIzty3tG38ZBWQZcNraXgjCtDkHCc6lY0PWSD7vhmZxEa0GZEIxFzrpL4xW--8BPoEDRXXQDfsR_DqdczMfW29Um5cXkJiEm9vCyokPJfm0EAe50UqYEergSJALXU52JOgAtmkjQ-XIGZ9k88VHRAdjXL4FYKwN_8u7Zjg3Fd6gh9UX0SYbOcwbTyUQqtMrW-u2sYnaTt3t1pTojCBp6nGC49Hk2ho-fOT5JuR_FjtVTs4Ccm-0d-fz3WyNZdymWRwGUwjAdW0DZlDTJSZzwPosTy4L39909TqBO_3KvoH93Oqr5luZMvWbAPVFz92oqEkXBvlYqMdjwnw0UiScX87E3ZloJk2Env_mxkjcUZO8ncg-F-LMD5settUMHTXubsIPGLyYREWryJfT3uIbbPSyopfrasTh5O5_0G0el3BR7t2nkrdNG2x7ndiLsd6JQAbPud3yGoV94vqjpMS_oTTTQzuVZCZZJkHtPczNdIm_0ByXugchPeWtpmHvKw\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"72863923-632c-4b2f-9020-9780a57a716b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-07716c5042ce\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=Mo2hYNVNH0Rj1FYrPiy0YtNr-XiyIjUcXE1r5YeJvbY&amp;code_challenge_method=S256&amp;nonce=639115972205999397.YTkxNDgxNGYtNjQ3Yi00NjBmLTg3ZmYtODVjNDViYTBjMWI0Zjk4ZDQyZjEtODlmYy00MWNjLTliZGMtMmMzNmY1ZmNjMDYy&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkvtPrylFdBV7vU2HsLZ2hXfhaykYG5KUk-mBST_h93Pfn5K45imIVokciUVyatLf0P12PoiaAc86RA4cDr5aDcCkcu7X19HuHKuuxP1PnmI8kTDot5Q0iPBdwklW1aQY0zJJvkiSAO7QKHs86pz9WzDOnWIzty3tG38ZBWQZcNraXgjCtDkHCc6lY0PWSD7vhmZxEa0GZEIxFzrpL4xW--8BPoEDRXXQDfsR_DqdczMfW29Um5cXkJiEm9vCyokPJfm0EAe50UqYEergSJALXU52JOgAtmkjQ-XIGZ9k88VHRAdjXL4FYKwN_8u7Zjg3Fd6gh9UX0SYbOcwbTyUQqtMrW-u2sYnaTt3t1pTojCBp6nGC49Hk2ho-fOT5JuR_FjtVTs4Ccm-0d-fz3WyNZdymWRwGUwjAdW0DZlDTJSZzwPosTy4L39909TqBO_3KvoH93Oqr5luZMvWbAPVFz92oqEkXBvlYqMdjwnw0UiScX87E3ZloJk2Env_mxkjcUZO8ncg-F-LMD5settUMHTXubsIPGLyYREWryJfT3uIbbPSyopfrasTh5O5_0G0el3BR7t2nkrdNG2x7ndiLsd6JQAbPud3yGoV94vqjpMS_oTTTQzuVZCZZJkHtPczNdIm_0ByXugchPeWtpmHvKw\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"72863923-632c-4b2f-9020-9780a57a716b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-07716c5042ce\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=cd8fd3b9-335b-41f3-9227-3aed65a423df; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/m4OhZQeEyMsRWlj/0MPZnLDP22zcJlQLYBEcBD5K9HpffWIKg5yMJIj8ZuICwkXse1lCW9SzDvWXM+d2afkR+1681zme0hKGpwSegMZAyqVQxF4k3beJk/4Zk5O4OsxXib2cj38/KnrEZr3sy3sE8mVsVrBLpTFSM+Kl/bJ7z6Z84Aj4aiuh9jl8aQ72RaFykDVUV52CH1Ar/ltRKX09RHvTXx1JEAYKFQBJr0CmWoHBoPqhJ68yScooEXTCfZvFGUULaRw3wExpg7BO/RqKPZYceIfNl+Kgi/L5VyQ15/FkvRMfTAbiAAAA.H4sIAAAAAAAAAFNeFaXZu/OXyMJf2z8JdCnMFCmt8WOV6FT7WO+auGAORyUAeng9JiAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:27:01 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.JjyBcrGQjghCzPAbh1S9g-ipqU6J2cgWL8NQU-Gg-6U=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtn3tP1LDeAdN9IoBHewnxc0IHtTZZeDXoVLtfgp-5VClvDDgkyUz8xSL9K6KwNYU6aMtoE1OIXgv-ubqz_-4PqQ_dfKNc_0MGRw-h_5VSko3a2F2Lu4-BpnR0wG5XyEIMpXDldp3768QdjRUzPlstg4F53e54iQwpw6EmYdthm2xrE8C-r6vvDB1-vTLWRJ6k2_UKSWT4nc0OcnEIwjjiqPdRWB0L0iNtsBGQHGPl4GW4Qm7GecLGvI-FwxeXT3P1Y=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtn1tszBnqkScpTX9ZgfizujP8cpISMJPOFq8FJABizvVHkxoaQvH9cDRjE_2rjO1notj2sGkBAhuwkpjuMmfAhpQr_qgS_rTo3Q6U9R6EZ21G2v4tMUL19K1q25TnuMjrbUdyfCdXcKdlZm_tIIByGkw5J3cxBZm5556t15ZRPZSNfH_CmXrcLq08BbAjiVjiqDFyUldm8-pcg6T6TS1tqWXMo6DbR5W2Cv3ttk-fEZHJq_Y00iTOuzs07Hmv8AioRbhXp1f8s0CfE4sa8wAHNOt97rUYMX00jtRMknnUPhixw1rdUlv2hsh235WlvYjtO5zL9jH4rjAWB7j_op8c8dANQtMd_MK7VfUx0llkPoX6SqlL1GHcntTNRFTJGakYi11q-xu5AFZkCb9E-MWIOaM_3FfuvRTEz2cBOYD3LHx23UbFune5JG_Cvzh5WjLZzyGKpt1gSQZqaTXTi5apAry3hRQx5Mg6xGiw2QQ8Kp5IlkTqhx_-IdGie1aWKEH0dc7QRIaub3rllwv_F1JAtBODDaK6Z0HTjDwNyV_0tyrTxzEa7WjTNBUyIxfycceZtmr-fmT5YpwZl_HdZ2ZMCJd046I5fxuBVneXYgEY6SYBIhRJuY5-9Y_Npk5js9UKdI98bJLI1OsVBQLZR4EkM0X_uUi5CuHXrx4_MHeEv-lq9NobR2vQACDv6v0jG67rZI_fMnUqDWYtl42-5f4PInxd36luGrcuX3aKG69XwTQehU2PPYk01TM9W5Jgv3usLtsQ0apw1rRX0Fj6KpOXiOlv_f0XAsYN_fG7S0drpnmxByA1lqWCWByj_-7o7H7vz8-mwdGQrNa6zUPpPuR4R2vA591nR3QolMN1CqnMEWJXqK2uk8KAquQgx6SVNUjgqRyKhljdGoWC_X37PoMm1sFhhMoKEphq2IThgHi8ilx1Fxp-oNUMbKJLlquNeXTR0DVRW7d417sGrRQqgrlgxFmmjtX8Ce0HNp6dKTwQNs2r7LfC37pHg4YdlG7S5Duandxo4i-KOmJPQTkvOfGWI-wm89e3fE2MW0gCSF78-X3c-s9ELDQt3DRjCtDRj_HPjk9DiCx-CQ5cnJznavAl48u0KOgunTNPA8_-Ak4kAEL3Vfsaeh48jl7idqSZYqiGJXPjxRlD9Uk6qEtmWADl2FJg7dIvSZT3VGJMbmg3DDuXWrUO1DfQCiVOhSO9zxfWJJMGkJN2GHNOPIcNL_4Jc6qThACFgY3DgQ7TmQd_Jr1ywex0aDM0SYMlzGp9w39KdSo6nd7AH4y3b2gVwO25e_i4OtbOWWsURTiDqrL7IQjgljd-BHO3PXfYGwv-F23Ef7dl4ZTwPTFPKvq05R4B7wA8oqT4JsBHTFAdi_g3VV13kHqSHEhgyCAEJ2dGmFBLP6sKZ7cgHvQ_1zMp7fnQ18qIrx_qlmJUVWJvAKhqOqopSB7xhTe-PABdsPFXsCk_6rcZr8pBqAEn4KZpKFCKOO27yfuRGfdn6Kv3_gNk087tms76twD6ddLZOrmKzLByNVIDLKHNKj-UO2c8K3uFw77IS8hayuXOfnLeoXrFMHfQuIskG9NMfbpM7_ae5Fsgqsd0V9JnTM87_cpeZWOKOgliODEhYzDp6R1PA8YdB8Mo_GukqbsW5bEKl7MeuKb4PoAu6oeeqX0nL_jMNAPnJX4PEyufi0trxjVhGHs0nKWi6RiMH5Am9yWan5rLsZnoZNGV4tFnHsMEbEtvCIAiCNEjlV8l3-JCVTDJBikgVGGnGN7dIQ4o-OTMZQzIk1n_e_aeWZxnZUR6ZOABKNMNHArA_jYIBOVzzoSVdq0QMdmAPuoq0Y-Z4pUYzLil4OXpTY4Pb0eiCzTKrpxLeULih-PL_NfvGOqF4OWihKcoJOZAvrWByBBXBSK1zoGa3bqGh9kFmU8SFQ4mBJcUQ4MfLOq6zdxRqYhdLxYu8zDnxfdEWI7jxGuLZ-3SO6Gqhr5Jk1nZp5cQpR4l4xmpcgBLPqRAr_QpKxkupRpqeKyFWmpAf6AYCQxr6avLf52wI9lxMUvu-TlT1TIxZwy5lbGHqRLJmRPmuhH-1jgTP7U3T2eFlucn7uHz5no092JNgnvzGxkeXJ1etqhlnVNMSDrx1VXLbfarYbw7J2okkRin6UKPmOFDOpZ68HpvKPldroWdazVjfaOQh1_Bo1XYFUDUiMTB93yXNyemTTgmiisDa3n7CI5fYDgIvq2T22Qjrvf7U9gwwDzPD3ga_huOGUiV41BMuLZf-ja5rX0sQjua7NQwmabdIYhmLsEDx4p-GAtTSziZ35ezlxojYkT8lc8qMJGvO1v4hfq2yMN4QQXEkaDXspBj55hJ93LdWQ1usTNolAXysAcyuhYyw0UYwwh9deqRqHUhmtwrSYL12JgWTJEdDK-sV0Yj371LnxQgcW0wMSIf5ea5tjAzb0n75EdQr2k9qFqA-7dC3I0U8VkyuLjQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWR4hPTDoEEM2Q=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=3C7494EF583F97CA66A56EA83FACE83E; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnt2RBJTaxuX4v9_hn3QukUBqHkeXFDWZVexdP_qPSQPRP1A0NiNLrF8O1gh_3Vjhg-3ugL6zSVHlbW3Spl8zzGUhRu1OMXnOCJSkMgH2zKNLC89Ywawn5B3JhPEftJIQzHn8Xxgej-lw7iVaPAxndqQA4oASklCOSY5eleZU8pibgU0Wc_M5vC34jrHD_iA70BGLncE6pWD0CUR-qVWIogviL2Ql8qCIKPQgrEwijHve6Dvl1H71RCYVbK1BNG0eR1S_NLIiL3MXX9Zcu2EILNaKQCco97WOH3S6O1BLbgFKp2qqKgXJwpXpizDo2tnaEEGEX4YWi4GqD09v3aSpBKgeKGVfiJFZ13INezCUBOKJaEKe6vLm-h16uQAqh9TZ-JrNAUirt4D7n4xTX6924qfa75mNX2eDMq8U1q46MTHuCuNziTUnWqzxSIkAJ7b1VFKORP_yQHZvfPRESF0NYWpUZioXxsjY-WQILFEw5ODFgQA3x5JC1m4QHBXhQoXu9JdtyzkZADkYnAhVB3J6AZcHTIZYil-5jLPQwQZZPTJP89fXBjrKhaubP502kW06uSVQ8QvM9MSYxWSkBg1tdzMLf5MV-txu5LX5wqotsRCIIWZExKAxaRrCQKRtiGraA;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWR8jv7DoEEMDA=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkUim584lfnwunZYl_t31PJYadT0LjUq9jK9FSbU9J8zemLUUCmGQUGfJ7Hcb8BU9YXoK-JFVKonh1m6Mb3yXiiNZBqvRW9gh4cyK0IK6CiIuiJUZr008rJrgcBa0-HzG9qCmvcShSKyZr4Z4WFwBI_HVq7pcZwtgzmymQv1xp08aQDVjjXAZ72YtvI5thz8L8dw2skacUvOad4zSbfQgr_4AP9XXAhOshxlQVlMXz0_w7_2ws87kJE6SaZGDstC_xkmieKxYlUKyaEnBqCdZ5UQLlnBC2--N5ND2l97wRBO278lVcSL89-huaM8DWw92eqZHVZhNPJC002HRjifUjOXfZmHTAe1jtdzUJnLsHfsfZNeXP6dn1l-K8L_j6S1ZnDYVLqZPTa8h1UWSEAl-h8R7UV_2aHScu77X20TWf8zFS91x4k22F93fpZL0UW9YuPM7lMRo4CSc0LHk1qlCXplNEO8muakiGblsYyZgFydiGtiUrXGCJuziF1wK7PpK0Ggj7tvIdrpXBjtGKLQvmXJ9fMXuMBqUCb156gxLQZh3zojlJgvnOfUHtkJ7Mi26p9MS_uwDjuhN9gJmAOBarsjgLZfre7ot3mJlLycavKcm5LBrl4cz2V52dF7gnILd7CN4eupiioH-Ej2mDmsWrzA4dqwvpRJHDc7DCmGwRlWA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWR9h9MDoEEMMQ=
     status:

--- a/tests/api/cassettes/test_atw_set_forced_hot_water_off.yaml
+++ b/tests/api/cassettes/test_atw_set_forced_hot_water_off.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtk7R8SQcTfWEdGA3ojSSv1FHGcrYQs4k4h7QJkDHSquks0TaImxLO1e-Vcq5EbTUVDPDtcO4JfbuVaFtCD-lpwdJ8gaDsbKuBW5WgVAkmn-wWVNYOf9US6iJStJ2NIc5qaNwDFCkiNhK67lX_hDjoMTgnTnnyj1nrYwA9Mo3BEoj6c_5T4jkwizGm9OpwGxBxisRJAHhmw4sMYYKkpPjoPnfhfSlxs_F4mNuOOOdZM0ybDcBW-tl_I4KQj4DLMGplU=N;
-        expires=Sun, 12 Apr 2026 13:42:05 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.Acl1IbL2O-gKnZzISqWdg9HOyuGKmkzE6owvyfzI9y0=N; expires=Sun,
-        12 Apr 2026 13:42:05 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWShgm3DoEEM6Q=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=bca308bc-9646-4f52-a52c-7251e6d8666e; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972253528402.MTYxYTkwNzEtNTQ3MC00MTRmLWI2ZjYtYTBhMDBlZDY5MWIwNzJjMTc2MmEtODg2Ni00NDZkLTkzNDYtM2QyM2EyODdlZjQ1;
-        Expires=Sun, 12-Apr-2026 13:32:05 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972253528402.MTYxYTkwNzEtNTQ3MC00MTRmLWI2ZjYtYTBhMDBlZDY5MWIwNzJjMTc2MmEtODg2Ni00NDZkLTkzNDYtM2QyM2EyODdlZjQ1;
-        Expires=Sun, 12-Apr-2026 13:32:05 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=tKMl9kDaTlIj82JftFbY9OtUy9iuYm7vua708sEQW-E&amp;code_challenge_method=S256&amp;nonce=639115972253528402.MTYxYTkwNzEtNTQ3MC00MTRmLWI2ZjYtYTBhMDBlZDY5MWIwNzJjMTc2MmEtODg2Ni00NDZkLTkzNDYtM2QyM2EyODdlZjQ1&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmxsZaCko46W9dwNACMjsGzwJTRtifemXpKnhBZNQrp0ffR2GEN7lsgGr9rJ5BQMQ2sVPSZWpXqSziImJTEbcDrZEY1JWAq0jz0kbe1Bj91_hQQES8M4au3oCRFU3TRDA-lfZk6hAGf_wNAFFUfxfi3LkDOustCtLLzKsJWqbP7xVHLayjNu0i3wnv-2Pxs7ZQfKta4qdcEz0sI3jYawoFDq2x0mSH2qHibyYaTz2Tk__-Og8DNI8pN80bJ34G5zmsUaJ4vHk7cOjN1Itz05eRyxbfKHzr1IKuA_AeH3e8STC-BnVANbqLOYnBgbzA3rq6ZV8T5rd5uNLJaWxwTvK-ZLt2c81ctlK-hONqO4PGzd1yyEVOuW_i4X9EBDOzGhtFAMa75DVk1syYGhOVwMq19MApKeqa4xJsszETqfH78BbpPyN9lsP7E8dnBdvOejZcKnyO8E2n7HTXRamoBqoiL473MX222huIHsPFCATaH1U_vQvZBTNTxWlk9EgxxMtWO3RzJ5WS1eXAlQL65cyZhb4368ysZja_Whqbl_sGIexCFm7vQPE2lk0mL5k2XYiktVYLwtEpa-mB3Olyv4k-qccJRXhYesZx4WbptOy0w6awkK3pBe7rSgsxPWia8nLuLFJ6KaQDRqvU7tIbPhdsQ\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"bca308bc-9646-4f52-a52c-7251e6d8666e\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-3a9bb36b42ad\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=tKMl9kDaTlIj82JftFbY9OtUy9iuYm7vua708sEQW-E&amp;code_challenge_method=S256&amp;nonce=639115972253528402.MTYxYTkwNzEtNTQ3MC00MTRmLWI2ZjYtYTBhMDBlZDY5MWIwNzJjMTc2MmEtODg2Ni00NDZkLTkzNDYtM2QyM2EyODdlZjQ1&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmxsZaCko46W9dwNACMjsGzwJTRtifemXpKnhBZNQrp0ffR2GEN7lsgGr9rJ5BQMQ2sVPSZWpXqSziImJTEbcDrZEY1JWAq0jz0kbe1Bj91_hQQES8M4au3oCRFU3TRDA-lfZk6hAGf_wNAFFUfxfi3LkDOustCtLLzKsJWqbP7xVHLayjNu0i3wnv-2Pxs7ZQfKta4qdcEz0sI3jYawoFDq2x0mSH2qHibyYaTz2Tk__-Og8DNI8pN80bJ34G5zmsUaJ4vHk7cOjN1Itz05eRyxbfKHzr1IKuA_AeH3e8STC-BnVANbqLOYnBgbzA3rq6ZV8T5rd5uNLJaWxwTvK-ZLt2c81ctlK-hONqO4PGzd1yyEVOuW_i4X9EBDOzGhtFAMa75DVk1syYGhOVwMq19MApKeqa4xJsszETqfH78BbpPyN9lsP7E8dnBdvOejZcKnyO8E2n7HTXRamoBqoiL473MX222huIHsPFCATaH1U_vQvZBTNTxWlk9EgxxMtWO3RzJ5WS1eXAlQL65cyZhb4368ysZja_Whqbl_sGIexCFm7vQPE2lk0mL5k2XYiktVYLwtEpa-mB3Olyv4k-qccJRXhYesZx4WbptOy0w6awkK3pBe7rSgsxPWia8nLuLFJ6KaQDRqvU7tIbPhdsQ\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"bca308bc-9646-4f52-a52c-7251e6d8666e\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-3a9bb36b42ad\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=b77539fc-51df-4475-8413-ca3551f7e7ae; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/jhvHuDs+4B1h6kgSnazS53AqAAIUGTzYc5EzxkD5DrlBPiv59MPb1p46zXXKsHvU9V8Bzl8355Yhzz2HbNBj+Ybvb3EmJGVkvmXOMUh+1i2ha2cZN8Hr+J7zGQaI+KbaOqlvaxTYuv4LYPcl40FuRLJOAnjOFYeX4Nx33RTZmgbQGeeHJcObNbOxo2WYstsrgfciB+w1dV91PMA1MSE/dy8FnpX8cVNlEbqMOsaemlyj4TWFZSdlrWmEH6DGuChZVKm1JUFXky5pyfYQzfRTpzNTVnIQRPiKwKUz6ekoRJSmaEQHgWjiAAAA.H4sIAAAAAAAAACt6osfvFix9gult8sz/c08W6D2PCr9vPrula1Hy52rGTRsBCu3QEiAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:27:05 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.Acl1IbL2O-gKnZzISqWdg9HOyuGKmkzE6owvyfzI9y0=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtk7R8SQcTfWEdGA3ojSSv1FHGcrYQs4k4h7QJkDHSquks0TaImxLO1e-Vcq5EbTUVDPDtcO4JfbuVaFtCD-lpwdJ8gaDsbKuBW5WgVAkmn-wWVNYOf9US6iJStJ2NIc5qaNwDFCkiNhK67lX_hDjoMTgnTnnyj1nrYwA9Mo3BEoj6c_5T4jkwizGm9OpwGxBxisRJAHhmw4sMYYKkpPjoPnfhfSlxs_F4mNuOOOdZM0ybDcBW-tl_I4KQj4DLMGplU=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkwdNsgT1PSgtzXlMz7KasKgZ8j_58gx2qXAmsPdSS6C70ILGIX1CJ1hKGo0Ssy6Gr-Qfh5y1gmd0gq4aL6KKr8EfqH-iRihSsVAzwq6v8Ot6M9-MYXJy_WthLnrdBxDjHNQON_QSEU1mcFtFfjfZIdygnBws1EUQSMg0tRI-ztOa3MeNWslqTkIpLXLcLDiqI_ILnj_mdUddNFI4mqhLHdjLPZmLIuXL1ajCnrc3ejLMfyIpqDn8Nv_0HHfPwynx6_LhClz4H1R_zRfKzSLvSUYIP4dbJB3FdEaW5cb_fPZByu0gY8mvjmy96G8_Q7K6uK-1JGFYeF3gu5cGmTpEnHdyyD73J6xol_4i1Zq2D8CtC_5d147z0Bx3znMEbMWiiQAkFTPwIhYedWQx226CiBEROtaVFs5wgP1y8PNVkh1m3zb3wBBbBlt5meVZmM4_rtNnwQi2F7dbMHjO6KWL8j0EEP6-yuiUztnXzKAuYp9zlCyGAeDMPvfcrFg7eH9hVzfQ6D3tXb1mgb_H6zmGyNcDI6Ai-ns9X0x4y2oMv5pZsNUhVAgQRrEyxJ5o3MSE2bvOqfy-Bs---hDxc81_A_YhHMyPULNeJr2T8ktPl-MnlLQ_r8o4Tinaow6UXZsNqFMhnEk2qbI1RMGBld04l8PDmxoxBE5y95gfGz7wC3rtOo27TRM8yeLi_djuLCZoW9bcmFcWqD463S-vVN2jPeJMW7NZeywvHAQ2HRo9imtGoh4rsaCQ0gfSQH3Pho1mP9ta73Yt_AI2Qd32ilDRbpPftCLc-K5cL37LiPXiN9f50_DHvAdSAdaNGbh-c0GHzKsRuJADc6brghxRLnh-zN-MtB3B9f60kNOTbWp2PPxlk8W2qa7ck1YHfsN_1iP6Pb5I1hr0jruzFjpDt0UVp3gMC8_MgJ2kvsCqoTl0u89cohaU3C2UF-BXjHmJ2F6jKOAU0Hp8QEs4cJoT4z4HUBfPCloskuQfLgSvwQqV8aDhg8CpeGNX_KqJV3t0ggvQKHzHS75uEfRmpGSf_M5hylFD1EHkhtsWE4FNaQPtMAnSxACRWSGVbB25gOJa4HqJtuce0u4deTmMqHnzfccwSZdhFlmU2mjM2O9v5-xlPj_02Tauo1Mwe5MveH1hPvmrkeYK92Fx3nJXOwazqIj4OII-sAiyQ8DsgEKe2nLgkkDKXgAGz-wOzNrxRrciKz4YP4kQi0a8L9PSW0SuXWAzHNS5tkDNbaT7EwIi0SAt6QDxcyQF1sCxVnIhO43vqe83S5QIXnmbwY9Mece-jwhWB5d2UyIKP6-4u2snLGYpkey0ykpb2Jx-0tCva6AV2dYB9q6zfTQ9dssPveQgbISr8cXlu68Ni-P7A8en2ZXGQA28P06wkdqENV1zU-OKLvuxXtFRE_I6nqkOmW9G2T573N_mqRrb48oKowCxnVTBo_MZ5H17HEJzdQHNK2g6Y9ieAOUskvfPcn3odqlvCvhd1BaFS5J3bTpnMZBkIo32oa5qzQuyuFXhO-fDOLYGDneE6PjB5w_tbu-RH2Ue9JuS7Vl2J_CmgcaSMGp88Yuf3lf09gUol7QZjELZqfGNlAjVbDU7l1tEALIiSCkxtRmN-HhCO2nyD3GP3NAEVTEJUNQN_IuQVlJQ7O5dA9Z1KTVRP_0QXvaBEeYcrtIC9AntyCTsvtAjAxzPWNiwJyxrzmCxMQHoRQ6vxEgRYQD7QHJSbv4S8YcqSWj8safIwt8N5PWD80U8ttNUIsAA8uTceOGviLz3iPr1dZ_TSrviyAr1bbRga3ea8VLlrA_MdwoFm3NMoGRgsyliKUoNOAIhWbq5rLNM8Obldenr7cu1nbrj3osdfPU2th46yBzR7a6Hr7sxmIO7khFca9Ia83GMofF-bTBT32tVdhmMHDelmowJaT13Efthxge9ocLGbUY_P_yN_Ze0alBhDLbjY4cg2h_q60hiUTpKCix1gCPtpO_mAdjaZV_YgxpRZbs0YpHRGgE8dmri_-SAcx3b6wbj9RyKdt390Ajy1ZnWmUFWte7jCJYe_gxc_Ks7MlYSg0FrfBNkW6cibN3Rsq_DFQzmI_bRdLfU72kRwbWgmpMx_utVSXoo0gONfxpb1J6lcrAaOcXUS1II2AGD2xeZzirlflzyQ6G9R2Y8iVvrkTGf1O6-G8VqulBgJfVs5nsIRIJ4Zf0mSQ2aTZISnfCL5lZW0LqrfARHSsTiXAuiEOkbFA3lTo1ebvrHTZmZwx5OGNEnsSyJnSPacze5h62D5CbvPr1ZXGB5HmijgR9Xtd7FkX23BJupJGsoEmNYr8mMAiSO7Qx03-eMvPzAAsXQZvpXGiRgJafB3J8kjLlm9Gs1AyRVYjqLQG2VwOH6imTsS3V4bLS89ftVTMO6bFUbhF1c0teJeVwUmDvxugYDZN6ccqji5ugphn89NSKCxjjf6gVOO7w0QigbEtHorEmt7YwfxotQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWSoiz3DoEEM0A=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=DE0ABF756ED5546BBC63B30DFFB1E5C0; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnxGSZlRoEZPgv2VO0b19aRCCPaLbU7_M2ObxbvvNWOV86JOSoRbkd-JcC83rK2rQ16IlvDVGq9Tfo5mN3Hz0P2e41OQM_VFk54o292ezlDAIeRwKRj8BIbOZ-yFwMG1cnEX9n6RF6e9-unwPcr73ml-Jc4kmGgVyPOZciJTGnzQar58vBvOnBc1c1qGTp8j8PWlZyy53ViV_IWKbLHYh_hNRRnXGL2tACQ4RLRHaXvp_gXcLGHlBP1fK8sWnbVNWz2jksCMDqiiAgqbivqt6V2SaVDKwTp22wL2Kc0N3ycjoz9lvLKlZjq_tDtEKoFxnkWsuGKJpnrC5_fHBGLI6unQ3F24NbJmhuRK0-RE53C-UQ07C5SJsm8gDIPySQSAY7zTqOknfdUPiNOeg7WpqdxT_aUbeLgRIuceJRrv1guetSCmMbar3jtlJpwJ0Eh9Rwayge-87K0GicgWLKsoM8_0B31VpfMQij44QBFLXTvISsjz2oLW-YTkikb5ekOlmSy2XZSsnMefd5Rnnmyi002KwmLjODfDntGffg8wbwbn-RV5RaF8ejpquiZaPdhxIVl-KwpCfEDEO0srGWEsQwLulIN4z0ZucmS_UsGP0RVQ278yQzCPDjCkiwR0-sJtKI;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWSqjUcDoEEMrQ=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlfezTgKiScnwkgbI2CVlgHCYOwc-OJdQwj-wZKZmwCgKNMr-R2wvRsnk4hOtUqMkv7wXrixOTQNhyRC3Ra4GNm1yb1_vt1c1F_G3ShukyvPBrNENvwmgfzWy-VC2Y2ELkyf02FOHGEWFPsb0dfECrk3R6EOMCW2WINFz3CI_jhdgtr-eoyLEA7bboPgdXSsFOGs8uzHCHHEMCkiACKG189uVxqKpfUBjZfq-kfBc-v0cVLwsY51gmKW-dGTaVI3dYmgZ8I3AXgn2qX-8B6_OdZhJhrAyVOxFFxDXMzRQzGZkM1vBjj1lMlZ2KFUYCiTC-knCt_413aQtNU6PVXQR80V-Y4Padb1PF8ngmJuE_O7kzreDHwdYvi4LLFFOl5WBLYZyo9YGq7AqrpobeXabgmYjd96AYdh_KV3Nr_1Gnldoj6CFmZcW_KIJtQxl2anFfHcgBVny_6klkEePkXFtJ76vgxykvHUaZSMtBfCOuZkEqv3poPtqfIMk7_-tTYNaAfpDQwxdMaHBQgj6OIF9NP3_IY7ZEcuFvOZk9Oy8SntQjhrlpbo9M1IyI_yXNYHKzzDCO_maEZjdkQyuulEFTfpBrzl91Rk8pg5777pXu4vFDX1QCVsEdHzdQiIFXpWFQT_cgOwePShPfJ1RbLmcyrVo9Lb9aC7ysXaeXyAum4Dw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWSrgfRDoEEMEw=
     status:

--- a/tests/api/cassettes/test_atw_set_forced_hot_water_on.yaml
+++ b/tests/api/cassettes/test_atw_set_forced_hot_water_on.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtktgGXKwrNMWA7bRHrCIs7PYnTEq3hLIMsMi2h33Cr7Wwn_KqPjWlEwo5ZW5-4M-ruo6h3PMSIzx8nip-NfkCT3wJMyfkYi7ZNOg18bgY3L-Wv_wDtIwvXc5pOobpqUoy1MMQnXlxqyFRd2Sg31Y68KML-JOVvzxAaOJDiSYKaRUcTKY1JKcqFZ_UBEgROO5PO5KBIRhiQggbYB7I3qfqd_Vi7YI1WyS-C2HyNhyitw6fCERuPuafXkKKp1YeiwJ80=N;
-        expires=Sun, 12 Apr 2026 13:42:03 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.sUxlPMbTAS0Rg0dl_LPvpJXbt_YZauOF_HxMsb22CpE=N; expires=Sun,
-        12 Apr 2026 13:42:03 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWSKg2cjoEEMsw=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=2503ffcb-2e56-4a95-80f0-4eb3451b7734; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972230752329.N2VkZThiOTEtNTkzMy00ZDE0LWEwNjQtOTdiNTM5MzljMGNlMTdhMDRjMGYtYjEyNS00ODU3LTk3NmQtMGRiZDZkZmE1ZGQy;
-        Expires=Sun, 12-Apr-2026 13:32:03 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972230752329.N2VkZThiOTEtNTkzMy00ZDE0LWEwNjQtOTdiNTM5MzljMGNlMTdhMDRjMGYtYjEyNS00ODU3LTk3NmQtMGRiZDZkZmE1ZGQy;
-        Expires=Sun, 12-Apr-2026 13:32:03 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=EOcZ7ulKX7qhT1OW-JdnYCAUfCcgr8_GHsONFhp0dtE&amp;code_challenge_method=S256&amp;nonce=639115972230752329.N2VkZThiOTEtNTkzMy00ZDE0LWEwNjQtOTdiNTM5MzljMGNlMTdhMDRjMGYtYjEyNS00ODU3LTk3NmQtMGRiZDZkZmE1ZGQy&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmsTp6H7h1OhZroM7RXCZLgjw6vNoerPBMagHrfPRuMMSdXYjnguvGWZ0OPbT-hoyqdT8D8LY9TmAzJq7kkaW_qs0KFDl__1zpwbE4WPnhS9gQPTrgc2V9Iqs1UZIkuoaJ3UA3Z35keatS7XDZ_zpEve83SZ-oaJ_wtfwC1Nnu4YbLwHhq97g-eQRv58CLlxorZqg-It2RzdZvu_-BkyDgAwGGNpQctY8_NnDUHdz4GywaZH1LnwVkh_p5T4_dr4lrBVzMIlgwMfNfwTdgUIkA2ZKUEZYqNgl4AMFZbtWyXr8ZBWWXUUfdSycNKqUAaLVt_P5A55Eel9b5BXDH9yZZpGbxi-OuVWwHjKJSqqTQ8LZMq7j-U1AP6kX8Y-YP9hwmh-eVLtH8Ea5QFSGjdinDUcqVnsc-6bhdEs02rNAGAoqtQHKzw58Qg67o5Y_Jf8IWtOdVNDrZ-z4WbF8Ifvzmzh2Pnfc9yDaTmIf4mrs5Gtr6hKuewEULYXwCE0PTLF6vScWI5YNiW9H1UOk_rBxJIS_29dj2AdsdymwcobfQzj4baeM0uYqQeLqOvUETf9w84WxNXCtII9YJSyhx48fH9XbSjZ1a6Jpv-rAajaSq7BwDUVk4EyBGbKe7gI1LSPdvgb4yiTnlP8XRyC7KH00p3\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"2503ffcb-2e56-4a95-80f0-4eb3451b7734\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-7e90c7287066\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=EOcZ7ulKX7qhT1OW-JdnYCAUfCcgr8_GHsONFhp0dtE&amp;code_challenge_method=S256&amp;nonce=639115972230752329.N2VkZThiOTEtNTkzMy00ZDE0LWEwNjQtOTdiNTM5MzljMGNlMTdhMDRjMGYtYjEyNS00ODU3LTk3NmQtMGRiZDZkZmE1ZGQy&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmsTp6H7h1OhZroM7RXCZLgjw6vNoerPBMagHrfPRuMMSdXYjnguvGWZ0OPbT-hoyqdT8D8LY9TmAzJq7kkaW_qs0KFDl__1zpwbE4WPnhS9gQPTrgc2V9Iqs1UZIkuoaJ3UA3Z35keatS7XDZ_zpEve83SZ-oaJ_wtfwC1Nnu4YbLwHhq97g-eQRv58CLlxorZqg-It2RzdZvu_-BkyDgAwGGNpQctY8_NnDUHdz4GywaZH1LnwVkh_p5T4_dr4lrBVzMIlgwMfNfwTdgUIkA2ZKUEZYqNgl4AMFZbtWyXr8ZBWWXUUfdSycNKqUAaLVt_P5A55Eel9b5BXDH9yZZpGbxi-OuVWwHjKJSqqTQ8LZMq7j-U1AP6kX8Y-YP9hwmh-eVLtH8Ea5QFSGjdinDUcqVnsc-6bhdEs02rNAGAoqtQHKzw58Qg67o5Y_Jf8IWtOdVNDrZ-z4WbF8Ifvzmzh2Pnfc9yDaTmIf4mrs5Gtr6hKuewEULYXwCE0PTLF6vScWI5YNiW9H1UOk_rBxJIS_29dj2AdsdymwcobfQzj4baeM0uYqQeLqOvUETf9w84WxNXCtII9YJSyhx48fH9XbSjZ1a6Jpv-rAajaSq7BwDUVk4EyBGbKe7gI1LSPdvgb4yiTnlP8XRyC7KH00p3\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"2503ffcb-2e56-4a95-80f0-4eb3451b7734\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-7e90c7287066\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=6b5c5a4d-4890-411a-89ba-5298246fac06; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/zGHifnFoOF/dkZlwruoNZI22Qevt/BrREMDScE40RdPTQQYqmO30VBgZhLxcq0HJP61xnGs1H+zf0c4XvhMOGHGKh8GtiGduiLD64hk5249sHJgjpskjUulU0GQGR1mL7E99WanL2o/yexF4m3pYJQrxn5GXbUnI0s2QBYQp4qagMJ+/SKg+gKRzUZ8qvW+pWoXuadusf8c7MtW0kNWmZ7piUPVKONfQvh6EUJ5j6TCZLRMGQuSpmL6xaFGTcwIKub2vxhfyRri8uSuC0ByN+3TYjh2+8LCeMp2bWDNWe5qvkYddWmjiAAAA.H4sIAAAAAAAAAAEgAN//hnam9fX0HyIxEpCfgu6Z5tsK7LTi/IXUBNhAUN1rIcY8mVDUIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:27:03 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.sUxlPMbTAS0Rg0dl_LPvpJXbt_YZauOF_HxMsb22CpE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtktgGXKwrNMWA7bRHrCIs7PYnTEq3hLIMsMi2h33Cr7Wwn_KqPjWlEwo5ZW5-4M-ruo6h3PMSIzx8nip-NfkCT3wJMyfkYi7ZNOg18bgY3L-Wv_wDtIwvXc5pOobpqUoy1MMQnXlxqyFRd2Sg31Y68KML-JOVvzxAaOJDiSYKaRUcTKY1JKcqFZ_UBEgROO5PO5KBIRhiQggbYB7I3qfqd_Vi7YI1WyS-C2HyNhyitw6fCERuPuafXkKKp1YeiwJ80=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmCgpKH-zcDyizRma1gw1xUYp1VMv6q9qBK3pFatLDjnhww-vz8NvnURm_V1sN3RqTFC8S2P0CXfG4upzbvmXnj_d-yGNLS4IMa2kuYvSwlu_GI9J30jYdV4Q2c443XNk8KinAe3pZRdHbWEIP5GXlmqRTOMlB-a69kuAJt2eLV9J-gcwCkKwJdesB0sJd5IuSM0cGlWaVOOfe0FS3aOZ8K_95Asd1cvEdoI7qsRkRyx9jG9SyUO8pBPOOulkDRK6uGxacfqXFS13Rtd7fmo6LXtXxOjeYtQIPouytJ0MrhynovCHGOQUFSuUzTfh4Q92FpoCRjk-ccvsQqsXj0GyCY4IKoLZxfB9up0UgiQKYzrEXs1NgU9p9cFnmwcT5It7nTIL60KzQ_3wjEwSbDIJ0ZkY1pTnXT-IdStZUsYY5Xq7bG5pHkkdN2EdLt0kfNdr6rS9KUFWNwOuPQ-wmj1pFJCiwnuWxaGEcXxSWZeE9NW8wWkvgYBn-fI4wzv090QFcJlJ_HR3zUkO1tpszx1aggx2BcckWj06_ZUdGpt3prv1kFPokw6SlEnEMd8Lt_x_8AX1pQgq6Mw1RUMDpcCPFuqjuUk6EGQXg5Uk21bmAJYIoHRym1EaYuaStiszg6PoIHdLhrTWdzWqubYy9zWfAx-qdvGZud-33F9aMktpTRMOaA1KJhaayfqsAniG565INpoYY0I82e2dk7fKno-Tr-3vRKGZqVlwg4xpObyNjLSWvOS5qXH07Zs2prXAz6l8K8UZ7bDDrMKNJSuFwnm3gGZyyoygeB4wEb4U-06nt3C8L6nnNe-cIRaP3Gcd4fE1k6QE6Qf05d1-DaNkjU5p4oQfBaRDPcVCI_RwxTedz5v9iOqaYlMaWAfgXt8Mf1f0MqQ9p1S8IUbT2RbZ-JJecxSpy9jokVsSVKYIKxGnxynh9K1IxgZOdK17RTZSjTd_CVxcs8kiQVl3-IkeFo_vyUKNza9ZZGBMC4WnkAQLwXY39zu0AxRc0-aaxX-tfVeKKZ5Dye3XwEFVQ2Cu3pm23E_Wya354lSBDz3XkDYVT8E9w3H2VGfjCxB_s-OIdON8prPbHY_fmV7RNFkdKxYHjqVrxn3Al9Zm828PRqEgbhp8ugaw_EJHTnHCK8iLE6L75LtEavP9cNZ3ZwiPK6DpQaucJBMji57UIUEW-04BAsZcx9oN85xNZpEKDzROi_emAFEnYv7ygr2fp57hZsz3m0YeqVsIHN4WTLJuM6vMEH3Q5Y7q9B3Rm8loxp6awMUBtOVqO_gzY8MM26DOyrWFSDRctY-817lnesZuigknj2P4c6uVEzEl-o4MJx8uCaiCOMFAX0r-IUSI8DckiFsRNVzclnTMqifjZKQ2QZn5_U7_raS92mFsuvimho4fDMp8Xs3wP8SEo8TivK5JYpz3dlsUYN1cs9obp9KvSm7pBj7wAtF4BCwDcJyjz6oq4LVzj49OSz6K8oKENTkGp97U9FU62s6B_6NKkdziKs-vuIGJdWuj0cEZLNk1LrqI7qgeMVuoh9eBPkq6qWxetgGAyPIZl6cmNaqCnfOVBOKwKmRKbl8XkYZ8MojVg1RpMD2MX2l6bYE_8tehtBZH3T_ewQCGmAV4B6ncLMSjnx-7vm3kF7WHvTAYl5l9-jaCRJJncEvzVZgWVARGvlsqCbYFMDd23lZQAXSGrrwhrqvDfiiTjpUX5F1z98pBtDY8oTt9fmMh7nRVlRFjmOlgqYQ8pIA-kn52RwUGXgErKmGTbxOBTCYn7_q6lGnK6bE8PmUM6ZMjioxwGooP_mUOaQAAsfKIoGKx825hDpo7TBgfyfSB9pJEt7JUnOwPO6NyqANW4CpUObItGz4ELHCqnSL-mM7Ag27ts7hjJ6jKmnB8Ud2g5UqHQuJway7xoWwUr9cpOEMuTakkcFsSM_v6MP84Yfyc4EsPrPQYf4QRUS9HksWar4YcVOyCUw7Eb5d2YSaJGZm2IbmhvvJrgjlOI3EJRf7ShW0gBU1D5Gk6Xm3fP0OSsHm3TF8wiN0EuEPToszIVP-djEgxbB3aUY0VRgnaE-nlb5R_vZEvqd0_LC9yvDv-UzPwHp11umr8M5tpjh3HD5AIpkSOYrd1_3TJBJ2wDP5IfMoJS33yJzHQgY9niaJE2TupOciT8QHop-hBYhP0AMrI1kNZWZ_iNvwQ5TwCzezKV1EEKoe-XO6J6SVTsCdgWwVkySUDmKuIIwPnEzV4GWzU9LwlAn1mVdt2XoB_UtPQt3TGJ_NL73k10m5eCCO8KXDd4pTFqHvyBKE-faXVixqGxOOpIW5MYPcQnvfpf3kcBoQz5t6EaqZErnMb12HNXx1TCQW8gA-Z16ExmhNTpWPtjyIsO7onlc1__VdXJt2OpldfOxlc0rszgPrnni97iy1ueYchyZZ0VXfhgjF0abcS9Nm5mOi85FrbcAplT_X1SZvkrZ3vfR0_vgDifuDw;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWSRgB7joEEMpA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=9ABF4E2D5D98923C8BA5E6C99258F6B3; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnQpfH0Ebs2rdF_i4idP3LU_B1375AU-nyGaFBQRchkpBp5QvYpJYfoTfeFy1m4kCBaTlpQ8_sXYMLPn-sOeCpttK6Sq-TwhG59YnI8QdiNarUU5m9jpRrPw2F6VmEml7slh2lo9aXkYXE1kks32sztlJ0aiEFt3nqc-sLmiHq1FicVOFUrEZt8pulgP_CAi9p3K3Tg2zDIatyboOROkhSh-BAxfUdmJXvy01A0WL_ws3VFnD72tposZKs1Rp2Eo5hF5LPsOPiJAxAqhZR4BRLhZV8gfDTp_wFeWXCmAiTl3phuugHNW96zapJBRbhn05vK0854aisnGSfwF7IntFj7gZqzd4mLav02gIWFzOXWXaZBPAZObwi539RCslBeWT1x8iWB2nnJDg73CXui6NIByFP4hGMxC-S7K1xDnLXJCdoQt97WF_lu5Y-cCAjguFq_ajTY9_Q9kueDUCWefIcwbPV-2TD9yV6DueQF-qcGRsAFCI6isvMzyoU7IeBib3xbvyGMtmsl_uKMzQ4YmVWC6aXMDEiwONLllqEx-4q8d9Pom2J9OrC4Qk6GOELRfcotKkBbPHlI2l7bXa9SO15VgMGhXd21XbGFul2ZbVEylocrFEvPIOBzQH4xwJQzBn4;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWSUg8pDoEEMvw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkL6jQpz944-ROnEfomo2VcvwAQdelydx5SVaylxfnAXhDvkYZla-7IH8hgIJlyEq2U7GO0LWI4fy7jk2Fh53L9TQpuATDpggKFe7W5g9VBo7gX6x1d78YaPOjeXrjeWFgSBKYUXPvzAn_DefsPCYZqlrcUf5PdSQ3uPx2yBCORY1vOLQUqu-PFiHn9hGkS-L8I7zqJaCsgxbJW3GLuB4K3rkmQIGKsDx4mQHArE3K8ykpRnhxYC1H1nu2ggFO52qip9Ps0EtJORfdDTQXZOeW9rnqezSUOLrmF7nRtP_BZ8NE6p6-uRZ_8Mtjl8j_71GLR3itChkM6e7-gCwEtq4IXOHJn5pecrnBxzwgJrrNGJH97XY3C8qivlp9sDsmc4-nARZEhog8b3KFimXtv5mpgITRQFEPsynnGu2HryIkNPIzLcE7deHqREMMpvJq3mR6iKcRw0wIhIfHp4_Iw9fF2ouAy3fTEVi-F6il5jy90Sn9MCKd-YTyYIyuno8yS37SwF6NYSqoBijlLTI3xTIIgOtHptbw3ku-QzL1mqyPvV2R0MpM60OJ5EK1POxYjTXI_lq6aqPBlrFEfk72utNr6VHCrWthsZNXdEDD7oPMz0nA-jiOdcS_-wTjtbi1aVJ4HWgraYHCHXRT13-3sDJu0F5ykPW5qdmA_kxkLEUnxjA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWSVjkyjoEEMiA=
     status:

--- a/tests/api/cassettes/test_atw_set_mode_zone1_heat_flow_temperature.yaml
+++ b/tests/api/cassettes/test_atw_set_mode_zone1_heat_flow_temperature.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnqVSmcuSoavT6fDbgWQu0TuNZm8O58sda-qMPewfBT9khytxXF7Irmlks8iQh10AalLTbKSaa9qyRKn-rLArAtrKWfhxZdMNMXUuSl7BgJHjvXpCxYL0Mg9UQBgnMqF7JK2XOEwapTFxC4UVAgcI-YeXE6ptngfzEXp56APeNHeEt25sZuQLoASH832EdnrZ6IkWUGQ4OE_6L4PrI7p01rnLidTOY93kAh_9yY_aHrqMHpYWlfQQPn-ce0w85SJos=N;
-        expires=Sun, 12 Apr 2026 13:42:09 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.GsQvXd8XzAutadBzdHbc4FhXOz07CuS4vZpHO1NuzPE=N; expires=Sun,
-        12 Apr 2026 13:42:09 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWTNgTCDoEEJfQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=1cdc7f5a-83aa-4675-9f80-29ecef8f58ff; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972297909236.NTAyZDEyODItN2IwZC00YWYzLWI2ZWEtOTQ0M2I5Yjc3YTJlYzU2NDk0YzEtMjJkZS00OTU3LWI4MGMtYWYxMDVjMmNjYWZm;
-        Expires=Sun, 12-Apr-2026 13:32:09 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972297909236.NTAyZDEyODItN2IwZC00YWYzLWI2ZWEtOTQ0M2I5Yjc3YTJlYzU2NDk0YzEtMjJkZS00OTU3LWI4MGMtYWYxMDVjMmNjYWZm;
-        Expires=Sun, 12-Apr-2026 13:32:09 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=sZqoSa9gXVFo9G6fFpLkBM_lzC7Beqs7OZ7d04s8pxQ&amp;code_challenge_method=S256&amp;nonce=639115972297909236.NTAyZDEyODItN2IwZC00YWYzLWI2ZWEtOTQ0M2I5Yjc3YTJlYzU2NDk0YzEtMjJkZS00OTU3LWI4MGMtYWYxMDVjMmNjYWZm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlIU9CoYkhvliATpOXDvoSN8fv-JKixLBVPkmElVqK2yAE9zaqDutTB37_O5U10ISyDGkFi2B8nAJoPhjAdFEcfVbgX4O4lPm_rgSiP-qY9gBSrPB5XHWpDjDXAvNKgF5EeMnrQfuZpKcTrCZc1xrMGKvxwc1PUoM2HRlPgFI9_NlHZ1SpXzHou7J7J_KrfTDuMXDz9NpqdQ5IgSOyL32qba9xwgM17ykdMquizyqT9kZKT7iLMjlvd-9nFYmjBXksi1wkVaMCeC6919-Uo6ecPHqu_T7vctmQu0G4prVMLLpoiZrsMTJ0tP1gHf_ZOJwLSnG4QUIPkbWEDo6K-2skH-L67EQKkjC4V3VF9oMY--vYMspvF9UVxFKY_VhmfpO1ZL6ssZ78MO49VYh_Vs4ntj_XkXJq--8jM_pMlXJH5aSz-EF1gAsSXToxbEc6poDIkM74mbWgKQie2P8v5RB-tNthMYxj_pFu0-0lLRS5Q39UtGvvIZX8oH_An0lhIETaPHgjmEHwjzdEQpocdeM7vCvQtcHF3SfI1n6-y_KHXMRMtUG2jvMeGUOc8dYj0B1yPbTTafkIjyHM2Ghz2M9Q_JMYivZItA81hDflxMI43IeNkZIUHVjSF5ug-PzFOWErwLZiie5bbuBJyIdxNkzvd\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"1cdc7f5a-83aa-4675-9f80-29ecef8f58ff\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-39fccdd52b83\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=sZqoSa9gXVFo9G6fFpLkBM_lzC7Beqs7OZ7d04s8pxQ&amp;code_challenge_method=S256&amp;nonce=639115972297909236.NTAyZDEyODItN2IwZC00YWYzLWI2ZWEtOTQ0M2I5Yjc3YTJlYzU2NDk0YzEtMjJkZS00OTU3LWI4MGMtYWYxMDVjMmNjYWZm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlIU9CoYkhvliATpOXDvoSN8fv-JKixLBVPkmElVqK2yAE9zaqDutTB37_O5U10ISyDGkFi2B8nAJoPhjAdFEcfVbgX4O4lPm_rgSiP-qY9gBSrPB5XHWpDjDXAvNKgF5EeMnrQfuZpKcTrCZc1xrMGKvxwc1PUoM2HRlPgFI9_NlHZ1SpXzHou7J7J_KrfTDuMXDz9NpqdQ5IgSOyL32qba9xwgM17ykdMquizyqT9kZKT7iLMjlvd-9nFYmjBXksi1wkVaMCeC6919-Uo6ecPHqu_T7vctmQu0G4prVMLLpoiZrsMTJ0tP1gHf_ZOJwLSnG4QUIPkbWEDo6K-2skH-L67EQKkjC4V3VF9oMY--vYMspvF9UVxFKY_VhmfpO1ZL6ssZ78MO49VYh_Vs4ntj_XkXJq--8jM_pMlXJH5aSz-EF1gAsSXToxbEc6poDIkM74mbWgKQie2P8v5RB-tNthMYxj_pFu0-0lLRS5Q39UtGvvIZX8oH_An0lhIETaPHgjmEHwjzdEQpocdeM7vCvQtcHF3SfI1n6-y_KHXMRMtUG2jvMeGUOc8dYj0B1yPbTTafkIjyHM2Ghz2M9Q_JMYivZItA81hDflxMI43IeNkZIUHVjSF5ug-PzFOWErwLZiie5bbuBJyIdxNkzvd\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"1cdc7f5a-83aa-4675-9f80-29ecef8f58ff\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-39fccdd52b83\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=8a50240b-b5bc-48b4-84e2-f601c5906849; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/0YJmVvRtneOjLkb8utc1sOkvm1/FiV2HXJJvcUW8ODLmPOy4wJXJUTXz+6r3ZI/6vAEqqmJBy7SWiZUOuhXukA7EhV7EQXbFS8UPxhdjaKMQB43knIk7QP9QvAX5yj9rGwNnE1g7Gh8Ax8SBEwQ8szT2upgFddyAvoTCxktdSGLmz3I61GURiDD5ROjUd/egwS1HT14hgXD6yzZhvE7yrvEsAu7d2wciycLbbzLnCsQjgUPbZXx/rRcYCBfmjjkvAvD71sQaBDUklo30zIaJB3ape38HzYoVKHPq4epCZAGBe4rjb0ziAAAA.H4sIAAAAAAAAAAtdaXgrfFWAaNmym8/yJRkY3heynPQ+K7hJ5ALLctGollkAXIjeNyAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:27:10 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.GsQvXd8XzAutadBzdHbc4FhXOz07CuS4vZpHO1NuzPE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnqVSmcuSoavT6fDbgWQu0TuNZm8O58sda-qMPewfBT9khytxXF7Irmlks8iQh10AalLTbKSaa9qyRKn-rLArAtrKWfhxZdMNMXUuSl7BgJHjvXpCxYL0Mg9UQBgnMqF7JK2XOEwapTFxC4UVAgcI-YeXE6ptngfzEXp56APeNHeEt25sZuQLoASH832EdnrZ6IkWUGQ4OE_6L4PrI7p01rnLidTOY93kAh_9yY_aHrqMHpYWlfQQPn-ce0w85SJos=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkP-p5cXSzjMi70pSoJe5AGG7-9ol3kzufYXGC2CftxIA2X5Z02zNgcuIUY1ZfcB3TPub5_FtPevtgtcw_wQUYGeC1OvXDNJU3mpvAjPnca9I4vdyWiqTWoOEKnYuig4R3J4fjRPhIhcKZdP_HI_SSso4WVolk-FZ-TJH4YgqehITiRHzGUTSGd8RUAiPDpAKtzDVF9TN9E_fnHIx6ojn9cK1KATZ7XVSeVcKIyWWdUzSyAWTbqK-PJ0Q04sKl7zeICe2MetNefRGYTiN3mZebW5QF0pm7oEfGcGVQMZEk8Q3CoBWdKv7DP9hjlrfxSYR4Oyj2HF_LEf8JcgYv-Cd3AYF_2wGCULg7lSQA46B-sNdsYd6K3fASKCJ5vaeNnPYNXJMQxb0dScQgt8eDJVPAA0Xox54Vd3P2O8QJtzLSsOeSGwGhy6vMM35h2wc0iwzGpAN-5TAyI5-L3NRSI9fAaf3s4Tejt7bgrRQ4BjSZrrY_b3SLhecwBB8Clr8aFnEZzOKyARaqnr95yCl6w23tK18KYh33zdlj97KWR9ra-fGLaq6M5k6THJtI64AFwqyfH4LjSueDZHqY46V-2oK2EQhY1lgF7SgHVEif8i0-tdLjLydHZW_VxLOl93K41Fu7LTztA8Jhig8lERDEHTdz7_FAGcSSQq2PZ_BbMNGxMU8ZSap4KS9NWOeTIwRJXZcMeH7cBcxK5Zyt7hfkNHk0Ee-BdZv4ewe-VtmdGNGrHFsjRqSOT4PauJYjEi2EWdoemsPRgmngdmqNxHNxhxba2emijMOUm19pkX5sdyiIZsoiBbPVUAFOXSl6ClbxXqkKktquo3YmpJMA40XRNssrAkKs99kFFEc_q0kRCU9hBr7EJUQIuSYZkHUQ1neadACTru9ZfAYMoPXDl5YFzqvqC03w3o50aFH4C-KhKZtv-YsddygL65Qxrfh4EernRX6Q018sFJBu-DEAb68CQKuVkHh3pYGyBnM4PL9VS3pv4SiEFgEFGDbYbgLbxVnuOHhrRUMYyAE3cKmKHNeEYk_sXEtxRer8KV26wpkVkb6zuRPIqT57fCtnhbdDowMNLzVIfCDxMv1nWl4ESS9zC3TjsUFYWxxuO3WX5pI2BA-vCru2V94gvEnHnTLhI9PNASJv1gMPVbVzMsILnIZiFQGxPGjkYGNNqsW25Y4nw-SXIU09jf7usYYoyCkbwK51HjF2Q8LFZTIyD4CP17PS249xtIVzOR_buZqynLXdUghRo3XNRMF5GwFLK5UNhEAYlPlOfVlzFWPk_v4f_C6pwFzrlCaUmHJ40J2c5z0c1NStNb9p2Y4_5VU0ocf6tvt1KovJi7jyfXdsyGbGjIfS1kpXzEzjVqQd3xiW_VBKkcCDokZjgjVdMfJVW-knL07eGsMSGYzCmtNv3BngJA6n-Rw2E6hJQ2t8P5jc_u8QQE4YgI921pJ1vw7m0XcfPlWzm0gZowccf4ZG-5TmGTjBJQTKMiQAgXoYiPo69ajB4cRetffv3mT2xUeK8z3IESlgGq48jUw3huQkPxcma-N8NYzNU-TAVuwoYPawUcx7QkdmAW6-7peyTXXgUBxGiprmyzutuaptSG8_6HOTX-1QsC5vQ2AbPJZSznEC-AfmS2c8szrZfQsolFyN6UReTxF7jDJelIXTC7ZOrVjwgcYRJV-1Fa7m6yU_i_9pCvmC0Sg_O9COIUlogPdMnxis7E5vfiTH6zs1fFHTPRsHXWeMJFlrR6yw7dfza4jLoaoPY7V5WNk69jTDK4Mz2jGVNyuwm-EhKNJd3bvH1LZV7AtLG9B09MRaJdrhx4Fyiacg1wQOiFCpYaeNVdmWrerzYq-EKH3kRm645x598W663MmGTguln3F3WyfknGnswjfI7sk4PyRRQSK7qYUWGkNbUsscGfwKzwFVO4kBCz0QpcCrwysQzGrd6fjgbQ8WdRkzSV2KeOMhpUnWYeToeRsNqwYF6zG4SNOouRQhJXlQPIVuPUgMOU2ucJ7T1TziTtDyfK4Ihv7AMgkGnhaeLnn7iBdWgglEVkBwNdoYBEmYrkPstev7U_ZD36-WKb8Vy1KC5brnaaZlrgkH1yjry_ZRwq54A_js5kdZdRL9TTgroDqAmbXxthNv1LIjo4I0SPy77y4C7Lm9AXiV6Xp-6u0MaeDWuzeWE2tN5kFN-dRBMgZR-P7CyhhH_gx5foLJ1dSFO3bkh1IkT4uRPmky1acy6CSsCy_-frcvsRypws9UFroI_YZIHTMhFkTUTvNu6r_3Vxcx389-FIi4t5BBVhxejvA0oozlSNO5Ar7JyzxuGY3B35KI8VoxF0r3mfSfkBa6R7kWFnv5UiQAth081KrnHUjQWr11iI4mM6KI9UT8cryZejhxWeRj03DEceJhfWAG79mA26T4GLkFYLlpqiQGS8m497xMzB_6HPsd3QsPVFX_6LhKv2I8nR7OWsvSeoLsg-tjkIw;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWTYjoGjoEEJmw=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=F9ADCBF5DDC80891D4CAF364766D8AF9; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlPNXdOJeFsVdV3kgkU4Y6rj_cD06Nkt41jYwWMyGbkFQXK9IRrbbbGh_HbEv0YO2gpUThHnzypvNNDiDaRDJN8DauHJ_sfNaa-nj2PQvx4xwcWToRmUbOgcGQzojd9pTaXBt0VFkKE2EjackrsJoZ8kAokiQTpXR6onsqhpSluzU4aLnUf9XT5HCAAnWyLo5Y_ocvsIzCyz4ZIWaq3y3VuHOjFimBJzFRl3YHG2soqrN4XLLScJfVNXSrDHTjZiL1YJFP6ykTgQtBOrOWwROoKBDyIptRu7XWqPazpLynjnWB7qL2SmN6V5nkJRGoD85VIa5uJJ1gNkBehiuvB34crGhckB9QzpLcuHGlSEP8y-ZKqibiu-eONMOQdsEc3RjaZuTixk7VZ_KiDLUP50IrCf5alatlTYAGS-dM6nlvRqMPVtKbFRaJ7f1_XWMEf4987cQnp3aNzK_MSOm8gDJ_v-Ssy3NPZmmzkWViu97-H54lvIoWqXGjkEVANT2fIU0de26sub2V-Hgvs4SGL-JepXgBsI3vorjfNzqvCNN6l1EgYbj93P5qCj06Xf4fCQc5gCnH2NChgIeXJO-QZT2j6nTyZxk7OtBLsxlrApidKig4fnscFvxkH5SNLzF3V-l4;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWTah14DoEEJpw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmmJOfp3Vzst_waeaugnAuuun6bzunDliRJ0MxofLSErDrkMut5cpJZc_2o5aLrAAfEn_rs9RzeUdYTuzgr2jSPSXmBXSWp77cr81QtxDWySG-3NsRqbnm_j3xzelWhE9H00ox_8N5jEnVGXQeCIyWNoOcleL5BZg8uH_bCfKedA-TPk578omjSXkgemC1ex8Mr2d0DlL8gpbvkuZY8FpNOqtLGKpVfgvvWu4SRhbPpSl90wW0_AMb2j3JfiU2ubp9Aq--WXhfcrs1UAabbeEbZlt7jaYFreb4o3xmNIpCxB_wIez8xkLFGYnMyLBBulGw5YHjIr3IP55ranxV9RSLIMH6Npo3DbP59Qhkka95EqkJkQ_kwfNvbwgWT2q4-l5uoU4uX97gzPBIsQnwb8arOuCFcY7E3ZJYlY3h0ewCjfi23Ol8Y4uv82D-kw4B9Sqm5ab7JZ2y3AcdyS09YPTrMZfN8ybbeXSkUdyAj8l3mrpcKjeqnYdKaIU4klGzuH3n4a6go-Slr1UB47bH8cG0zfbCuIUlOpgCoHniWuvqZjjEHg5-rEozfhlGaEiC63SFMiUF4pRc5wjoj3X-jD8PCfwWALv_m9cX9JiMcqbrMc563rp5qZsrLvuai27XdMSWyOQG7iepEVDP61Lka4y9di1tbw7Y0A8TscR2w29VaYg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWTbicvjoEEJ7w=
     status:

--- a/tests/api/cassettes/test_atw_set_mode_zone1_heat_room_temperature.yaml
+++ b/tests/api/cassettes/test_atw_set_mode_zone1_heat_room_temperature.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmMeQQAAG_q4ryDE1UvySbGHer7cYDOF2uBU7HbOrQjAu9n73MnaVODVSZN0u0Us2D8uDrbuGOk20GVu6pA_ZNBiu3pLQGy9Sw_uVNHGDfARv42tFoRz3oCbtW_I0F6aRRaRwhOfmY16tJSedsKJI9FDdniU8rny1tRvmccHn7ZJ3h8vmTpzCzsQpRrj8wMXLtnsi39UV_pA53wDIBoOT_ytC9w3UiKbfXGyncPiHJI8wZaSqsciUvcchBYM6S3uIc=N;
-        expires=Sun, 12 Apr 2026 13:42:07 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.qTI1Qv-h3IvZmgB9RP4OCfy4jlOSSfZ7jplCPRLpD5c=N; expires=Sun,
-        12 Apr 2026 13:42:07 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWS3hopDoEEMoA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=f9c1319c-500b-4949-8997-b01074f252d1; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972275686038.MTExOTRmOTUtZjEwMS00ZmFhLTgxZGUtN2QxZjMyOTZjODQ4NWZmMmUzYmMtMDQyYS00ODZiLTljNmQtYjlmMWZkOWFkNGNm;
-        Expires=Sun, 12-Apr-2026 13:32:07 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972275686038.MTExOTRmOTUtZjEwMS00ZmFhLTgxZGUtN2QxZjMyOTZjODQ4NWZmMmUzYmMtMDQyYS00ODZiLTljNmQtYjlmMWZkOWFkNGNm;
-        Expires=Sun, 12-Apr-2026 13:32:07 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=awIw-qtqP2aXvNxGvpnDV31gJ8RAQjXvFo3SfElZMjU&amp;code_challenge_method=S256&amp;nonce=639115972275686038.MTExOTRmOTUtZjEwMS00ZmFhLTgxZGUtN2QxZjMyOTZjODQ4NWZmMmUzYmMtMDQyYS00ODZiLTljNmQtYjlmMWZkOWFkNGNm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmOgZvgbzAisHZzoMIphld3MHjGru84xEjB2-whC_Fw7M5HEXSPfTgY09lZHCI6xBJBlgA1SRmMTrAQAofTnKMt0w5oJ9VZ1_-mmDIwDEaknCjGCzHkq7Hwcr4HnRJCFa34-2s6ZOe2eBdd_F0ZzuI9DisGrHyzCNTecBza3FK-N2kjKnukv9V6J9rVM6boYD56GkjPcj0RuXIRMfMRMD0I6WZCXjfxxHYAwYOOUeoJol54nDOAbkrq1R5mqam4wwrpAXTXGyAP4_TkPq1a_C1WftgUTvxoonwubh03yb1yaB17TPQuCQSVeKPRWmqnDnvjJMGCu_AAK6MATG9sOyX-HY-4BSLaLKP7yQdlNp7DpwxgFokvrcp-bY8goK1F6d91sXkfu3Z2sLmAzJGJUg6IaefBLm3ZbwhExHOEVrN_x-mnl3JwD78-ycShhZENhggeGvnqdKvMfBMqSvT6slCO4O_gro1EDGtuhHxQCeIyE1aB8LNeSMmnVTQS2qzHScWJgndm09KBxI9mEMl51nuWpaj03AlRvb-b3h5vYeZkthQkmZD_KDKtp8A-jdpDz5t2y3p69gvGIqwv0LJ_sClb_3U7aCokG3om5LsACp0Z4Jo4mtzBxE-ZKRH98JLScuHK4dybrz06Fn6xgM7_-xpa\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"f9c1319c-500b-4949-8997-b01074f252d1\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-3f0694cddf28\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=awIw-qtqP2aXvNxGvpnDV31gJ8RAQjXvFo3SfElZMjU&amp;code_challenge_method=S256&amp;nonce=639115972275686038.MTExOTRmOTUtZjEwMS00ZmFhLTgxZGUtN2QxZjMyOTZjODQ4NWZmMmUzYmMtMDQyYS00ODZiLTljNmQtYjlmMWZkOWFkNGNm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmOgZvgbzAisHZzoMIphld3MHjGru84xEjB2-whC_Fw7M5HEXSPfTgY09lZHCI6xBJBlgA1SRmMTrAQAofTnKMt0w5oJ9VZ1_-mmDIwDEaknCjGCzHkq7Hwcr4HnRJCFa34-2s6ZOe2eBdd_F0ZzuI9DisGrHyzCNTecBza3FK-N2kjKnukv9V6J9rVM6boYD56GkjPcj0RuXIRMfMRMD0I6WZCXjfxxHYAwYOOUeoJol54nDOAbkrq1R5mqam4wwrpAXTXGyAP4_TkPq1a_C1WftgUTvxoonwubh03yb1yaB17TPQuCQSVeKPRWmqnDnvjJMGCu_AAK6MATG9sOyX-HY-4BSLaLKP7yQdlNp7DpwxgFokvrcp-bY8goK1F6d91sXkfu3Z2sLmAzJGJUg6IaefBLm3ZbwhExHOEVrN_x-mnl3JwD78-ycShhZENhggeGvnqdKvMfBMqSvT6slCO4O_gro1EDGtuhHxQCeIyE1aB8LNeSMmnVTQS2qzHScWJgndm09KBxI9mEMl51nuWpaj03AlRvb-b3h5vYeZkthQkmZD_KDKtp8A-jdpDz5t2y3p69gvGIqwv0LJ_sClb_3U7aCokG3om5LsACp0Z4Jo4mtzBxE-ZKRH98JLScuHK4dybrz06Fn6xgM7_-xpa\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"f9c1319c-500b-4949-8997-b01074f252d1\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-3f0694cddf28\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=3856312b-6d48-48bb-9df9-fb9e05f05306; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/b4vRP1lJXM0JED1x+Z4iBqVzYbHzZ6RAv1eDVAyMUGX1KDqbU6aAfJuLsM3FCdiq5SMdHM/eJMsNbYpc6G6OGMHvuqccO1hhR/CVbL6uxIcieHP/5N0/oRpCGKDiPOEvB8uSDv9PyHDcynIsczX/jTHLzYOTd5Eiq573zH6LNft28Bq7hrNV8J96DqEaOnOA8B/0FQpnl9R0qp5WFsNGizJV3Xn9qpkiNdoQypAFiqn4axlQupEVIRpgb0TzrJcrOk/6mpRYpV+0J43t+tXEifFyfM+nEYGR4jvGKorHYtK10i4HXdziAAAA.H4sIAAAAAAAAAAEgAN//wQt2p7ODGIBXZh7SKsaWR5AAknOjOiTc7qTSVS+glmvsuLKzIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:27:08 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.qTI1Qv-h3IvZmgB9RP4OCfy4jlOSSfZ7jplCPRLpD5c=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmMeQQAAG_q4ryDE1UvySbGHer7cYDOF2uBU7HbOrQjAu9n73MnaVODVSZN0u0Us2D8uDrbuGOk20GVu6pA_ZNBiu3pLQGy9Sw_uVNHGDfARv42tFoRz3oCbtW_I0F6aRRaRwhOfmY16tJSedsKJI9FDdniU8rny1tRvmccHn7ZJ3h8vmTpzCzsQpRrj8wMXLtnsi39UV_pA53wDIBoOT_ytC9w3UiKbfXGyncPiHJI8wZaSqsciUvcchBYM6S3uIc=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtl70kWWjtiO-9Y3jhddpv7HXl86TG8zZfLInzMTczXQFalh1cEtxfLKKL1IKx1aw_QrPuIeZmd6d4JSCV8_T-x3ywoKKz8NoR2IvIRhlX-nyG4mu-GO8SFEmpVXqlTr8I56ztJMSjsPpPZgbQuru06sSeLNt5C6QtuOKEf9eQiaG_kG_EpyZWuoPVAmtw5DBO6MatZqzJShN4v56WyCXP7BnMGOLet5LQOX4FxXYeO2hs3YbjRgxi0LWXDXyHvqZ5Rd7DLDXy8RqRRhPU8pr7bV2KA4-6HKCutVr4hErSkA8RozlyGYudFyEgTlsHGYdkhFr3E4_OeQENoRz1CMOmz1M7vOqpDPvMOVaGcUzJ0K4MHN5VBCWCdy03No0JsLBbFuLOU5Y6Jngcad-UAc8bxdq2r2hP9OmaE7MYHXs8XgbQj1EoZhZR1n97pT6wPGRwW_eEark6BdjFEQr5ghz9W7iOeFGSEI8BmW6HvcOXJ6T5W00JkkbSkAVBAvNGilLFfFal5r1qOWN1-0KezSuZIoGLEJ4Rzud4A-0co8QbM3ErFdIOtH1DrDFB9AXqL961q3NzcU1vU0ne0p_FRlMXkTrvcbqjYh34F8FEcYs39EEUHo4vXX8VrMN_OWbZpah_cFiMkMF1Ogc8IEnaDd3ABrixUqU8XpfV2jZ9wKuwWw7p00UhVy4z3Bvd09_9KG76DeuRgvUW_XPOjlePXLOswI1DVagmo0kyqnHNTlFMAaFmbMuDrrcxkQxUiDmoqvX5ajfY1MLwKRZJ1NWChZhkZFNjYO_3OMmc5h3w7x_6XaUoR6ju6gOvzYRwgCVMu41bL2oQwVP6HeE3L0Pjz0O3Qyf61bDyS31yY5M3MMxQowJW7B7Ce6a0c_-8zEthqZDgcDC_tBCNOrt-TN7-tLcLpH2HNCORnwMLiuNER02GQUdgdkT-kE92F31gDxxvYDDdSz-ZqCVV-3odYDeyk-xrAqQb2y4VGF5ISDOLUYr-FoKbR8kE802iNLp-dyNtSbsLV7PvBf_THx8sPmBMrqyVQ3H1ZLQStzdBqc6d0F7dqPk92LcQJJ1Qt-VZecRntESN6H-mhzoJAB-VtvbJcErDtfP1Ot64p5LPUvP2j7X9_3dJEKM1om7KuGzb1LWNm2O6hSezMcKo_tfdPcoRz1dCLDOZwgDERdByDAHnt9RcuCATo9HDj5M0o4MbwAJHsmlU9l6CV9LYSnGlO_gfBGYnZCSuDt6ZJp3bF1vLahBtUfkOSGhppzGkQr3qdYpvRtOTL1muEseuXo52J3Ufg5fZrdOV2bSi4X48mOheFhD9shxr09H6cG529oBq6eTBi3dGQ5xhpLCFidY40Kb9Im-LRxF-JoK-FKOYiAhHwQza2dGAw9fARa9H9IFYc9aGIACoZNLyoyPxj6Lbe2n3q0UJs-Fsx6q1zd4Vs4e79kC2MucjuE3sbqWI9XvEt9wPzR3aEmS3Zy7WfPt-UxRX1K1V05m3ATkKy5N2l_Ej2MU5mplzcmqJb1jkPV3KtSINobH5igZdqgrTIl_tPmd5sHYp6u8nQg1guw6gKt6aoR42wFie0krhe37c7z0OWG80WsCVZsF7fGFlrfqCjqDymJv4gh9mxGqdNCQKGmApVZyikObYdkgt-xb2AA1dILq_kUayRrQy2ePjMinJUx5SW5HR6_cGHak-XiX-8E4qfEsEtaN5pz6Dcu2Z6HJlQa8WFuTuyORtA5mLcShqE9Mnak16BTeWbWzzG-U5Ki5Fz9xqC5-mv8XPHa6ncgE2AA9uyJmyxb_nO_FZz1rMRrJO5a0bNKkJ9F-D4_5ePdh5-sNoSl8lj4icA60fKBO09wjFiX2VFF76u_nQiQ3CND4U3R3oSfJ3rjzaP6xafwc9iqxSwlG3ZvNUMsAZbas28ukOpTz171PzAC52HnRbH0KxTd106wgxUbI8E9Kg06YKnNj-iO6T_gXwAX8INvUrK2zavrvoMhE_OC5FCd8zKQQ41Dxq1-WmeJxUJ5en3ll5APQf8yss5f7Bcys54x1DMO6Kb-4-JKDqZNuzNJqSNxiWUz6r_Vme1w3KZtnB4ZWcTKt1tGRKh9tG4IYpWRsSr-zGdlzJ_BfHPhv0Xl6dbDWY3JjBRPrio0ftD-30PPfVEsZHj0hcJqYr88cMJldcEdN8hQFFIE5EXTrlXgO1pun5_gkasAJ4LN5mpjT-YdQhxnFM7-PZmK-6Jma_oHdSBWVQXooqm2Jr7ikzEZEnsd_UCFVpggKCUO368ckURZfZtZo3wA0S4vbAJAGWQRsGW3UdGJzyH7reypP5vQ0qcKjhr7kzHqrhwY3S4eAoO0kZagsWNKnS1zcPF85QieJDLdD53ORO1Sgpklv4U_E_3Wu_rA4259gPvku-EwGFlLfkL3w5rVBD0vbfKYHC6Sht0nDqJeSsLijchSxZqjFTguVkBM-lR3LJ_n77vHFJgGyS7fldpSHg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWS9gmBDoEEMEw=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=26B12D0E6603952DFAE3EA3A90D3A085; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtngponiZf0hpsa7woMihm9_Z3Ik_gv41i3PhrLG979ArD3Z57YxW_tGAYVjeW5QMgo-wvct8xTfuNCS1dUWlBBBCcditAhBdGeq6WGgTcY_HxLm1iOUXbLrs7hJvewXgcRwKiIJFEb3QhLFBqq3ibvPHPdVIdQAj9061Zbg-SM8g6CVeWxcyUB7Qw10fbCgpIO7yPHOWYQzmT-2nwS8-NXQnCWJmKwjLtbkMUBtC2-IfYk1KyF6CaSgeVGaaHA_LgsVPPrvA_N8mCI_SJBG5yJ-xMd0z-UvIyC_Y0gSOKUCulTj1h4d2zF5OpshmLv-Z5z7O9yCUB6QWpibPxIPTQ9fw4JVZqPyZEwmhtu72BKrv4iYXuaPPGDR5_bK2KbSGo_vs9AeBvQyVTr4g-2GfA0G-e-ao_YUKtUFL7ZJ8f5n8h9hkQ8iBvG9KiEEYZ18e7-Vubm7NCCXRow3DYZLuf58IdjXGYCMbFQjuP2J8zk1foh-NCoVBGvefvM1B7bTHcdHG9HdHLWCqvjKF2COokTS1wrGJdbZH7cp9ijGy1ozvdLJAHotKg_ATVelsk7xh1fZnCsZ_XXG1oAi1EnVM15lX0_c7GBBhnZZN7H_faSm453IzBTy_-Cr7Xn2u_6lHPs;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWS_iqsDoEEM0g=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmQIV-Tww-1RFgVmq5rPUs59ByH8LzyBQKxR9LcqFh-Gd_7YK6dfxoKfCLORnAr0xdc-YsRlEZOjTxh4oxxdHztKf1rzKdVA2CrHcpbm-gVtrRj0M6A0V2L7IEVLXdwjaqDhyvcAjZoRhSdVoBFWKXQd0LM1aas2yNIUT56O4lb4Lwe7GdfIHh2Pw4vJl_NtgMKqMidMGbRRoGGUnt0sNOYXy5wSh9MRs3rRgetsCvn6fui9YgLIxo6WWxYUBS-ojvQh1ydfkeHhDHsxZDgioH-YVO2-FUqM7oh2YUJwMXZACAwNvDw166d7_2Gqm8oSoWsSuRQJpP2QpeZDzKn6gal03MiOE-w1hw5hMj-D2NdVtJMDGtqYrQYPMwneykMvLzinBAVyqVQrfYBNtM8UaRmoUDmxlxDtmOKwQogXhaoFx0yGf-a9_JzzGz4-td2YadmwiR7Ey5ZQccLcukJl2fjbjFIEpOC8nGHSohBPVxPh1KVa5jS1px9Cpi2zZn6sN71kZ45vHolKT8c7FSbGKYYbf5wbbq5mrdHx5U4ZneX79RDjiRURGZ6AcMVYZ-rQqvAJNFjsckL1ZsmOTtYnYOfr1HGHH2LvXAR70cvAwXw9ez_LfwAzloh_sqTHeUj-iIJ6l3HBNX5zjLefg6_6bRj_e8QSwJOhKzv_kuRIS1RSg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWTBhmGjoEEMKg=
     status:

--- a/tests/api/cassettes/test_atw_set_power_off.yaml
+++ b/tests/api/cassettes/test_atw_set_power_off.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmUaND8uXkjsSoGCAFWWISYtTC9SHPxiMb0WiUXSeNPv0_8F6Ry0FwdXUJ0-1ktntVse0EkWIxHpdLixvrCpTHaZ7Xe3e-1x8xJyd8sbb-32ltFBd7vedfCsUrrj8qNkFshklOK1VCCGras65GZ_7pBucnq9af_RUml9_fN-mR4Z44KSKMOsDAYogpaJvLa7AHuDqTr8A8hVh56CUbUq_BchIFapO9lpPYizZhI-5vI771m7YV9gKRFhvg6gnlgcts=N;
-        expires=Sun, 12 Apr 2026 13:41:54 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.Vu2xSM_dzWlmUKCvkuwwRBP7m3M4qn2Gz2tqaAKuBgE=N; expires=Sun,
-        12 Apr 2026 13:41:54 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWQxg_JjoEEMTw=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=bd1b3bc5-e618-46b7-a901-35b5f3ae57ba; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972141352235.ZTFiYTE2MTMtOWFmOC00NDdkLWJkY2ItYzVkZTE0YjIyM2QwY2U5NmQxZjEtMjFkMS00ZWEzLWEzY2ItMzI1NDBjOGJiNjQz;
-        Expires=Sun, 12-Apr-2026 13:31:54 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972141352235.ZTFiYTE2MTMtOWFmOC00NDdkLWJkY2ItYzVkZTE0YjIyM2QwY2U5NmQxZjEtMjFkMS00ZWEzLWEzY2ItMzI1NDBjOGJiNjQz;
-        Expires=Sun, 12-Apr-2026 13:31:54 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=-4HGJPpwO38kTnFSSe2hf-0rCI_CaxZG_QpHpTweJ1s&amp;code_challenge_method=S256&amp;nonce=639115972141352235.ZTFiYTE2MTMtOWFmOC00NDdkLWJkY2ItYzVkZTE0YjIyM2QwY2U5NmQxZjEtMjFkMS00ZWEzLWEzY2ItMzI1NDBjOGJiNjQz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlUK59apbQ-UYTJyZ96PULdpvyGpeOWdEtqxP3DE7v0LtggGoPvwBDP9SsPLa8J16xMy1BXUPnG3xVX6VBv3QTgJbF8NmrE2AQ4atHzNM5mLBbqFsqR13y7XqbU5Gwb6fAY1n3u4iLyC1-EDHHMexFY6Z-7vJfD4UJIXqIrsGbre-chXg3P1IQ2b7XAty3cTYaiKLw6QFgwEG74abfcrUCQTeUhL8W3X2m1XymChEXl0rUtAOHWGy4QD9qsTlHgUhtdL0gWtIC6D1wZceoWxE2WTAs6d_Iu1kH1qar2TKrwsOhj2S88047bYaJTFmGM-QA5zTIzvuxkj4XcsKQgnoks2AMGGUWhFjgx9xH3jhj0BtH2SMNBVbFiphsydujSBCLf7bDxM81uXCsNRBUICCf_ggtB-kHFRbbbm_makbiC-PxQCoysWw3lRlRlomhxf0YNeLjsxHx1RagF-mnUO17aCVmq3x3TSz9-KG-dWB9DzE2466LzhBFhnidWH4hTl4IPlIhIjr0V1mLr0Da-mXaumQ-MTjd1uhIINWhrIcpeYfYdwI2CcEgV2c6ZG2Hk6nNpLg1d9SWE7-bh798pxRHmqDRLTm7AbfY3Mk7a9JDp-lexvRqHSI4LNlpTmmOcfw0_VehzN5ZW7U8QdIEc13Nw\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"bd1b3bc5-e618-46b7-a901-35b5f3ae57ba\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-1c6a83bf7e9c\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=-4HGJPpwO38kTnFSSe2hf-0rCI_CaxZG_QpHpTweJ1s&amp;code_challenge_method=S256&amp;nonce=639115972141352235.ZTFiYTE2MTMtOWFmOC00NDdkLWJkY2ItYzVkZTE0YjIyM2QwY2U5NmQxZjEtMjFkMS00ZWEzLWEzY2ItMzI1NDBjOGJiNjQz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlUK59apbQ-UYTJyZ96PULdpvyGpeOWdEtqxP3DE7v0LtggGoPvwBDP9SsPLa8J16xMy1BXUPnG3xVX6VBv3QTgJbF8NmrE2AQ4atHzNM5mLBbqFsqR13y7XqbU5Gwb6fAY1n3u4iLyC1-EDHHMexFY6Z-7vJfD4UJIXqIrsGbre-chXg3P1IQ2b7XAty3cTYaiKLw6QFgwEG74abfcrUCQTeUhL8W3X2m1XymChEXl0rUtAOHWGy4QD9qsTlHgUhtdL0gWtIC6D1wZceoWxE2WTAs6d_Iu1kH1qar2TKrwsOhj2S88047bYaJTFmGM-QA5zTIzvuxkj4XcsKQgnoks2AMGGUWhFjgx9xH3jhj0BtH2SMNBVbFiphsydujSBCLf7bDxM81uXCsNRBUICCf_ggtB-kHFRbbbm_makbiC-PxQCoysWw3lRlRlomhxf0YNeLjsxHx1RagF-mnUO17aCVmq3x3TSz9-KG-dWB9DzE2466LzhBFhnidWH4hTl4IPlIhIjr0V1mLr0Da-mXaumQ-MTjd1uhIINWhrIcpeYfYdwI2CcEgV2c6ZG2Hk6nNpLg1d9SWE7-bh798pxRHmqDRLTm7AbfY3Mk7a9JDp-lexvRqHSI4LNlpTmmOcfw0_VehzN5ZW7U8QdIEc13Nw\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"bd1b3bc5-e618-46b7-a901-35b5f3ae57ba\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-1c6a83bf7e9c\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=e2bd31e7-7a5b-41ce-9e79-cfe4a9e79f34; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/64q7FOW+iinxQniIUFBwVM0FP2RcvnYHOjkStgHOTu9E1mNn+5Sw6Q0q89y8aQO/q6oMsYmysk8SVRPKefenDxeILHYk/Y/0HBdvB7PuHGjH8Uo+d2jEI9ipCf8Sw/TV6dANx7CAHJNdUfqd1i26PuWs5G9CtL3GYh3T3fA8aAgNTfyQSqQS3pton/hIA3Mozh6ew4tvm0CMaSz5lWrN4gFZvQbwPsCKayLCb/Qc3TJwIszKN354cnGDYk8bxkrTUe64kO9l8DQ+R+UlI3cbkqgoKgVKoV9XK8QV/HIIvHc9vVc4xjHiAAAA.H4sIAAAAAAAAAAEgAN//W9z09h+QH+LOxB7RUvHHaPVTtyfniyumI6rFkBO6mck9vLRkIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:26:54 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.Vu2xSM_dzWlmUKCvkuwwRBP7m3M4qn2Gz2tqaAKuBgE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmUaND8uXkjsSoGCAFWWISYtTC9SHPxiMb0WiUXSeNPv0_8F6Ry0FwdXUJ0-1ktntVse0EkWIxHpdLixvrCpTHaZ7Xe3e-1x8xJyd8sbb-32ltFBd7vedfCsUrrj8qNkFshklOK1VCCGras65GZ_7pBucnq9af_RUml9_fN-mR4Z44KSKMOsDAYogpaJvLa7AHuDqTr8A8hVh56CUbUq_BchIFapO9lpPYizZhI-5vI771m7YV9gKRFhvg6gnlgcts=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkIa3eeloF-jMOpqQ-1wFkHTr-c-p3oxNGwWORHRN0U9386cqkH8v_IwEY6Ztd7-xaLyzLpaw099J3EEoUOJynl54w6ZQMcE9GpFa7XgLEOSWA7RG4S-OBJ9NrUEOgsGm9dadCW4GwRKGEOfAA6uBRjEIvS-P-XhAePavmhfDL0nXr90Zv1ep1fpcmZOexuc2PaxcT1ltewgrQZ4yqYS-miR2i37UfGCvqYiiv5hqwVp0douHt9VJDfPQXkeGFN5jmAv0w2h6rdo_Fdds_MeGO23cBja7qT67goYALIxHXSZh1AbCdkDWuz5yI6R0wIuoNucaPTae9Ur6zd1uD6kNGWZmUvRDMcM8njnN-0YK1GgojDscOLCQQX5ZGTXzRHVJxL9YBpbYvDyCMgLWMBA_Ug4N6-t6Y5qorSJdpEvZKrllsL2YuACHHosDaLBLy8RHdyZcGmQcRwMWIMEYM0Fn6kG1ZD7Nq6QTGdb0VrVRDSXI-w6NYJ7WQBXlmI4_gGUEBMQIW7Gp51P85zlTATDG2F1nZDQGRdvnHn2qhaA-2akARTngEGbU7Ru3ITzkxHKdfED-aMLfcMKUhylcSV9kjaJB8mP9jSI4UN3_a8kb18ZlESRvbQi9BtvTjnnBzELaze5Lg8KoP29sI58Gwy1GtsG8VAnt7Dp9t2VEIhTVeLHPtkmr5PYdLYUNfVeh4_m60DNZWNz_X030bAuwgLgDTSL3gozmW9FOGAeJP1zENbh5hoq3QtHvGErD2aZ_cA2Ao0ziC2GufqwT1VLC3bYt8w5hkgB8AM0VdUmVw3Nf5N5TsKoe_xwTbieQHi_Rz_8ggxVy-h2iuYj96uwFuHBxsCLu2ePurCl12vOWnoF5jqxBBRXoyMp8l7CYMgV95Gq5-kAlPcg6lMPBZk1EUIgKybyQ_eUWZ3BZ0-bmr_lGhLLsv1Gsp4Qt9g97IJL23rS4FLsH_vsM5-H3Lhr1pcHFSi2MymqdedgCtIBxotoWI_9X9sSU1CSdI-rJuE7EHtdtKtCPq-iyd56Du8ZzRlIEaW0Jn1eDjjsVsAYViZVFBxVmED1X2kwipgHv4C0uLLcORlpvPCaJIF1yIFzdrlQza4Ae1_PZo8kxs1imdKke3sWw03R5S-dsFfhmY2uaWC61isVtHmbj9oWXTozXcdBtSrMi8jcphghszBrSGv-nuV0c1VG_djNyEOb-CBBNtP6VnkAgyiqNKoP0JekOSDFRi529X-aBnDMJbdamag26yYRuBjYjUTVBTWXL4iERBOICWvAf_lGFR6-i5ng-HODUnxxpKx3CyHgO4uEHOsrylFW-zh-BYisCkYF97LMjhTgH-3EMPcrOuSEDqaZtOjQnzJ4IzFw84t-FY4mqDYidP69F5lq7GM-8LhzoSu2TZOWrmfiNamsDSVnJ-39ssGMl0i_FBPK3SbVnoApeaME_MKqDnZwrh_8JlGKcu1JjROCO82IwaaR6oBPUJ85k1qnfiEhmueuSyON1-yr_d22LOw9-VNgiOc1r-3SUUf8T2axadkZAgrz9uFu1dPOF8YLLylrDILrOrp_BJV87W55fGFQF5_MpbotMLjc8qBODsAqklSsdXC6aClZUYNWmlJdjVdlkYwJAs58Bt4MyaZFe7ndJqWcQScoRSg-Pq7IIjIENwsDxP2u5r3ytpCE-LJyRkrAFO7gQ7x8oOiM5OPDm56kcyMgrTZIISiBk5PUthuS3fCO8JRrUDmHI-7pxFWmM4IOMtyYKFnbDnVeKItzMq9S_ufD-OctzYG9kMmkyfxoCPKFIa0GnHKrrioPBukvIUWIxihq1vW4DGexkIxld12UMlIEjxORp_rkvnDjn51jYbFewx6T-Ohx_oVNQburxQrjjwoUPixQS-ugKEyjI5CFhw9jS0B7gRFdOwqQJpTsXY9-1e08l4HrTo_Kpra2sGz-TY46m6Yg-36n25m1p1QDI62tW_2_LjrDyRgD6vHEW16IjAXgrgDU-pJ4wlcSsazboUgTU5o3YCPZV05ky_QXtZila7dBqSuAKj2dc029v0LZKDg2t-IhVGfjqwdz0gIUZBIPhzSKb4cOB3Dja5NbWEQYMCL3Cg24b68IkQ5vYjqLa95dpr79VB0xvlOxagHRWCGWrVvRqEA-VCl3kak6xE-9yzh88_1NRPb4f2idXLwhH2C0lJAYcB9p0Tms3-3sg2ZaXXOMvvMD8TH_Ie9Z06v6QwT3T3Rf-kUXzNXHAEGekJOXTqxh4xxa1pY8vXc_jcK2V_S2uBYdjWkkioTbG2w4nPgtJybIqrcmaxTUCDxAJXUsnLwg72zWNG-vGkqjNa3eDXiAZUtR-TZcvxflyVV-6E2_WzzdR9Vl9i7cps4cJEzUb4I2H5A0_c001frDr-2K2sozH_Zl0gQUVoYSYzRKEpPy21jwgYTh9elbq3szoM7-gd5QvPx32iX_AnFBb89xbZr8uKgJ14acfoNUg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWQ5hsqDoEEM6w=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=5BDED831361A14EAAEEE58971F4290D7; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmkFgOBqhxaWi1crS9-rqj2JX7OhoFSJM00-rkJDWsc6CpdWjEfM7ouCXs8IGQGMH-HuSA7jwZ8X7oeEpq9U73Bc9e2lu-CnoV2UQd4NUwOkzfhIsH_BlUvfP7EZj-dghN6RbKXm9eDHI2Rntgc_h6zEaa24H9GDMxFk3C7dLIIqwOhvhbXlLIsSRQMbSYT4Tiv62r3g1vWRacTmu-07eEaH92cyL9OAArnN1PzedTKwNeyy6ahqWkM3Vou6a7uOuIKzKenBHMzTHMy8UCEmf3fYpr3QCOTUOhUAL4Ziw76tVXmBxxAdFXwOa9742gplCDn4NGRVvfg-F5WNl8GCzwwDIZdeGm263EXIWXHMn9uffERxudh34EexaXjxJW4xA7o4Yi39MqXnM_5JuoB5YN6DexHlMRJPMWxiiQkHbHAnvmUOpMfB6YKtr18QiELC7ny-21BKXDmuaZGTzuhZRIsc9FtpGg-bXyUFtkIJ5s9eQaVOsUxL10UhVEnmOCK_w7KkFnj2ebqFNBvnoNKwHEWqDLwSuhzh6URFkjdYP81QxIBcczGCLZz8BxOJhZ0Y8V_5kfDpRaT5RjkVXItmNEFFQm1gKhG5VgzCPFC3yxEDZOvogjfxSsyRSNRKgclzTA;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWQ7icODoEEMVw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtl1C8xNEi7lyKe202gK_I7jZT_sK27f4lbWr8PSiPKGWcEGT_Ub8PSBcM1M8sUjVPqOwwrWmgzZh3mYtyARoKNvc2hVhhpkXuJ-AVY5dCS60CEJ4fpuB9dGPNHt-apiFkBtOeSmtrXjWquwHG9iJwyHjHGz9al3qCpZDxoeMl1OpH5Jr_C0sCGjww3MR7zz9l1M2kJgt_bBqbeOP2DfDgqXdUyrr2FWIYApwNbmWH_ziqwP3HlQ6LeSBZOwQdOZh3qQooYMJR0cQ2JTQIG1-sYBz7_PhCFb0zWhnwlJDSRhbQ2tU4yQtwyrLY-4jbcrmI8WzUjstbKcw_qDqkC3U0Qq9FHWO3_ZQXG8XkO5AaKwtl-KlBYYzIPOLTfRwTPLLrBX_Eev8RyiBGyG8vAPaYvZbRtDOlD8rCmE17-ALjMM3fTW8RhdqUWcjedwmJjv600WSkqfxFImY7sN6TEpu6KNarLR6VqqgLDj_AxD4UkugPSbpZZQn92-gzc-eyWEcimn1rOKWLgy_0NSjrl8PH6_szKCbs1p2jan3PQgPRSH81yHnnbuB8aDfUX7yqmik2e_maacDcxZ1xXjKAQ8DyAIbxPQ9F04ob8ugpObg4Z8My-rRboYdBHqAfJc3xWlGc34yDz60VqDEvjKv7TChWyF0k7pBvA-kuCDmkGaF30MDg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWQ-g_cDoEEMSw=
     status:

--- a/tests/api/cassettes/test_atw_set_power_on.yaml
+++ b/tests/api/cassettes/test_atw_set_power_on.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmal4UrTIB0NgtmZ4nZuwRoQwSy--UpPt4BrNYZ5RvlU_3YPl4pqrCkFgyi3PEGWIDDcF7o6GE2vhbqkwcHVzKMx7hGkJ-TJl3GPo69t66pCm7Dntue9PKSHWWRcy5UdJzqymPnAtmqXLGIpvTDRHNq_1UaSuwOVD6i5R0HLquHGMBS7QuBDHEcFc7tNvAT2rY3pJc6_MztYcSGXwB75WYIo3BMxZri2L-gTOfykPLukm32HwmAm57WFztH0Ocivv0=N;
-        expires=Sun, 12 Apr 2026 13:41:51 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.SjCwf7cnMXU8wKMvzYtRRNUu9_nIylT1exmNgR2KmpA=N; expires=Sun,
-        12 Apr 2026 13:41:51 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWQZi1JjoEEMEA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=923c3abc-fda9-4e05-b3b6-3f4198551047; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972117596701.NjEzYjE3YmQtYWUzNi00NzBhLThmZTYtZDI3MzM2ZjVmNGVjZGQyYzI2MDgtNWQyNy00MGQyLWFjZmYtN2M3ZmJlM2NkYTA4;
-        Expires=Sun, 12-Apr-2026 13:31:51 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972117596701.NjEzYjE3YmQtYWUzNi00NzBhLThmZTYtZDI3MzM2ZjVmNGVjZGQyYzI2MDgtNWQyNy00MGQyLWFjZmYtN2M3ZmJlM2NkYTA4;
-        Expires=Sun, 12-Apr-2026 13:31:51 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=DCRy6nBIA2BjIJiBDjXfUYzCAR7xojuPWbRnTLbkw1o&amp;code_challenge_method=S256&amp;nonce=639115972117596701.NjEzYjE3YmQtYWUzNi00NzBhLThmZTYtZDI3MzM2ZjVmNGVjZGQyYzI2MDgtNWQyNy00MGQyLWFjZmYtN2M3ZmJlM2NkYTA4&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmtHOQjZGvjGGcr1WQ-E0mVENxT_4HghULS5h_7lVckO6T2CsIW14hLMf_CL_JIahrHGsmDlHBN6oxIRUYUocbOU2MFWq8Z9zimkCjEZ646owWDHYL6wOZYHt-xFFeNbe-xdxifF4MP-57t05bVAoug3aMFwIjxK3aV_FvfFNGl0CvCI6XbULvRSzvKGHDSjC3CANOnQMMJI5cL8lSLn7Z0Lq_LNp4oRG6nazGPWz0wHpvqV8Fydncmurj7Lku5H-otV7-rLGl3B5St4Wyp_6v5WyC8BK_we211Ys_cEEtYb7-Bo3feiQQqtjejCfz7eaDVb6BugYAtVC-4Hv6bCAkfhGaglmvM-MTDltOcVp92tR7mXbn8fK12fBZOo15_aOm8h4Mkyl-Kjw1i-sFB8GK8QzfToNb-omBTgF3526Ambn0-L4ttcsR4DIzxfbZjBDGog2NAUUuGo--MvL6J0oqndr5ml2-JhbGhe47AIQeDovN2BDXav5dm7slkcY_eyXHeMpbBNEQDwy1qTX2PqOR-SixGnfwdi-5m-Eb69Qfk8J5LXgEp8mDHJG7fMT-x_LH5PeGIzBXwiuQ3rM03hwGT2-_BO9BxxW5BdIcAGS4lYmsmTQXxvMY2oBX2rrwGrWu1Ir2ej0QU-RJ84T475IqE\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"923c3abc-fda9-4e05-b3b6-3f4198551047\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-1f9eff1a4e4d\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=DCRy6nBIA2BjIJiBDjXfUYzCAR7xojuPWbRnTLbkw1o&amp;code_challenge_method=S256&amp;nonce=639115972117596701.NjEzYjE3YmQtYWUzNi00NzBhLThmZTYtZDI3MzM2ZjVmNGVjZGQyYzI2MDgtNWQyNy00MGQyLWFjZmYtN2M3ZmJlM2NkYTA4&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmtHOQjZGvjGGcr1WQ-E0mVENxT_4HghULS5h_7lVckO6T2CsIW14hLMf_CL_JIahrHGsmDlHBN6oxIRUYUocbOU2MFWq8Z9zimkCjEZ646owWDHYL6wOZYHt-xFFeNbe-xdxifF4MP-57t05bVAoug3aMFwIjxK3aV_FvfFNGl0CvCI6XbULvRSzvKGHDSjC3CANOnQMMJI5cL8lSLn7Z0Lq_LNp4oRG6nazGPWz0wHpvqV8Fydncmurj7Lku5H-otV7-rLGl3B5St4Wyp_6v5WyC8BK_we211Ys_cEEtYb7-Bo3feiQQqtjejCfz7eaDVb6BugYAtVC-4Hv6bCAkfhGaglmvM-MTDltOcVp92tR7mXbn8fK12fBZOo15_aOm8h4Mkyl-Kjw1i-sFB8GK8QzfToNb-omBTgF3526Ambn0-L4ttcsR4DIzxfbZjBDGog2NAUUuGo--MvL6J0oqndr5ml2-JhbGhe47AIQeDovN2BDXav5dm7slkcY_eyXHeMpbBNEQDwy1qTX2PqOR-SixGnfwdi-5m-Eb69Qfk8J5LXgEp8mDHJG7fMT-x_LH5PeGIzBXwiuQ3rM03hwGT2-_BO9BxxW5BdIcAGS4lYmsmTQXxvMY2oBX2rrwGrWu1Ir2ej0QU-RJ84T475IqE\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"923c3abc-fda9-4e05-b3b6-3f4198551047\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-1f9eff1a4e4d\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=0413233d-02d2-44b9-ac33-ce315be7b8d1; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/+jEVhW3V8jDsJg9cTT8/dHMuVr/XnXjy9EADjfKICcNO8uZ3bSI2dwQHrMfV6NmN4ntKunaZemwrV3128US/JslvGRa+AY7KF6yRa84T1IlYhoP5WLudfzy79IP065TRmYt4zGmAztsMpdFkJiYP6Whj9yax4pmuG4AMnKClYWHqs7SnBcE6IaBhFg/GZT+deQzD0aZ3nFAzZ1WCJObPpG8zTWBiUPNb4OUysXhJJix2f9WKGTB4J9Aiebi0INNIBoXLoVsP0mxC12C2xeZb3EeaQvGJITp7woimK5Vl1+Gr4dX49v3iAAAA.H4sIAAAAAAAAAAEgAN//e/hkWaRjYKGHJ0a4FfXho4qh16Qk1nfYfV0smrqFgpdZUPOMIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:26:52 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.SjCwf7cnMXU8wKMvzYtRRNUu9_nIylT1exmNgR2KmpA=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmal4UrTIB0NgtmZ4nZuwRoQwSy--UpPt4BrNYZ5RvlU_3YPl4pqrCkFgyi3PEGWIDDcF7o6GE2vhbqkwcHVzKMx7hGkJ-TJl3GPo69t66pCm7Dntue9PKSHWWRcy5UdJzqymPnAtmqXLGIpvTDRHNq_1UaSuwOVD6i5R0HLquHGMBS7QuBDHEcFc7tNvAT2rY3pJc6_MztYcSGXwB75WYIo3BMxZri2L-gTOfykPLukm32HwmAm57WFztH0Ocivv0=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmHeB_vqery1gXZnMXC_wF-azyeCLBTFOJvLWzvNmgualnowATjhXWTCIR8fs2TMeu2Y3x-U1UycapN1E7BwXWgUDhush2XZhxkE8UqOEgHwT0y7TnfZPZkfW46684z0-5_tM9kfFv2O18_WujjgbOcs6jPqe_C0W3codXmYIbvYlDA2ZZQ3MiJJwJJg90E3O5wCqfPz8BdW8D12HN0pDSE0e30KXgqEf9zPXUdNDDqn09MLFRxkj5TLGCY2uzTR2-8FgrAJ9sgZJj4vfCXp1WdR8o7ZwDoalr21xIXXzLbPekBM0oM7VMSphM9LzlBhN5zB5eTVnYceUqFmqNtRhSvWCoSM0aQ5EAAFiYiD1W5zRP5acxrkIeV2wPGhak2gZCcOnvW3P5if5WowT2Y5hqCipW9TRNBKdatYvbrws64VbFoldXGZt-2WRQlq24qGuEbpkTrlNpijSYUYbiz-G5_VFtLdH7LKjfy6qdgYvxd1QsdK09SvzF5_QswuDJr3WWST3vX7pMd6O7JqjfcsRxUXBiu2XofCnyQImKX8EdNqdjwnLMwh5vzivnMCHnnoy1-wAFtcduOoyEZQxHeAJTtPV8yvss_XR7aPnRSi_83zed2F5hTIrtTq0M-DfPH1I2h6oHqD1bb6Ge7LmJVRf5SivTmTR_nE7A7TkiUMdQ0DJSQ6VTDq5ut2uCT9P0SbTnh0Q1lupkgtNAqfdGECJPUzTZvVwFbZ4XbKuyuhCQJm9I-snVvPqmlGKhk0x5-SnTHou9TxrgN75aNzpjr01xqx9KX4oM-tbghFf3Kvb6zcCotLSr8SeF9qJmBKTLJEzsiO6_OAa9MmR-Cb4RCTItv8XUz094i_lGjd63TY_c5fvc8zNwBMxzt7l3sXKGqXYXlBw8OzcvIh9Xsiq5NU9-nFrp3UL9WZAstsNZXVMY867TpDBZR1iDYu5ETjwalbhR1lBgCxDUb8XjzKFggjp6dXgC2WGhQNs1gtgMO6wywKiRTaTIc4eLUQxl4VTYzHxbqgvZ2tNUVsl3MuzQbeHIx921zB2nxh-73ruQ8IdBvwJLL2TJshJxuX3zPVpSOsrrSox4AgkQTF9bySg3ungFlksOGqyvMEftK9M12BCLdIj7KyowPm4ZrQT55c7WMR0kzLR-mLhn6_Ke29sheQu_Yqmurl29CimQ1pe4_J2UHC2jBDOcuSSnbDKK-08Xb9k_ADh2Jq4GMpk2Gobiq3MFnQySKfOgXjX1lZscC9xLKNxxCMsF3zDcQH_Nz_YF3uR1-7LjMsLapMHrrmhXdYTFTeCo2jvF6Xx4A11MfMc7OC5vz6vaxb4cCTfw4m_UiynDwJJ9i1EpQnhKMaI6DX4vqOEW7Qofzsxh8AiSy4hbL3jcPyftiOg3DnmnpMY7-X_xyd-eN833lk-hIgcg5wL6MLOZV68Gm5aF_OSQfC5Ve7hngWD9yUj1jLDeD9RkflX_S2raag6uPOLdfSkhMfFaNS2HQVU67iX2KrZxlve39T_q3Lv-XIhGvSNdsukctyDUzyKj82jkO0Kyi24Ni-vY1y-H5vELRgnLFWwXl6rjhQC7YizUK0Em70XlZ15pQdiuge0xFJdmSIRQI2oy3nKw7drFCyUDJozZoVcUxOE0ahPl6989z6Jo45ijZmj7-UA1ov8S0I4E1usQhya83mYmhNes-IHniZrjll3Kzu9GWwMfuZxLv341oMrm9vS9pxc0I09s5ySFXQ50XfILNgXAYbXvVHkdx1pc95liWefDuJ7m_AAxklm52L5tjcekrdkBfFUMVtGQhCdXJPm-5DRBXFj3ZYy8HMg_6bqXc7vJHLPytKE6TCiIbaUP_lPHAfSInzTScRsbv6hpEgxWjyb2uMEaPEUs5FFP2HLt28tlErdOT0oswW0l9Vjf4WB7YUK3g0Bv_bd7kkPKtY96asrdb6xsU5Rw50zVTnZ5Q0wmCScDG5edS4VjCWNAVdYCwYaLBs3z-yScOBw1FgKv9VQUsOK35p3VpLlVdzj4ZDNw4Fai6srcwUniN7LjFbyml_xu8-VUCSNgi4Rh9Xmt7U-tIsNwon-I6ah9JSaMzmmAr1gEqd5PLVI1SUX1Jf8Z28NaDzqExXyNtUmxksFcQlIfslEQO6gE0rllW0RIoyE5rVqKyUpCQfYa-E_kuKfizdg0ToLsBridtq4aJp1DdkwE4dqPPnQeqTH1-iZFTdQRqGO8MlDvYQ8tIXzih0I025bou2KekoqGKDK_NXnkP1FBlu9Knk5c5Ws7dGnDAMzuolzd1CZEv75SC1401zfswCxw57wlNRW3ZAGV7o_J9Sw7fZIMpiSBBw_IGQTCXXeWtnJ-lHEHaRVp73POZNjeecEtFwn_qam3L1uwq7np_BNH3HPpHYeNXW1rLeU8eUNQlWALODtZR9QoATLiTzQSPNboduDN9Rj0_00X-Blu9n2_9aOfhVS4jykqxiha4nE7LXw;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWQhgcmDoEEMtg=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=094C4D305AB0E9E29FB1B1494FCF42C9; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkjG4nbT-fSq1QFWuTWHp4Aafudu7t00pYTNzj6HIkOVxSzLohyCfjADtmIj1ssKD7KXWUodTx6_4u9uHV6dYYF89Jrd_uHygM4eOyb_mkdC64CWYl1GQ0bS6e1hXirBoABV0_VxadgghMKUcxWoWaNqWXtf87VO9wbJEjTaidZw_nmxenpKyd7ixd4OPsduRIpPYkCS67Z6NvCsT4Xn4Ig1yjz7iO5DPNkWaC7gJ_G_B-zND0swIJIl5KapJwH7tC-4Fnl_JDLSHaWLUmzH2bCR9SSut2ndH27wYQhuRmkH7-k-G0o_VTgvkMCHcnxUWnYU7XaJM17wuxdTbFQMX8G0fnr4e50CVxJnSgXjY5oFoIKV7IHIKg_9Uro6kUbmAWCAu0O0pfxGOJJ-XBwGPXE2ZLjs5jW7DnUznuDrTACEv679_yWw2sscr48-wpNft35v5UF6oUEUG_fDV8eQ_0-oo-7XqffPeV0MDYSXQBI_JlB_hAPU2xd_xnsYfPRfipK2yxqIWX610K64gMLZxZnb4NgrdLZx-yjJTO9PNfz4aGpv7T4mrhonswIYRn0IZwDOIbBakT4Tl8WqY7TpZBYeua3G5x1hTaPbjlmEEwwBy0gTMyswpbH3QAIPYSbjYg;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWQjjPPjoEEMDA=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkGjcjyVewgZ80FVTPgRXlU-jnkekpBIt8HwrVGnNjXQnMhPumbCamPhI3f7ampL_0AE_v3DtTu600y9ETl7u7VL8cCNdQ5uvFjnCfZ27pRpKYdxXsjNNdyQu3SfpyHsSr5sl8qIHeBb1CF7ya9iZgRbCjCIGwzKiwXQWRMfiRNlxs_AWV7xQQEJtROZkpYLnyQ8mFqCSrwoVR82BggIt9h1MyebCWquijM3WQgkJ5M0Uw9Sj94r2ZNDYbBmTGVn7_SPSgxYaoKffHQv-6xvBjmxHIbuOLB1C2vej7wk7xoNSTiqPBfLhd9aG_7qrUjxgMOAiY8_NATlM4NW7vKxn33hB4o5sPi1XVlVujNHfx8CfyMDACzR4Cqvi6W3EUzxVLrgZQrEQpX08tdqtoP8-UOF-1Whnq2B2PyFljJby-MpTtqTPNZ_6m8SpJxGEhT9BPASiLgMaLf7-MEF2A-sBPwIcKTpLGMgZOfAQ2bad-9xqJ_jWNpfsYGxlnFkIusWaxVrebCEtQCd0GJymglr_01wIkAPk8UjW4d3EILLlbHRafMHIEgdQElWy97ux_ICO_ec5QQRZ7Q2J4VGDUIE0G7M3_FYbLLTxV5jyv3eC7J006Lq00t0-hTD7FEYkhs2Md_3SUn1NNnULGqTeEm80QQUUj_xMxNL_RA7-Pq7K4NHQ;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWQkgCADoEEMog=
     status:

--- a/tests/api/cassettes/test_atw_set_standby_mode_off.yaml
+++ b/tests/api/cassettes/test_atw_set_standby_mode_off.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkfZQg7Sb7yLJgMvZpZWUklzg2ohUSvohywueNiFJOjLOmNr-yMO9vZwWQz64L2viex5e50wl5PzBz0eZpwGy6DPlD2D2nH7ijKTGqYpuzOGigM-QGxeBHh_4LpbmhiyUGs_6Jx7r_l8R4WRm86P1va0AWqkqPWw_OqLszSOGJK60Oupw3jMHaHo2QBRvffSTows1p8bU3uTfDeqTx91P0ls6wqM1U2FBwfGBIF9tUi_uQBpUr2xEeOkANDxe7pCHA=N;
-        expires=Sun, 12 Apr 2026 13:42:12 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.fguFTMNTMtq5U2g362WkBK3VDMGdkFRQBDXnyO9owgk=N; expires=Sun,
-        12 Apr 2026 13:42:12 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWTojSDDoEEJEQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=707ce688-f53d-4058-b781-f8f02f6f6a84; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972324438497.ZDJiMTRjMDItNGY1Ni00M2E5LTk2ZGUtYTgzZWI5MDI1NjJhYjE5NGI2NTAtZDUxNi00ZTEzLWEzNzktZjY2ODYwYzZmZWQz;
-        Expires=Sun, 12-Apr-2026 13:32:12 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972324438497.ZDJiMTRjMDItNGY1Ni00M2E5LTk2ZGUtYTgzZWI5MDI1NjJhYjE5NGI2NTAtZDUxNi00ZTEzLWEzNzktZjY2ODYwYzZmZWQz;
-        Expires=Sun, 12-Apr-2026 13:32:12 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=rc0ZKIe8pA84pPTXBfPv_bUFYJIo1cMn7vl-mWYWHmI&amp;code_challenge_method=S256&amp;nonce=639115972324438497.ZDJiMTRjMDItNGY1Ni00M2E5LTk2ZGUtYTgzZWI5MDI1NjJhYjE5NGI2NTAtZDUxNi00ZTEzLWEzNzktZjY2ODYwYzZmZWQz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtl0BTpkt2HGIjLGSqZGbUd4sF4bOjhyXInXacAcySD3-v2wRPS27miMkTBnJe0lCsb6VD3IJ2rSq_OOL-k39Mb1xwUOLTF1I1t6U972fn52sHNv64W9UOogXJe1VXjUEGNY-99VBuF-ihaxtC7N4A5DQdcAxqSABG59x3eCq0Wdx48ArYZzFga6cEPvVe3YhbXz4nOmt7H2TQ_G78MzBnCNjaRO-BmRa6F236EuyZxVQijP_QiNdg2tl3X-3SRUH7bJQmAfwocDJrFVFL5aHUSCzfY3qfCCP3tySaij7LLUvxqZ-R5VAxde17d6DocQAWZmOF8D-qrShlWU6yS11r7RyE7gv_x8EJo4uL0cjIF9d_n9SA1vhcxc73H7q_W1bng1MsW89aR0K9WJZIrXpwll-o2-Yx4_BwTJnmaGIbQ9UbAcMZXPWSNFNG9dzqCmulU2-0eQN0IPhFKXsK-WxMqUnJwsKXsa-QY3uzkm7ZlRRYgLY2Ppda6R_g6wFebWkGbJTfZVBs_EIsJ5i6GgdPrqLZhxGfisiTiuyMvivPmwce7B-9gVqda3p1YeQ5UOHFI3u18k8d2gL12CkNeSeRKQTW4wnt-8o0KQsqB0dTQda8C6AqohDG3kDyvSUYL5LLdmMHj0XhqYcuaCGu7j8sNG\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"707ce688-f53d-4058-b781-f8f02f6f6a84\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-d0503e6bb3f0\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=rc0ZKIe8pA84pPTXBfPv_bUFYJIo1cMn7vl-mWYWHmI&amp;code_challenge_method=S256&amp;nonce=639115972324438497.ZDJiMTRjMDItNGY1Ni00M2E5LTk2ZGUtYTgzZWI5MDI1NjJhYjE5NGI2NTAtZDUxNi00ZTEzLWEzNzktZjY2ODYwYzZmZWQz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtl0BTpkt2HGIjLGSqZGbUd4sF4bOjhyXInXacAcySD3-v2wRPS27miMkTBnJe0lCsb6VD3IJ2rSq_OOL-k39Mb1xwUOLTF1I1t6U972fn52sHNv64W9UOogXJe1VXjUEGNY-99VBuF-ihaxtC7N4A5DQdcAxqSABG59x3eCq0Wdx48ArYZzFga6cEPvVe3YhbXz4nOmt7H2TQ_G78MzBnCNjaRO-BmRa6F236EuyZxVQijP_QiNdg2tl3X-3SRUH7bJQmAfwocDJrFVFL5aHUSCzfY3qfCCP3tySaij7LLUvxqZ-R5VAxde17d6DocQAWZmOF8D-qrShlWU6yS11r7RyE7gv_x8EJo4uL0cjIF9d_n9SA1vhcxc73H7q_W1bng1MsW89aR0K9WJZIrXpwll-o2-Yx4_BwTJnmaGIbQ9UbAcMZXPWSNFNG9dzqCmulU2-0eQN0IPhFKXsK-WxMqUnJwsKXsa-QY3uzkm7ZlRRYgLY2Ppda6R_g6wFebWkGbJTfZVBs_EIsJ5i6GgdPrqLZhxGfisiTiuyMvivPmwce7B-9gVqda3p1YeQ5UOHFI3u18k8d2gL12CkNeSeRKQTW4wnt-8o0KQsqB0dTQda8C6AqohDG3kDyvSUYL5LLdmMHj0XhqYcuaCGu7j8sNG\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"707ce688-f53d-4058-b781-f8f02f6f6a84\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-d0503e6bb3f0\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=691278cb-3413-4b6c-b71e-2ab9666d0506; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/PDvKMKg0PYKbIPfJzZbHJRwjnk645kKNCbxcNgDYuK8obN3CMajsxFUNqjb4an6QNWQcrJYehlOxBf2JLYJ5iR9prmUDI5Ktf2lVobWpQQIqYkbW8YWi/Tqzv/kgBF5JiZduAErs/npRDSjOqiXbip87ZDagXjdyLl2gvd4HCSvBEiNtokfS/ZB+BBOyO7UTBBYCdcVhA8vGUSmcsDlZprtnR0Hlm9/2hSErmy7/vj8Qi9/zTAMhKc6fqY7KEunfONJlMXQhtD/Et7PJvUT0LIdUtq0WUAcwNZZH+QfdTrPQ1PF1y/viAAAA.H4sIAAAAAAAAAAEgAN//kGjZ9LmpsA+wz2K/rFkGmKHjEmIkrAJrWpZhfDQb+Jyflhx7IAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:27:13 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.fguFTMNTMtq5U2g362WkBK3VDMGdkFRQBDXnyO9owgk=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkfZQg7Sb7yLJgMvZpZWUklzg2ohUSvohywueNiFJOjLOmNr-yMO9vZwWQz64L2viex5e50wl5PzBz0eZpwGy6DPlD2D2nH7ijKTGqYpuzOGigM-QGxeBHh_4LpbmhiyUGs_6Jx7r_l8R4WRm86P1va0AWqkqPWw_OqLszSOGJK60Oupw3jMHaHo2QBRvffSTows1p8bU3uTfDeqTx91P0ls6wqM1U2FBwfGBIF9tUi_uQBpUr2xEeOkANDxe7pCHA=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkAKyaqUEerLmfxHq5osbN2Q8roAsVrwHuMt2KLcZHj0HgXGfZ_dlOmJjAy6IRwV_nMBrLgLHIwXT203aJtJ91ku1luqpAmpuwZJMSkwSXLc2NDOen3XeWrTrWmwipCy3KhE6UirOqZ0o0MX5xrKJwV02QWqP9yOjQ-Vf_LXEqG9UJepDG4nM_pLmQDwFw1oqfidPIXN6NAlEZFIdVRVvmR2kLzhCF7EUk8v33E6ndAyg2w986FkJef7ZJYVmM549WVy0wAdoeb-lCdwZa6P8LbYYaQ3MZ2J0RvluEiBfecJuQ9U98bX-ao7BxehFJXufLc-6jnuhx288g8Au5nD2kmHQbAN9z_zaNZU5Q9wu_oIIDoy0yqaEsd-aZ5Gg77coUxFZUvRlCncvM7M5bg5Bz6jWXFjNmhpzcrerbncfKT-Ytvu-yoi3Gdpi9RBBMj4sPnkdXkeP9DzGGYv-kF95_rRYxcuzgXdpscuVqu2l1opkavF3wczV2Iu6OF49uGaFI_FZrSByw_HYppxSehdf8zHglLGD8X6Radp4XuYXj8aE8AzAfoAkgYY_nd4y02mzv2gIOfgKgSuMYD2kRHDGPbb9UlWUO0WpnPI7JVEZ_ooNnBAe9POBTz-3ybqH6zKSdsGz9YD_l3Aj61PdHdNXZxh1EYtf_sY2a5_L5aWbiNlOSf4nTEzjQG4naprLrEC3v1-LMkB2nPpTM8Pv2h7MkED6TJRypa79-NrmtnHRnQcclh-RBLDvJ7apZkvoZw1DR53SLbIERVl_Gt52zjYhwRKIOdgr4tJdcnaIAf5ZTFrOGA0U0qCGQ2ATT8tzSVIxFtxsgm6_NBciUCid-XEHKC8PV8AwgelBarDEPBImk8Nk00tOEDEF3l2gxvxxnTO9klEgs8AMjW4mDZ4Aexpbwjz-7KLJd34DqdgonY142sL8kAIwF81VHV46jy86Tp4PZQU0Wb5yiTaSWQsa1DAe3kc3xxe7mmBPjMSXps4elcpz69SdfnInHF48ucx7q4cKyfLi8LcDwMkar7ahd4iR2pbFwM_sA9BQjayQUEf1ODs2gcevF5MCbUL9COXvE_N_4QVDVVmPsXGqEWKmeZnBm7VCXA84pt5pKC8Iq4gNPiAvZ5lRZucdoBCSfDP1F-L8pTFny8KZp1E7P3PzhxdSuUDPWMztWGsQbYe2JsypVvEoeBOrrdXx4zhjthkMaTUgzDDQIHj3n5cwWfXBmOHXXQYgglU1uMNJgUZW4Sh3DBJqg2paCw59xWVDkggXk_URIsdHwizT-ir6rpeW3hGluhuQ-MMPufed3C4gL7GA0vFECdiSt86plxzq65sX5KqsZjzzjxGj_nGaV694YfG9-gJU50_QzF9XYuM9L3gn895pzrdjjH4YUHhfpuhS6p9hX9LjDmJGZON1_Ellcu2G1MXjeJ26_DzQUNJS0TOBHXuGkobJxP9M5EXI9jZIngMebp3707-pfTrxwnJdZhxUytKpvek5m_TqLgKYMKJXiTfLIJ6o0tw74mrVftWObhgYNpPzyWanOFhNIHulR-J4I2TzGM4JA81arrRrMBmFtAaR06b4tDeC46Mupo2MH-NJEu1jPRbu9HnuXTWsc34W1lUSZr-zY-cx8UPRwnvTDpIytMMF8u_Quxfb9bf-k-VUc4_mioxK9KBNkHItaBGHv8yY2chEqgp0QwNBWYSExNlO8gtz_kFlFCacqxjI6i7Cb7_5Se0ib3zawvdUznp85NtqOupuwNDXJ_gppDhKel4-n4Q2HRlDMQeOEcwOs3kk2gb2KIqZgq1_gDfAppZp40gVImHeeD4rRCvSjixbTCkDq0jqj-jwbbZ8NKJ0Ria-jz01yqbwb7EUgh0mGRA_tqemIdMTCZ8xWiFtd19G_9W2dKN81ICtE3mMZn7YmtXcHjBVmD0n8kZWA9qD-SXMt_0xblCmDpRkaYhmQZrmKPMSMvb6myaPY2n8yTieaigOfzsB5S3kE05waDAIguc27y_OePd0hqummxoObP5SShyzTQJdSCBFTxTyZ5gnBj4P-qj6CBss9WCR9eRuOm-f59GUgIBOoAV_IFiAbXG0PIjQM315vrjPUBSrkKBA7Cfget50OgRHgBGkTGsaCALbJChoPSTRb5bjExzsQ8bxeEyxbSp47xYwj87PhVgwrk02vljNpja9-8THuLApPr9X6se7XJXbyYPtZN0KM3R6y686TbJJpYLPx8NjSsn-QfxJBOEzi9FIw-SZ8n6ywPcotz8QW_gNLVu92QiM43cW2Ooeu_KHAquyMYg8Y-xldFw2isxMjGf2ypFeSQlllnzemNUxMK210r2PgPf7egLr3vhZjVbgREnflBFUPr8I02rXJwcAMne5tdwkL9vu6L5xlJQynkUC5DiJEneggzlWAZjmRQtC_L_q_D92Ufrt6TVyEhu3CDY87eHOkN1ffIMG9MRQr0ZSPVC7iAHU9lr3bu8g;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWTxjCeDoEEJVA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=D5C3F3E5FA4AD5A07F15AFCA1BDD713E; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlmW_ZBJ6msGC1LipCOLLqi5pLbjYCS0tackQq0Vkvr70OTCMB1ITOZHWxdYuAqdGJk2wayxszfzpcaOuKwrWk0Sad0-2Qjsh2NLbk6xySXFJYO51ggU12JzATpIySl-BrDdL4OB_V1vUcDD6Hfmuwrnu2iBcuta4-rFkQHTh09ujAStlJ4Do8eFbSw8Uf34X6hurvmFxnmUXPY8stHksEPjtZ7udd9At40nT5Xs4wrr7V_5Hc_WRJBII0-QRSDJfk_Ahb4ooRLXuZaQGC7ZvYBFmgxHkOlhBtaauFJaazKRcaLOHXGh0IpBlqvkRZgpiZs3EdT3OPj-MCHzgJGM21K01G8O1pOt8MT1gowPb3k92KJeNlvOcb2C00kyGkSL4_gh2Eblm6Ng3V-AksENha8v_wX-ajRIuEX0XkdLSii_rD_OCYTYREqG3MTb-N-qMZxcjBHY9v6WC64N1yw1W0leDSddhkavMcZeubINBUXSwbWTVnymHzNObgrZM7Ag5CrWP_9V7FDuZY-qxy9b0NTn7s_owzwMWWKExAfDRlNrl1lmmT_jNs_RbFb791ndg9G7QIw7Hl1O2lntmwK2KPUN6XS38lojiKED_M1QdRylMhlNEaeHoGuePqa4vKUjyA;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWTzilCDoEEJ7w=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtn3nOy-Q2_8L7WXP4PeWDQ0O4ZWzq-jQHReBoCUUQqXIL5ertdX1MHVwLl7gOvru3oVEYkJlmPlrGzAZg3zoD--9_P7AVanUGbXcBojwKXGJtNSswsJxu8jnY4dM92QeS-82VZl3BQyiazVUAfG4WSv8pLsij2zMWpAowKBcRqFuaCB7umCKF8UOMtMdyuH8zstq0ustg-khxwk1SI57egJVpqYJGOZixr_7_Jh7Tw4yb-PJYSyW07aNkx7uMIVAtrrB4pIfaOqhLnk8KC2iBc2k-CYl24eD599JY9DrM5vNClLefKdCWEmSN6ngFtajqEmk2RoCEuQo2fK4QgA0E1SIIMVRsHIpICML6DLdPX6GTw8qjFdSlHF1oR80Qp9_WM4-U-gAhAEw9O7jQdr-OFtsF89XyfZGUKfPHuHdvbM_07pPxfAqJM5cglL0i4VcDLttvVYsb7s4XwhRA0U8K3pt5A1JiNlhFVxhDZ3pFq0h8jnb7r9an1ZhlLzNOnSv-zJoAxgEo5hgA59O6dahJyJl5Zr0chJz9kPuHS3aoPDQJtAWpTVDlzZCds5WLW5tTLKcsQpPy6_rgcEiv-gx1FlXTOnoONPs6teLeKxq_orw0i7SGVM1i5L9b5E__2Q0IOG0yVLJGOx2vd6_hNhncaUb9u4Zw6rr9f3KZtqOMzeDg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWT1hTODoEEJzg=
     status:

--- a/tests/api/cassettes/test_atw_set_temperature_zone1.yaml
+++ b/tests/api/cassettes/test_atw_set_temperature_zone1.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkMllZcr1DZUVB6G2VJapmzTlSz43pECqcHoC4KVMrVyllUGMvP9L5DbHBTZdxbxHNJWK8ckCl5TXNVBDcA6j7RohmWLRBl4R70LJXKhdYKGtFgDZ6GnbwqXaEkz-f9P96RIoCzrO2DGDxhth3PrVWY0yX4yviWGRAZazCF9giN5VSpPB1_ULmVF9sBYiNWDYHiTPbA9-DCvyZUVb3XirMIjT_0NZY7bETZ_nd9ANuBhEOhcyBtKeaYRzbXSwBNOoo=N;
-        expires=Sun, 12 Apr 2026 13:41:56 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.hUmKf9LJUfF34bV4JCJWstHqboBghhq-ZvnfnUl7uuM=N; expires=Sun,
-        12 Apr 2026 13:41:56 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWRLiiQjoEEMVw=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=a4edaad6-34de-4c25-90f8-65898f63455e; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115972167656946.MzBhOTM1YmUtZWRkZi00ODVmLWE3YjEtZDgzN2YwMjI5MDJjMWE2N2U4YjItOWI5Yy00NzgzLTlkNzEtMDk1Yjc2NDY0ZGM1;
-        Expires=Sun, 12-Apr-2026 13:31:57 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115972167656946.MzBhOTM1YmUtZWRkZi00ODVmLWE3YjEtZDgzN2YwMjI5MDJjMWE2N2U4YjItOWI5Yy00NzgzLTlkNzEtMDk1Yjc2NDY0ZGM1;
-        Expires=Sun, 12-Apr-2026 13:31:57 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=eCfy_I8YVrdLDWM5yGtVycW5CCEZzEpdidFpvffrvr4&amp;code_challenge_method=S256&amp;nonce=639115972167656946.MzBhOTM1YmUtZWRkZi00ODVmLWE3YjEtZDgzN2YwMjI5MDJjMWE2N2U4YjItOWI5Yy00NzgzLTlkNzEtMDk1Yjc2NDY0ZGM1&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlvtzeAlGGQpK9pe36C_aQ8uW6BbrImjLgWXKb3t_t9xgwyQCU3s65ENtswSjbRPAkDmSe-RQqrSaqAPr8_wAqoi-ogxpbngjiR7FlOwdTx-WnGnBTGOzQ-N7BgW8qAK7CNDkgjnbRptUoTZYAGJmDKKIpRsTg1WXzDwiJU-n4oxNnEC_IMH45BTqdDwCfnNp_5PwwhW6Oa2eLdkI_FigxgZIiL5CTrrVmKiezgK5LQfpPF0ukWXMpR5-7S3Oa63epa2MkU_Gs8syQBu9lmAQrOD_jypvmxp9sRXAqXoX0Ok4sSuLy8mv37hX4UfQKwXsEEDQP5I8RLhgyjqOZxyuMk_e5Dm_XWH2qcTdUZl2ngxfc5N3AZ6qio6Dd9hQhEeh2KsRr5v6j-eqKm1bOXzAIuyq45UtTKtcPrK9zmkqIOE0W-mHw_PDvpIE11ClIeoGYXrn9QBb7sO6TLz80sdC19WR9F1WL_S3qc0capJqE460_AvjMXk59hkvdhuARGRKarGzt2UaJ_uZPoYXF8Kebt4JPKdu9RHCPH3kcscGmoE365HblM8B5uxa5_DXmCgFGVx8naZ8Gi2IIc5p5Y4rxxlftbjJg0qvS5LuY_RrbGKP6NcE3jqYKofkVTJfQiU1lXsgfZR-IIQMwzoDUyfcHb\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"a4edaad6-34de-4c25-90f8-65898f63455e\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-716211bbc677\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=eCfy_I8YVrdLDWM5yGtVycW5CCEZzEpdidFpvffrvr4&amp;code_challenge_method=S256&amp;nonce=639115972167656946.MzBhOTM1YmUtZWRkZi00ODVmLWE3YjEtZDgzN2YwMjI5MDJjMWE2N2U4YjItOWI5Yy00NzgzLTlkNzEtMDk1Yjc2NDY0ZGM1&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlvtzeAlGGQpK9pe36C_aQ8uW6BbrImjLgWXKb3t_t9xgwyQCU3s65ENtswSjbRPAkDmSe-RQqrSaqAPr8_wAqoi-ogxpbngjiR7FlOwdTx-WnGnBTGOzQ-N7BgW8qAK7CNDkgjnbRptUoTZYAGJmDKKIpRsTg1WXzDwiJU-n4oxNnEC_IMH45BTqdDwCfnNp_5PwwhW6Oa2eLdkI_FigxgZIiL5CTrrVmKiezgK5LQfpPF0ukWXMpR5-7S3Oa63epa2MkU_Gs8syQBu9lmAQrOD_jypvmxp9sRXAqXoX0Ok4sSuLy8mv37hX4UfQKwXsEEDQP5I8RLhgyjqOZxyuMk_e5Dm_XWH2qcTdUZl2ngxfc5N3AZ6qio6Dd9hQhEeh2KsRr5v6j-eqKm1bOXzAIuyq45UtTKtcPrK9zmkqIOE0W-mHw_PDvpIE11ClIeoGYXrn9QBb7sO6TLz80sdC19WR9F1WL_S3qc0capJqE460_AvjMXk59hkvdhuARGRKarGzt2UaJ_uZPoYXF8Kebt4JPKdu9RHCPH3kcscGmoE365HblM8B5uxa5_DXmCgFGVx8naZ8Gi2IIc5p5Y4rxxlftbjJg0qvS5LuY_RrbGKP6NcE3jqYKofkVTJfQiU1lXsgfZR-IIQMwzoDUyfcHb\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"a4edaad6-34de-4c25-90f8-65898f63455e\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-716211bbc677\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=c2a1eb43-97bf-4acd-a395-aa1c40f22d17; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/UCjGvQIu5CEYPv6kWEUJhxIvUOV6r0zALRHRBlnJDt5lENBc6mGVW7KrhKa+r8xOgaZA6IriA+wDO7gNxKd8xwM8bp1v9vY2HVpym3sfj6R/zA04jME9CrHw4TNEX9sp6SU9gqArpfUrdWu3O+Fl6W7pwSWGwYTqRnxVDYUAW34Vqcpx4CL28CnGiIW6XHUo4uKFP8a6zT/dn/bNsk8rR4tLEGmYKpWH8bVgc9FMBAszS+ifPTqAPeyNNSCbEXYrb7geYf0RNtvzfamwvNOiWTUGuCLWZmzjYm5UBuBg8UHZLKzT3zXiAAAA.H4sIAAAAAAAAAFM0+DPRrWFiq/PPy45iX049eue5mvGHrZyMvunkBzfETeQA15EKnyAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:26:57 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.hUmKf9LJUfF34bV4JCJWstHqboBghhq-ZvnfnUl7uuM=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkMllZcr1DZUVB6G2VJapmzTlSz43pECqcHoC4KVMrVyllUGMvP9L5DbHBTZdxbxHNJWK8ckCl5TXNVBDcA6j7RohmWLRBl4R70LJXKhdYKGtFgDZ6GnbwqXaEkz-f9P96RIoCzrO2DGDxhth3PrVWY0yX4yviWGRAZazCF9giN5VSpPB1_ULmVF9sBYiNWDYHiTPbA9-DCvyZUVb3XirMIjT_0NZY7bETZ_nd9ANuBhEOhcyBtKeaYRzbXSwBNOoo=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmni-Lfs7RWxLI9NSDidi-HByftI5vZSrjQIfy0yf2O9Y3CbAgIIntDK94K_zoIurwl-9L-VhchV1TikjjQIzdQuvpNMYazzE5F1MSdMKPecsxMKlH4K--o9n_3DB1sV49y5rCf3dqaOxCKj62Nu2Kgkdq_4w7RwfVAlr4DFMhP87BVytVMQ1-kW4kPv33plg8WOQJjQqI9LLmis8yjm4QpRAhjPRW6GhdRbsXJeLQLd1EM_UurAsv-aZqfbuyXuShldfscIVZ3Qr1GBcf0co3mXZD3GcasGxgXRyZPzDLcpq-2qkZhGdu3Ig2rfkSjmLJwwEYEruL5NO_JnvJiZiynpydGX91IWAI1qlXZeFUT4qH1zB5ElpqbhxedB33cmBij_1snlRX0tH7NPKNbVyTea2fIa-6K_JbZIMrgsNeYsVFzMlQpBlBWZO7AZyMqbK8mg3adrpCI_BpX2L772fCL4MEORiPHXBfTT8706I9x5hPnl4JZHW0FeVr-liNXdwTT1vgbRdVNM6KNJg8cGOP4GBXEEtYV5GDqcDe-JIAM3lCBiL8LtYRyjRKo1mHJBRY7hxTdMhRW4kwj05n17NQeNaTSpypy_IFQ4Z0pl3-yKfJ3fPgD97czjpbGpOgI0OIo9p76HUYdyfi4Z-Q5fqPlnq7j_T5TOhUupe4-jkdy3bkGiGG2vi9GIqqgMjrU8BV5PSdKd_0DySTt3KD5q6WnHEFHoiDep8OTrX3U1iSdmmMJLCN-LSR64jIJ3eXSC9xouqoU4MxJEmKn_M_QlcXJk9_wBYgSIvBcdnnVQyXDmIUsVtDd8gJ6vQk7N6YBXXxyvngyeMmAURZo0hEXOt1bzHUCcdpi5T0cVwXtGQuX9mgKB9ak3g6P1_ne0tM3240LMXAqoahX00ih2Ia9cSk2VELwCZL8Xq_P4zRaOgDQkyiUkHOoERgLlEFXUDwlrf8VdtlNducz0KNoV8IAcUTCRU3cqClmrsYpPbX7NKUJUsq4nu84Vl7FmFeEyf5SMpXdBD1d90B0KghuSc5plSp2XQnm_K0DCfe098wo5V_t3nlVfex0VmYzlFgIFFTvp7GcLUwdv7ZtMmOPJgFXbTWfQXc2MZIBRBzW1r-YH2nwjbJH_FW9j4AwwiruwMVzW5xdLFnHZSD_WV5NXkwfSFJf-RkpWX70jxYXN36a-tWzivqhTxfHYwx4sWmDpCmZjlrHrQb9jL6Ye4KLelPaNfxi9q2AuV7GAxKKpIMVlOu4_i97_sUYP3iMU6NFLdtnCpuK7FL-Tk4F1M21_20h4gHQSYMinsNprS7QayJI9AzrMZVz_reVkZcrXgZCxB0cL0NtlQqvLEE6Wt-RpB-dw4lR6uxIk0D4k3d83bF2KR_rACMLda0YbJ29DY7WmZiQEIGW8xlzch0IZzM06EpeMlyDlANDvxkHPEWed7L1-DDLY9AgGiHBG8-1gwYTLuC-MCmfuc7yNlKY-j_EHYx2ocGgh7dJvnN6zQgy63ZXucp1HQ7zYH326iRP7lWBjJ0F9mJppVKeFz0AjAbxpUf3PMbFtYvg-v_-hWEdcaiPxOtmDRunWQW03El5rmzgyf8mJStjJMtzhRBfF9hD92WsvG7we4_FdIxQLcb7OkHMdzSTvbb_TZcwDZNXB5UgVblHRNRQEd_6wNOiXRRhNP3x1bvxy_ieWCzstEenKjqXXcJLb9tDSd_zDmQjRnbcmKBlNmICn_REbgVXq_WjJkprakLvYIv9C3x9MiYZy1BYukH-YaciXD6WaAk_5kdxWglLXfIsp6jUWlypSu-owEJjmWhuT942h4pu-6ibnlYBMF4O7AwvHhPe39wz8gKpiFH_JciZOxkZqIFYuavY54usFs1kBm6gbhHy_jvz4oGwmR3IqYhkNOqmDkLwjptWLvvoS2M5z9j6Z6NqLUjDTN3NZU-MzDp5cYRCapsGMFEfOSOWqrSCYa0TP2ylvToCJ_0XVJcso8CY8GiCTqc2uYhbs4WFBLlCigPlGLLOBXX7a5GO5P_Qpk_JuhOwm-dpTrz0E4L-mrFxn1H4BfEBUNg3xDXrFq2M2y5DL2F5G5ahr3oqCqhCIO59UDmrx0iZvZ6khk-Qyi4QrniJeSt7VxYfI8VHtrklSNmyDUp9_5B4t0l7X7UfEKIONhKCcTCAD1TMJ1Ka1jf1MPfqoNPqytHbVaqX4l8Vj9vf3-pCGr0LZoPsi86UgPx6V6xoRFDjAcNJfaCuioRe3GFruJq8V1ptHpgN_ZDv1_yaYItnS8vTQOY7mXtqYz_rTu-7Ii3tjKyk4fEHd-ikd6l58p3hMKPVPevzb7m1AseLdGmYs9yEF3GU2bFl1tAOuP6QOnqvAG9al6VykO8I2-Hl3N7JnTDb-PluXvtLhdtCslVnCr8fpn2t7AfODPgKEtomcl86byUC4RTboIJ1smi-4c74fYHj4FHkO8GhN5d-VmEJEX-jS5x02Q;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWRWi2XjoEEMYQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=A4B8476550DEAF6C39EBD0509C037189; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmgj2p9ykjE66xKC6iJbz8cfIHfVXGWkqWgwD8884yYqOMVSsWiQaEc9Kz7mzzDJkQobzUMz05dVTaFdvrsCchBKPXYxDGVIgD_s5XZ3EbvqVPs788Ivd3GWpprNpopzo0w6HjV8ITZC3ks9FhaJhUPbCUhJeuUVVEZ_mSk2f6pIEM5Gm1FiHsFX7mQ2ILTsQ3GjQ56vsBmorV_JKzkU3g0EasZ9nPQ1smVpCLRECrFIo4IO7susJ4lsMDApZoBEGC6zmCR3GkYci0fWtt7kAvHaqK8C0NuzGbFQKdMLvgVAISs3XMAxOHdLeZ9zakqVvJOEixUv3kqqLFg2tiKyZq6An_bdDIdzbMOwzAjLgjDVaER1Ry0UJuQuPMK8cTH9NPdKVIDHhTjbjVPPhUear9IvaxyNMAXBfZQggyfmOjopAML4z-PuC1h1s66TR_86JH63FlokhfYpVGGFNa5t_4skkjiUfNQ6kIzpxYsDQm2wS3kTnPA94ClIKgqx1Az-m3IMDt10OUpx5S2gJ1K2M2AHHI-1xs-Ud-omC86N7Z_VKHuHtgzggxsp431nF4Jl1FKIqk62AA07zepIjUkXEIpw5mUTK-1NTBU4tUrgJqzlyyBlpHRimirihZidXqMRvU;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWRZhadjoEEM8Q=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmWJYyzldLVpM4fI7g-16uqUdHOcZVUeouFGdEvmVoTTpXhPpv6Trh8-ZeljlGHt0sOnHCOGoh25YTRO1cfvlGHCxoFDPWKESOEpNCQGO0mKTUrSllaYddgbxuvEkQNAmJB0YcSMl_oNblpJJXMItyfdcAjboLcN4RUgsNF-ekWOnwM2tWvsOqX4_MjwGAJIv-7gQHPEj5xgqQrH2xq7VhdhlIiHE9trqu_MRkSZKfZJRo_AydcxWNgxqFOwdyXyyhehsCe4fTiztmyYrFtVhV5SwmU-LOpcyV_HKDwH9zL6CBu4L_v0H6LQwfgOmLkR1Z2hjgSEYOdGAp_Q6_DwOdF3RWOV0GbcGcc-q25c1ImNDS86xz7Lxvj6-PJpxJUC5pfMg_cX5vJonjFPky1tmL6Wh9XMslIk6xo35oBT1Z4MZ7w0dTT-tkX2SEDDH2mq8w_MJSogiAwt89_r7W8yo731AZ5l0WIbRwZtP4h7rOmyuLnAu_MDArlJfqSKMi9R704pVT5aX14OeKXg-VCEV2RV_-FLbxdvHFsOH0ateyYbBjGXWxsdlcNygwmwQA57a4LfDxeIWsL0NsU3Uo85wlr159jJn5ppq8oi3juFzndj2EDKHQqWvSHpbXaIkC3M-E8e8CRC8r3RCEj8_05wcXjaedpOHZCBgYrut7DLqecoA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btWRdiGEDoEEM0g=
     status:

--- a/tests/api/cassettes/test_device_state_attributes.yaml
+++ b/tests/api/cassettes/test_device_state_attributes.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmY4PuZ-DiOaFlbMwLlDFvV0mI6fa0v3VxIWckVTx-mONfrAeA3DYKjFWNJbFtpIrzK5Y-Rn__AA_TS56QDa827sLHh8SHmtJb30i5C8ZOdSqleBeOoBifucaFpJxAVskz7zCX5yAVFqoRa4IUklG_dBCjdIosPOvQX7KoyEsQ_MZMoEwA7b_ki32MSSNn_oVSV9GoENWWVmtrIWRYuV7EC-SqzZOQpxI7uDMuUMluAHF-J9jg332H9mdzvUkkAHPE=N;
-        expires=Sun, 12 Apr 2026 13:16:42 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.nTqKdpcxrsN_2Q5bIZ3RDHDfq2AQqWzwWnmL5AS4z9A=N; expires=Sun,
-        12 Apr 2026 13:16:42 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSknhzZjoEEJyg=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=289a51f5-6981-4054-a872-1ba4d2b53628; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115957027817842.ZDRmZWY5NTUtZDUyOS00OWNkLWJiOTktYWQ5YWYwNTEwNjFhM2U4ZTNmMWItMzc1Mi00YjM4LTljODYtMDM0Y2M0MGNkYmUx;
-        Expires=Sun, 12-Apr-2026 13:06:42 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115957027817842.ZDRmZWY5NTUtZDUyOS00OWNkLWJiOTktYWQ5YWYwNTEwNjFhM2U4ZTNmMWItMzc1Mi00YjM4LTljODYtMDM0Y2M0MGNkYmUx;
-        Expires=Sun, 12-Apr-2026 13:06:42 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=G9RxhSCwZXi26Dj6kwyri5zbnOCWn7TJcpzMyoKiuHo&amp;code_challenge_method=S256&amp;nonce=639115957027817842.ZDRmZWY5NTUtZDUyOS00OWNkLWJiOTktYWQ5YWYwNTEwNjFhM2U4ZTNmMWItMzc1Mi00YjM4LTljODYtMDM0Y2M0MGNkYmUx&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmWCERHxZRGC-PMXFZW3YUqz5w2LXuUaGai-VpdXF7VBlUKe3X4IoX76DSBXd9A-sbF-oaxZ0rlFfkXKgnlowsvjfjFxAq_HBVyZd1IbyPGwwuQki8MTxyUOUGeZ1gYocE4CgQTLvXpU73J8sIgVcbfc4_-vpRB2xJCeBG1VHd4YoH2wO9KLPH2dOggjFxFw6ISGcEWKYsGtVpCMTUxmKFA--UV0EImtjSyhbcT2jD5JZQPGCw9hakck8aO5tzXOgVICJDEMrLdQxTpmKV4dzT02-UeKQYDt11FP14WGR64l9aUkmjFxGaNx3iWwSHcW_2SY9olV1-6lnJqVxVxnZE0sNrIpyI-FTRDjnQCNkrb585kgS7RSvhCVW3KEbnEJz7ANhSf0cwWA8HywriA718vcN_jAxhHmRD5mvLF6WalrbnEo9dwi5dY9niwPUnCHVJ6y4HQj3ccjqEiCivaVblsDg7m59spcW7Svvbwi5EbCN7Eqci7SN4xqKshs6vQxhN13bWzukk4tHuUgpdQF6i2XvNcZNbs2iStr5_BLHRzQs1VAf7igvXfZmCgVXTkAsJNF68QpSmh7Nr_wADbtHDHoLCyCdw6ALTt_uoQ_LbJOEjlc3AlrCABRLF5jAJLN7kBVD19EIxxKM2D4Wlv8xwH\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"289a51f5-6981-4054-a872-1ba4d2b53628\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-2edb9a4f8383\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=G9RxhSCwZXi26Dj6kwyri5zbnOCWn7TJcpzMyoKiuHo&amp;code_challenge_method=S256&amp;nonce=639115957027817842.ZDRmZWY5NTUtZDUyOS00OWNkLWJiOTktYWQ5YWYwNTEwNjFhM2U4ZTNmMWItMzc1Mi00YjM4LTljODYtMDM0Y2M0MGNkYmUx&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmWCERHxZRGC-PMXFZW3YUqz5w2LXuUaGai-VpdXF7VBlUKe3X4IoX76DSBXd9A-sbF-oaxZ0rlFfkXKgnlowsvjfjFxAq_HBVyZd1IbyPGwwuQki8MTxyUOUGeZ1gYocE4CgQTLvXpU73J8sIgVcbfc4_-vpRB2xJCeBG1VHd4YoH2wO9KLPH2dOggjFxFw6ISGcEWKYsGtVpCMTUxmKFA--UV0EImtjSyhbcT2jD5JZQPGCw9hakck8aO5tzXOgVICJDEMrLdQxTpmKV4dzT02-UeKQYDt11FP14WGR64l9aUkmjFxGaNx3iWwSHcW_2SY9olV1-6lnJqVxVxnZE0sNrIpyI-FTRDjnQCNkrb585kgS7RSvhCVW3KEbnEJz7ANhSf0cwWA8HywriA718vcN_jAxhHmRD5mvLF6WalrbnEo9dwi5dY9niwPUnCHVJ6y4HQj3ccjqEiCivaVblsDg7m59spcW7Svvbwi5EbCN7Eqci7SN4xqKshs6vQxhN13bWzukk4tHuUgpdQF6i2XvNcZNbs2iStr5_BLHRzQs1VAf7igvXfZmCgVXTkAsJNF68QpSmh7Nr_wADbtHDHoLCyCdw6ALTt_uoQ_LbJOEjlc3AlrCABRLF5jAJLN7kBVD19EIxxKM2D4Wlv8xwH\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"289a51f5-6981-4054-a872-1ba4d2b53628\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-2edb9a4f8383\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=1b41e0a1-8009-4444-920c-5a4138188aea; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/6lYyoytmK2ohOFdr0rYpJK4VMYOi8hBzwuc6huzUqv2izFOhh4Am6KqFj/KGR47oc+JofiAW2Pt/7/mjGACfxk9GIFbCaHRVPM6O6MCopVP1Lc/+P1OKQs3hSJhSkbFGDumf8pZ/2ZM+28sJel78kcLcWdpWdZQn3jCoPo5FzaYPzR8xdeprpHxC1unDfQlfUsxMrdYallOJuL/+4XY61KCvp6YLPTXtoM/FTtOu+TZThKOLuASYkFdQrdLBEEZ/Ho0ZF8xFLJTPzuBeqRb1CvTrVLPKDsm3hEB5sJAqBxxUZ8VfdMbiAAAA.H4sIAAAAAAAAAAEgAN//6t9Iwt8REZXqrOZ/q1DDlxy9fnfbdfSmIf4KQovuEGCGG9PCIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:01:43 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.nTqKdpcxrsN_2Q5bIZ3RDHDfq2AQqWzwWnmL5AS4z9A=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmY4PuZ-DiOaFlbMwLlDFvV0mI6fa0v3VxIWckVTx-mONfrAeA3DYKjFWNJbFtpIrzK5Y-Rn__AA_TS56QDa827sLHh8SHmtJb30i5C8ZOdSqleBeOoBifucaFpJxAVskz7zCX5yAVFqoRa4IUklG_dBCjdIosPOvQX7KoyEsQ_MZMoEwA7b_ki32MSSNn_oVSV9GoENWWVmtrIWRYuV7EC-SqzZOQpxI7uDMuUMluAHF-J9jg332H9mdzvUkkAHPE=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmgM5xeFC13CNtZrlrseFAfW-TulB_dBBT0QFLV2NpZgwg-oKngnxc-onFFANJ-CVnY7_kNGwZTj-42nevdW5GUP2CUxbTzK06B7cTOPiy0ejpS48ntLmIOGiZOt22XvXsTFozZc40MbHqnno90cmWx4IQRkeT3iqQIk0xZbOqe27Oc9NAQmu8jO0oMBZ6OXWUKyBKxoH5yAQo4EEKCpdwkq_pedMtAVCdIzSlgSGThdYxbRwxGN0B1lfGZNg83LImnl_8LZRTHjEwuIaIS953vFaRQGh9dSQSDJ4PDhs5trV3iFS_s9xIThypS3pT4U0rgOj48Ou7mGP7nKRqhDWhf3PtTDLukayHn2u-eSq8oy0p66ifRIEuiDt4_ENu6_Ff8VXoFI8U66hPRIPRU5WfFNRe4xGe9xz_8WR51XX1CN09MaieO78i_ogWASRfR8VxOfK44Fnbl2stGO13OjXBpcimgdN9Nzb_Ng4EV1OjFM-D8F-WJ8taGj5X8VN0cNQjONE1gJyKVrSPEmBmFjKfJZj-zG3LZHOFpc9-ktOVsQ5Hp_PTaw41443uO3iXKi7loqjmuKVS56H4Ie6vNeYEAEhDJ5lwIau3aC1Iqbrq44KIhb8EAv4XzhBF4W4PxA9dxh8y1WprZwQcr7vNaspiHluJkEX78p7Y8a9J4NypiJJ0C5nhTLz98mSFAdxsCvanJ1-gkO9vgOOI9bzm2Cz79Yhu0dznQlwNZNkR06DWbwuiaQZOKQdpga6CMgytWRDm-KBWgsxfV24ln_vd2UQaWe7MdPXTF2Z_ZjjzEhZHjIkxcbIDn6fwrc0DNbDf26nxcttelggzMBwHM46JVAsM1yCLI9-AVvm2L-ZMBMwnMJp91PBW09ASFGPHaDDbBeFiEu078OX4q_vYDUVTY-GeAhnZQ8ClZVvFCfG6n6GtAfjCZWc1sTw9g78M1-HCTOFRfGZ3IyWIlJkH_PFPkjcK3tG1bxJT42Tnx7TE5OP3sABbaahcbb3SppOqc7vuIkILsVNOfalRxyrrWbcQfMpiC3fwKHP9rercsIBKrxJDLZcGprGOVURErMxk9Dv3BfXnmHxjrIXOpUwDaQ-O11B_qleqAtd9VJHck2NSyOeYexpzEpwTDO-I6To-Rc-2pGbeLsnQ3n0DhVUh-bXuKnXTg3fG22HBIzQN868Bc5fMVylX2u2Js0XSMllFiyBD8rP3stsg9TcIKSoSSVeNZydUXn0rG01J_2TkjmCtrrupMnigGYW4XzxfBXT6HPt1F3gnoDIxxPGN8XQ3UWGKF95StuOle-BSgBP_kOJiNJ4LgdQrDwYnWharDGJ3hiRNOTiKkxasM_KCIgbcC2O24_ILrwfwqY4w_zdJTo05m8p9oFQ8h6YGA696JqT7uVIY2nvoh0a44qEwsR2gmPAOkfawkKsJ4DyDmfdumi-Gbxw1FY75Xm9XB7WRHo_YmlxpUKdNEFWJfBrBhpWHukBQc0pGHPW2ramGYm9fISQNVdWkyp20Qe3NSEuo9HdejRHDkewBRqSY-iV_CDm7_Pqiu5ok6Hvibe__hP9PWxowtjyYMcCxOIzQwztjB_7AFB1SPwOa7Nm1afsIisEr9m4L6bVj35bxjmEhcKAxuM5c9Udf-KtoMTjFXrKsam2nsbh7IyLHn3uMSEXDNaac46gAXjhGmg0XZpvUQwBYGOA45juBVXCJYUCJQtAgVBfj7ftJno8l83Hi_zRW3611SF-aypJwyx9tG9aV9dXKynLX5L_rHX2Mw67yg7c4VbIC--HQ5w_iQuDCSG_wxrzbp38wfM4cEFwkZhKfKyMY6bA8_d5YiYEa5nkVOVGr36o24FV5TOF8tnmHQS4H3BdttsBMhE8XodQa31rO6JXPXGWzCdzByQqU76vj79B20QB0teW0gZneNu_-1YBxa_MjtQSKbhERGIBWS90Vlr8p3xewPn0kw6PYZ092JlgPU3oHpdaAlEw-aRkIZcFvffHbcB5AIWY8FdcumzdQhs79hhZM8_ZcjGBPhChFpokLDQFNlmja3lmMLioEtMzuPUK5EKIrwqIAHWmM1rp7p5JX4IMen83zqf_Zw5sZ8aVTjN-zJH9e-qtUycWEToknu6AbSyX98n6Dq-KiyWUJLuKdhbHxXBYdR2DOWGHkuTOZuOIN7apGpNjp6ODETQO6LnwQ4-ywOQVW3HtT5Zy7s4b5JYjF4NWj1_xk6-1YwJ5WwhoJ6Qn5MAv4F8bXRMk7Jb4JJK-IukNajXNpqexL3PHG1SHnrbLT2PikrX1ok4hl-EuZfIOXFsIugpEhakP-ZX2FMT3CL01xia5p4HVn1J9NPqsR3fd8XZh2DBGRzkBaGu7m8bGLyMPP-pnPfexLLUyae_mxkaQR0YNnIZ6tu_ilDqoN3NeN4KaSJD4b0Lyb6-2CBo4eJrNk-w8JC7aJZtce172tg8RiYJz0cGD6riocYMrYLGSSoWg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSkwj8njoEEJJw=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=21C0A438294FB6E76B33B39B06252607; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlnRHzzr14a2o1aXdmsPnBxo15ZoZ7iFK6Xz3QSXPgo_KE1q6zFRCZOfPFTj1kugQZbur6LkRf3Ptu6atzxYhAGht2KsozCceJM6OtX08OUT38kDlpo2U-kWku6066lU57UtewhI_cc1jMMFVMw8sGlCirSmmoRJFHMSnXO2RfcaXbdgAysoIZ5p3GfveEAop2IoWbLmg0ZCWSIs0xnwOS8cNQjW44DZqs6JFh93t-u-hAWGXrLrQb_mdhlIkxxt5DnqCJV6QzOOLTj0AMkSVEHvFrT4BegFv6f2lduOp4yfytxwhfITDqhr9cr24ZKALwwQiiomVlBHvQnzc9xNZo-Beho1y0DsIveWTOHPkii2WnPCXWZ5OgEVKOeJAYrtonlP_VDPf6V7VaaS2EQ_PrazB6cnLtY0-kc6s6t54mWuUTdeyrQpc6dWWu-V-9HQj4ZhB0fqzVmw_AnraHvSazEnUgHHHRIkD4IZG0RfBHdwdt3shup-dRHGslq0mZPZFhzpLP2aLK2VqI7Z5dgpk6QuQIacc8Wx1CjKRxxNvWDAcc4iXMCYPrj6kLS0gQihYr2PaLMh6xl732uBiRuk8dfRT6zOnN7A9zEFTi-X3Ueu98b2cPLI-MUVSdBzfFNeNM;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSkzgwzDoEEJMg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkfu71gp0AF7bzlkZMRqwHqsr1K6ENTlTQUYLBVn0rlsoncFkeaKSCNNR0XAA4IT2nKV_0FZRUK4VuEW8-_rKh3_Kam6je9fMCWEyGAQVYa4lThLAe0OT-UooV9BjiBdpjuWFmqB2R1GjSvvf_yLmivK4Nr_OZNxwn9_6PA--OxcrTb1-PftK2lIqOfiYEWP464lbiNP8jcJh7Cbf_hRG0zq0M70I_r7Zu0X8wcHV2x62ij-TKarTdhRCvIvx1uhGV6EHp8P-_uiUIS-6cA1RFoWpIdEAhAs0mBAxOsRsqx2rSvKMTdyyAMoy129T7HfGzvAe7ttFlmWYfLWroMLBvgvZlpopkJ8G4ArcDK8WXcsTLZDo1CBEwJjxjdvTPcDgqrhf6MEcMSeTXdKjMJsqDhPtKEOK6AnbDnAGazPVdV8BmUebUIs5J5laC08aDv3SIULHiKwl6w9R34uGptXHFkDIO_5YWGCfexD9HG8kiOtjn6g02Xy1tl6ISQ-YQV4zBuHisd6vzRwCmwzoLmvoQYLbtyk0f7yhtrDcMfreQ59t7vycBEHOwfKJ12w9c9_c0PDK4kf5S-apcKKdYATHZK6NITJvfjrf1UpfuWhMmvGIOmfR9qWTp8OjuRDMeyehsiTm0f6eecSDrlG4icY_TLaoQ4gkVvx7pWa85Li6Xbrw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSk0h03joEEJ8g=
     status:

--- a/tests/api/cassettes/test_get_atw_device_from_guest_building.yaml
+++ b/tests/api/cassettes/test_get_atw_device_from_guest_building.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtml7Yoa8XMqaQ6iKxF9j-BOXa-SIORtcSBw9sV_Y9CicQBKl4AQkm71RvS8iDvYOahvSxANtHtJqe1H1wtnMjP79Tw6TNds8G2lEkCkqYbhc_-OlZ6C478oSI8IMq8-kznYgWQ6lJj649INuynKd2_SXfFiHIApsjsYSJpbeesDTNQxjWhw35VMezY19V4TEDTg5-_Be288d-3zMrH6LdsDELAtebKmWQ01a2O0pPNRF6fkogZBMFDtq2n52O-A99g=N;
-        expires=Sun, 12 Apr 2026 13:37:55 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.xkPTRUVz_G8CPmvw4qd-9GhScx-x3e8Xcy-IJiJasfg=N; expires=Sun,
-        12 Apr 2026 13:37:55 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVrcjp0joEEPoQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=53b6ef99-15df-4bd1-901a-1baed458a27b; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115969752990127.YzE3NWE5NTctODBiYS00OGZhLTk2N2YtMWY4ZTYxZGZlOTlhZWVjNmQ0ODItNDQ2ZS00YWExLWFlZjQtZmU4ZDYwMzJkODJm;
-        Expires=Sun, 12-Apr-2026 13:27:55 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115969752990127.YzE3NWE5NTctODBiYS00OGZhLTk2N2YtMWY4ZTYxZGZlOTlhZWVjNmQ0ODItNDQ2ZS00YWExLWFlZjQtZmU4ZDYwMzJkODJm;
-        Expires=Sun, 12-Apr-2026 13:27:55 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=DoQqyCsk9yWwI3vwdDNKJ722-t4PaN9ywy6NbAL2_98&amp;code_challenge_method=S256&amp;nonce=639115969752990127.YzE3NWE5NTctODBiYS00OGZhLTk2N2YtMWY4ZTYxZGZlOTlhZWVjNmQ0ODItNDQ2ZS00YWExLWFlZjQtZmU4ZDYwMzJkODJm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkolZPNgpp2Z5MLYXPzi92Uv06e66iZEAHz4suX2c7Isu1bkpgypq1l9SyXejlrMKcGcXpl9fCSu47T-JI0UZGzrMWp0jLbbSxfYE1GnuUrn1aWLebxsEoSERqdvSDkQYsPyceGRz4aKJnT3YZ1xPeY4m_wf6mp2QQcxIm62vaM7RPDrvqKbfeRqVF9mf7e_16vIOCfAKakYnqyZWuGEogTrGGURHLxBXT5jpCstdshCHaej74XYxOnAR-9_0Xso7gKy9HG1p-u0qBonfJNfxbuRFQpwUAxKp_S4T8TwkrEvVbNEmrhjp2C08mWO5QidJWhAMfKXFj-ZO4MjA5vPDpddGfim28oODMEjLhUyV-UhKN2yqTvGVuiF-m94AAsx_fc0LSpmtfS73pHTpVm0RwYjCgnqM3DVrSxHcial6iUZCcE-KEx0owIFU_4bUTuiqLPbeAXfnW_Kmntkl-wk-oV0hQElgBNNFM03Ob0s_IquVofROLYDSqwX8T4fPeb-sKl-UW4tWpbWmZj9577P6anjCBK6arpqiRR-eFWibmbj4apBCnD1cSWcHICqXS6hrd0D7GbT4NucHxhwWYcncxpoPMk3LoC_vNb7rNHhg1QH5dCgQu0l4jrIti_LBjneugQ6XBNI0qEzXg9fKzZX8zx\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"53b6ef99-15df-4bd1-901a-1baed458a27b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-94308e04e270\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=DoQqyCsk9yWwI3vwdDNKJ722-t4PaN9ywy6NbAL2_98&amp;code_challenge_method=S256&amp;nonce=639115969752990127.YzE3NWE5NTctODBiYS00OGZhLTk2N2YtMWY4ZTYxZGZlOTlhZWVjNmQ0ODItNDQ2ZS00YWExLWFlZjQtZmU4ZDYwMzJkODJm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkolZPNgpp2Z5MLYXPzi92Uv06e66iZEAHz4suX2c7Isu1bkpgypq1l9SyXejlrMKcGcXpl9fCSu47T-JI0UZGzrMWp0jLbbSxfYE1GnuUrn1aWLebxsEoSERqdvSDkQYsPyceGRz4aKJnT3YZ1xPeY4m_wf6mp2QQcxIm62vaM7RPDrvqKbfeRqVF9mf7e_16vIOCfAKakYnqyZWuGEogTrGGURHLxBXT5jpCstdshCHaej74XYxOnAR-9_0Xso7gKy9HG1p-u0qBonfJNfxbuRFQpwUAxKp_S4T8TwkrEvVbNEmrhjp2C08mWO5QidJWhAMfKXFj-ZO4MjA5vPDpddGfim28oODMEjLhUyV-UhKN2yqTvGVuiF-m94AAsx_fc0LSpmtfS73pHTpVm0RwYjCgnqM3DVrSxHcial6iUZCcE-KEx0owIFU_4bUTuiqLPbeAXfnW_Kmntkl-wk-oV0hQElgBNNFM03Ob0s_IquVofROLYDSqwX8T4fPeb-sKl-UW4tWpbWmZj9577P6anjCBK6arpqiRR-eFWibmbj4apBCnD1cSWcHICqXS6hrd0D7GbT4NucHxhwWYcncxpoPMk3LoC_vNb7rNHhg1QH5dCgQu0l4jrIti_LBjneugQ6XBNI0qEzXg9fKzZX8zx\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"53b6ef99-15df-4bd1-901a-1baed458a27b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-94308e04e270\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=09a876a2-50fb-418a-a845-b2c4c75e2c9e; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/auCH35Paa/+aElglhxxp85tGOHUopNfxqGXTXlLV393Iy983KN2JuUaQP6etiT6TCkOUMyJyIBSrx37X9Fo21ChNwxsTo9uTcsR8LHbu0+tt4jVwHHYepNJiI/D8csO0ZwrCxpCPGCVGMC8dY76CUUyuVDbH8ySaMIH2Y+5zmJaEH3/5i+IB9aDRstk6KKUvedyV+U27MmBhkEiXPXaRj0UUI+MsW4r2YBjwjTfT6IoxN121CC77oHPWu+uDHZM4e6JbJGe3EjZhB6Spr8hvAFuojw6qb9Z6vtz6Wylok881snTy6SjiAAAA.H4sIAAAAAAAAAAEgAN//UP5AVQoa4cNeI2awzY4SqAbpwBTou5d9qNgMyKlaZqN6bZRVIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:22:56 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.xkPTRUVz_G8CPmvw4qd-9GhScx-x3e8Xcy-IJiJasfg=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtml7Yoa8XMqaQ6iKxF9j-BOXa-SIORtcSBw9sV_Y9CicQBKl4AQkm71RvS8iDvYOahvSxANtHtJqe1H1wtnMjP79Tw6TNds8G2lEkCkqYbhc_-OlZ6C478oSI8IMq8-kznYgWQ6lJj649INuynKd2_SXfFiHIApsjsYSJpbeesDTNQxjWhw35VMezY19V4TEDTg5-_Be288d-3zMrH6LdsDELAtebKmWQ01a2O0pPNRF6fkogZBMFDtq2n52O-A99g=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtk2w9qElOcRnFW37HLf6o8x838ulL4V4waVqnXHV3pNS7_I22cI2Pmqq4uRxzpfXp-ayv2D7XlWHeBYz6NHV-Te_FptbAO-a1gRmxXsHDMS8VDTtj7od1if57vhe2epb9PRv47YdNgdztt0w3xQvNYeNKq9Ox1G-AI1LxXhSBJ12X2VeOv9zmWgGdWb4m64tTWIOCGGsh896K0u0oGNRkWjaQ6L4T2ZTsgedYbXj02-aJweyQD3LXVhUHU3qvZEO4UDik5Effxj-nVHmoAUhRO1ExbmY7SEmYLOVJlSwz2EqNHF4dhj35Q00cqOGpHG6NccA2UxfFFfhZbr7jFIStcUxOMjaSfFmSsV_Dwy3La8QGEG1XTki6JmTeL_kWWVohAq1BalbPRr_pw9G8l7sifzwAtjWuj6_2afPya2zz_1gkQ80elWpfz1PaAXODCx_r7uv6QTLDGE88X5F2wsu8Er2n_a8rWV143hASjxr3DhtbcFGcCsDJuX38a4aX2stYN3uJCfyBe-wP5B-lNQs4a92pAYb9tZ_38031oM-HhcEmRWvKlmzFbA94FG2qKrY6YGlwkTr7i7r6hz1_o-zELUPftpxSMUtidJ0tYIVAk5LmTSfNluhwi3yO0FpNaV1z7O1oPGT4kLw0f9pnH6erhwlH7-dDjKijmXmJ_T2vrJrbCstFqUxsXBBuD-Y0J5K-jUicNes0bv89mnOWnBjKgfe09IOBAEe48mfd1ujFoN4gWmgBwHb7IDpMiyj4u1ySFGw9Ap7T8bosIq1WTRt49kANeCzK8qjloJFABiND_l5k7Y-En1GKDraDUXd15sAqWwh2itxgSm4xeBBxNM-8uOr_8Saye8ExTcQ-C_eET77gO4ARAdSdfPYcvFYm3utKjmvTC-A5O0R0EJvlhvATcyMbxfMCaZNSBwHVziWX33sbqJI72_IL3pw2uoCW0e8IyvFurC3prBKjN4-LpB_fSyuGVnfvSjF3gi_vCr_rdnqrxYwywzjwwlOXZMBxUJKZMI8s5fzU2QLdRwlqNHu1auxuGRDzuy3qsoCSfhiBYdqYrivKP68wl6WubHjdJ_giEFYZ_B4WDmZmkkBDx8LXsZ9P3CC9bnuE5lwfHyY_ne8JcxO8WJkkE5jOTPCe00WZrALQkF8dNTxmT-1oU4JwddMgZXXduxD7ynh2eosqKDGyPthvShnqVeEDBn1F3WLhCfU2BGRFnzz3qFv7uNzCGfz_R8tmt9s4-Mxsn-d-UUyTZwCegA4OrIF7RBSqHa8NKOtcCFjY0EflnYjT6SUghkqHQ4TyGNho8smDNzXfKSyP0VJQ9VDSbLJffcVqaaLY3flLAJjShPowbRrZNheX8tqwup7tatbov4WiiQaxB39DP8818-IlaJNvSrxoHzJ0hB79D4LujRCHwX_NxRXIF26Qmh6UI9bVZ9xrfCYC2qbbkRmloiR9DsjLh6-J1QbbUcE6tixyylPiw3HMjNUJ3LTNYzL99nqKJ6INmqK19TDTtTZvomP0da_hF9R2bEcbSm3Y3Kjn6lGv8F_gq2KNPjyzYlRUnetXFpu2mzMXyMtyoSDbd-ltwlcsoyZYSNiDbkkiATt9zrLKgCYJjyxbLqoANTyxUZed8AbT1YOakThtIFhjTguD8URFYkN8BdD_iijuikIF7qz2GtKL0pSJVoYfWZ8RDvSCpMRHyCgj6MSVW6tn032cg1usxaztIxiwVdsnsV93Hh9WfrQCX6aSRcUsseFf5hZKqWciKThVkZoGielPs5BzvndnlSVyNyCXeSh_yNTWwyQwllj-QuyaejsgwX0Rn--zyFyjNFasl8lrq3P-pG87CGnz1GC8PYPINL_JTXwdtMsDRbDnMc59Sxn8TkJnedD8WwzGV70CA_rY6ECJZ72UlQduSXPhu8dS7tg6p-JD4RsGLnDYbislsRsaQvdq4I-OaBbcK6bhbkV4ZVq5-a8LvV_mXl5iubkFUSlCFMV-LRRNFbqw9n1JZ-GJwLyifL7LG897T74_aFJwo0M03qEiD9Wj5HGSwMq6FxsqqOMVg5lY2YWT1cQT401r5ptl6hehaLNNDv8l9McciqTZZivU_l9QikPi06nLLb0Vg-DkwVhc0CqhGHL63LnyelmhyOm0xhkymYIylK8yRELaHDl0oz_cANIYcBjpJC5bNIz_lQb5pIcPx3bZlklV2tFSvMmBObyNIJaqaO4goBh5xIfrUUl0JqknjmhvQLgUiTSweIhsuHCqOJ99ZgyCYLZKbzsQJUs3oE5N8eoYzD4P7Nj-7XzUsQQf0kJD-dq5sgxpvTfCB6jy0BiFW19KNEwKCa4vOYTxk-rM7nAjjR0JkrUDbLDMOSSowlDmYdJS9dSZlSHM5Nd4AI4Am6B0maNOYsXxY9zCsmJ5BU2CVTLy2hS2RwuzzBe0mSaRmlH4z--MZ064NS6LeH4u_Hcax8FDoqTM-b6UsFFZSH3Q;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVrnirNjoEEPZA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=8F80E777DA1EBBD5A699FAF6400790E5; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmUD522tyqY1Bs5cTsxVyJR8ZqVAqg4BCEtHlPfXSzblyLxFkFVIc5YOm4fpoJBIMnv0emuzDuLU8WHnB-9RIVHaiv48_9wdvG2usq8-znxoR0GYQpzBZaFPXZqTdi5cGY_tNQshGUOtXL1W0K3qiRaZ_mbseiuGwJL3nTWFr-vEW2p3Qf2J0Sgl6Y5nVZESU6lBeqOz51Ld2z9K2Vg7zgRHFgC0vnTAk52bDPUkNFXBRLy8zsdQ7yqyoUD_ryRxUKC2ZkkV7BYOrLyCNfqUDcYw2BQbPeRDZcvGeMNxcYsINkrfUU0RMMaRcw0pQk3IThutEv4tdjFhiv5QOa5ft3m2ywc2hG_LUdzCfs6Gd-sCxQhtiy693l6Xj3oA_kR7B3ze8XVq1DEbXksZhiscH_zrbcLWCOsbGl67Loq5MzQuYwIkjVn6eEITrGxiFBYqZrIG7nyYamPPi1diF-7XJgIM_YH8WBAE8THlPhIJyVD13HE4OCbeHg-_VC9xCcfT343hUN0MJwGBE_VQDcwoyrwhjvA23wfL0dih41KXo-h9ATDs-PovAiCbU-Nnf5D-yUdRg_JWtKPW8LfaZ3vyKnWXMQy19hZSiif_Q6pN8Dtr8sr4C4Y19MLs2EBSgYXPEY;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVrqi5wjoEEPQA=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnmqFh23lsEmkafQkjKPxLuiPGZo3UK2v6KPQXUndSOQYELZTh-VxjNPNvCbb4CTAGjdbMN2xpwDpqK6bz87_NIGgAqXWAbcpEUM48DjmBsRss_CznLQRH5DZANvcPG-zj00ptndV8Q9R3t6ZKS2R1TYAeHBEFtEEJNzEGAPbR1VVsNPBrSNO0Mo012DgprBZ-5irWZlAn9ZWLtnBjmRswad1ol4Or-kEt6FfO6W4Lk9vvg3cC4sWn45tix4hoZ5sltkgdJcuE0q2K92EX1ta374eMvPLJOULEu9utlxRHwJTsidpUieRxxtYoRPc2WDK2wHV7l1nnwHPGwBU5hCLhvJNAXc5aIGZahaxm1znIzspXgrwQBkESSTbBfZHtwjmyUSXgBYN7uUkxWZXx0HN1hg1LvPI-4p3hWAKCClfpbf6xdn41FoS_skNXmIJoXRFvC_0wYLykRENRC6onyPpLvYI-7wyl0OBE_IYYzieKjuiCa-bh79wMe4HZEMl81xNYU8irnQRd3MUB4Tn-Ch8Az70WzYr7pqZ2xfEKakJ-OK-7qadHjokKSpuFwlOyeWcDBFYQx4VF4nSlVpZjFFkrjMotU_-scKNuRplMidYmY55nsWRMXEtrbuM4xOqnjcbq3rUNEEsYkkPeZkW7jMTO-OhrHuSn6w69UfOkTB85ePQ;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVrshLaDoEEPVg=
     status:

--- a/tests/api/cassettes/test_get_device_by_id.yaml
+++ b/tests/api/cassettes/test_get_device_by_id.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmuDUZR9rO8KOyQQWIhGgvsh4-qWI-QJJE22f8me7LQKBBLeTKq5ighGJhcanNgZI4tSd8PoRMrBDP3wvPc5wdpxqcueuRcuewvbPGiz0yiJ3iLPSxxzL6oNGyOc-DpShPX3vHy66aZswebj1YwY_iUN0JhVJ5Wnjh7lqm2vwG2pu1lRGFTMTQWvtmGTPopKZ8JjiK4w-k6qtpUGJQmn_eO0WV_M61zQXi-pIyO8wRipAnun18w3Qfs53rpho2flQo=N;
-        expires=Sun, 12 Apr 2026 13:16:40 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.tAP3ari8giH3dxqWH8PlszbtqEI9CKYhgv4YzKKyrXE=N; expires=Sun,
-        12 Apr 2026 13:16:40 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSkRhrODoEEJyg=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=cafa56ee-bbe5-4e02-9526-6264c3d5015d; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115957005345018.OTBmOTcxNjMtOTE3MC00ZmUyLTlmYzktNjkzM2M3MzVjMTY2OGVkYWNjNTAtYzQzNy00YTcxLTlmNzctODk4OTU0NjY5MDVj;
-        Expires=Sun, 12-Apr-2026 13:06:40 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115957005345018.OTBmOTcxNjMtOTE3MC00ZmUyLTlmYzktNjkzM2M3MzVjMTY2OGVkYWNjNTAtYzQzNy00YTcxLTlmNzctODk4OTU0NjY5MDVj;
-        Expires=Sun, 12-Apr-2026 13:06:40 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=Fh39OqTmjoEcnBM5urxDJo1gmTQbU7PlqVPg_LZ0a5o&amp;code_challenge_method=S256&amp;nonce=639115957005345018.OTBmOTcxNjMtOTE3MC00ZmUyLTlmYzktNjkzM2M3MzVjMTY2OGVkYWNjNTAtYzQzNy00YTcxLTlmNzctODk4OTU0NjY5MDVj&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlCcMKyjxNZK0sKCmZSqHdli2u8tHADpre93KmrYapoB7JPQXDCt-AKxWxqB94jYYRDN_DtzSo5qLXhDHdbQ33QnvSa5gCQ5HrL7vOWlBk6hE56KRfuLeLrPeq-6sbu7SO4pd26KrZdBxplQn9mnr8sTbwukxbyfCSQS-XUg7i0wHgpQzqfCjQUXKrPS7mSbzbgDZvpLr9n4Rn3FUoMQutLjt_Rf7_sFZu8vinkp_clq5hcG7vTN6J9v8A1DeNJhOnn27eMH0GFp-1KBrhgSkOa_bMe2oSYQAHhlyOy5Xd-JEW-XcD5YkS1c3y0ioSU5MRPDUrymevnof2irqlZnYaZMhW5VJbJ79yJ2M8VBqG2CR5VjAINg5G-xsnfrMsLNTv5HoRDuF0Axmn6YZ8TSuq7M_oKYAt4nBC-VZ3QHA6E0tY-xDkzZ-lO-0cd_r6_SVIdr7v2gLSf_2U58aQaD74J4mAwPr-uZ2qIB7OuFFdZ2vvnoz0OKtOz5-zZgVF-JG3hBAWMQSzOo5FPZumBfKts5qmRoOK3nGDzBB_OKk1yFDxXTi5hxdz0fenX2cFZZbeMdBz3v8vo1lgdkgW1aqiY1iG0E0RMkPnSLwFLvyFeeCXX-7YeyI78x9OTSOoYr9NI-GO-ZWrzlUN54ylul1j-\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"cafa56ee-bbe5-4e02-9526-6264c3d5015d\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-1a9c83f4eb46\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=Fh39OqTmjoEcnBM5urxDJo1gmTQbU7PlqVPg_LZ0a5o&amp;code_challenge_method=S256&amp;nonce=639115957005345018.OTBmOTcxNjMtOTE3MC00ZmUyLTlmYzktNjkzM2M3MzVjMTY2OGVkYWNjNTAtYzQzNy00YTcxLTlmNzctODk4OTU0NjY5MDVj&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlCcMKyjxNZK0sKCmZSqHdli2u8tHADpre93KmrYapoB7JPQXDCt-AKxWxqB94jYYRDN_DtzSo5qLXhDHdbQ33QnvSa5gCQ5HrL7vOWlBk6hE56KRfuLeLrPeq-6sbu7SO4pd26KrZdBxplQn9mnr8sTbwukxbyfCSQS-XUg7i0wHgpQzqfCjQUXKrPS7mSbzbgDZvpLr9n4Rn3FUoMQutLjt_Rf7_sFZu8vinkp_clq5hcG7vTN6J9v8A1DeNJhOnn27eMH0GFp-1KBrhgSkOa_bMe2oSYQAHhlyOy5Xd-JEW-XcD5YkS1c3y0ioSU5MRPDUrymevnof2irqlZnYaZMhW5VJbJ79yJ2M8VBqG2CR5VjAINg5G-xsnfrMsLNTv5HoRDuF0Axmn6YZ8TSuq7M_oKYAt4nBC-VZ3QHA6E0tY-xDkzZ-lO-0cd_r6_SVIdr7v2gLSf_2U58aQaD74J4mAwPr-uZ2qIB7OuFFdZ2vvnoz0OKtOz5-zZgVF-JG3hBAWMQSzOo5FPZumBfKts5qmRoOK3nGDzBB_OKk1yFDxXTi5hxdz0fenX2cFZZbeMdBz3v8vo1lgdkgW1aqiY1iG0E0RMkPnSLwFLvyFeeCXX-7YeyI78x9OTSOoYr9NI-GO-ZWrzlUN54ylul1j-\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"cafa56ee-bbe5-4e02-9526-6264c3d5015d\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-1a9c83f4eb46\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=a98f50b6-c5f8-4ec3-8a6b-0fb70d2a7aa3; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/SrNMWPw/vrDYfzEVLvCP1OO/76+RH+ICe9b/Yi9+zpD6wnSphtnauksWE/jVicHQkDmkv7Avix+NGN1Mqzuh6cY23G3blfVzB61N7mmLcWUArRwhBz4uVDxA5wq6M6ccCP0zmy3qu1xt/ZSvyEg65BrvYuj+1F0ogyMY8bbv0IXHJwzxe9gR2zSkUgQBfbZzSTgykGAAqSMys+bnmC/Liuu23C7CLDaV6dvLRYvYQ9LzR0Fb1UeropbxmnY0hV5+W3hU19SLPgrPpOX0zC1cJoflAKIlOvrsICVa7dFOd+eYPDlmQ+jiAAAA.H4sIAAAAAAAAAAEgAN//ctW2gDv0XmylrSzkC8nkIplCshG599CupeyNPWtD6C7FoBbKIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:01:41 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.tAP3ari8giH3dxqWH8PlszbtqEI9CKYhgv4YzKKyrXE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmuDUZR9rO8KOyQQWIhGgvsh4-qWI-QJJE22f8me7LQKBBLeTKq5ighGJhcanNgZI4tSd8PoRMrBDP3wvPc5wdpxqcueuRcuewvbPGiz0yiJ3iLPSxxzL6oNGyOc-DpShPX3vHy66aZswebj1YwY_iUN0JhVJ5Wnjh7lqm2vwG2pu1lRGFTMTQWvtmGTPopKZ8JjiK4w-k6qtpUGJQmn_eO0WV_M61zQXi-pIyO8wRipAnun18w3Qfs53rpho2flQo=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmXVi7rrzeSl6GBxAQoTZFkyo8Olfe6ZNJwTyQm-HhUEmndffhjZ3GlHjACEBfqQn8RJHa1V_XUwFdN-y1FW2QRyNaxfxT6c2XxVHhbR5tyPcknGGtuE-XyEM7fiW93sjC8C79GX5l0cq6GHvJ9RryvyXRzRvJxCCitLABT2y0-Mk_NgJs8jdVt9zTnRAZVWIM8BKNlaDGTNmqsJXtJSqE-x5BsmWJ5-OZyR-JuGuFIb_n-zZewqY2_dUOkOsCtxf40YbUedLyx5Cp6YnGxTmlmbyV80WX6Cx2Y9PdoTRxdUlhbnvc_xYXhm7a10u7iTvHrAGGXuqp9Ua3DyQNu2Wq5vlwJer1baN_Xm_jeMo_YrGsyDLz4C7Gn0pTfC7Vo8GKeV7rAG7nC375oCIgy6eYpM7MPHwOgpzmlax8pr1xdh0Z3p2dPrj4qUMcaKajMHzwkngad9BkqXysBHiQnk2rwcviN7bl87mBAPLGlbIMuZFC1O-tXRqF8257EZ3iv0vSzH7J6jgeZ8Ekh9cwCYesB5oT2yzZSWHjE6ShtJJ_KfgNXyWKW-6zn3saGKReOihquliJ9TBx_7HypEXETB4tvyctnctXdOREWI_iTY8BCOGOsvFetjuI0BRwLk2qbn-KbjIl7ZugYxq3vcA_lKFxVoczTFI9wIrbzIj_dr_mvRHF8UUvD_uFsTiekGdZWzd8zCMrNJ6epVJ0nw1bMoEYhJUGOp3T0sUlMbKzC7o2QZNEtvvnPwjZAS3xnjkcW3pnClzQgAfDKpxqR3eKpZuZtXbjok-8itiVaNNb2_J9TARusli9xEHv71j28n7hxD9PnVFHO1oJh_cAAz6d2XUsXBt_c0-cL_5XpKpP59QERdNv94m_alwutjOmvIVwSUEAMsH1TqC-dbB2lDogN6yg-kb_-bnhxGDL5IfDy0Bw3Pt9Mxi-qWxgyQRp8tPiDqC9MuFNIZnpIpokB1ElzMHaPJVKvroydl6qZxQH7h6Pyo_UENl1q93xF1bn29PQA4QrVrK8Qyo6zy3vjeoaX1KMWRzcoWlYPor__3S5F6n2o-uzoPXv1Mf4sMAWXYNXTjMlbbh9yhTiBb-ggrYh3F8lUz_5UnYt_G1H_3VudqIWeqKfRrMdSOrx-6ktl4eeiIHymc6iG0EKFtMyrYpqGZNWaagjonpKOBM91eLInf3UOBFHXcGUlb2GeY5U2xMLTAlUlkddzPWDeJ8dFSDJsRqi8SVeKwJtJ-kt6C8psmstqFYl0dJ5UgQb5fX9xJzreO1jb850p3foOMgxCB79rXM4jM91-RifrE_YbwUHUdTa6B8WZrnjyjbNkoYPK5Y-OJxOkxlnotmxJVZ9Ck0_k2S7Jj0JoKZHgU-Ux3fCduoqaYZL-8WZhKmwUagMB_MaOR-8x1SZJm0fOsCj8CHMai1hduzEMmii4yWZqEr6psxQPmGx5mf5hmOoWlfP1V-HsAYDk3ThEnrYWy-KFP3S480u8-kdCTkCah6eoyTbkQjyCF4G_vQ0_i63pr3pyf7c5xtWFRTd0JFpD6kuJ4BGFM9mIqXoFO2zszk1DW9wggzxPKfJ3zZW27I6s2r6XMFqCFWi7mfUYWfvsH4Az4ezn0DXbJJGIVi4UWDFCfH2xKJUEDJ7XCgHcIL6yJnIVA_Ayyu6ywNOMxPcoizREyjaekAxbQtaz13RnH440zVSmW5GoXEL3ZHVCwDuwnIuPpf6Z7tsW0a_Twf7wbKGDt9d6IxdBwkPonHMqZZyH-UBM1At1GtMwHG5sQd34HO3duyE5fMLGBaiHiitoTcdI9L0AcJX7hzzzGC48hYjyYE25Qx3c3cmCdB4V3bE7xinJ_x9xF7AVzzk-D2bc1vBa9wiIk_vMoL_0ZsVARnP_NtjrX6jgYYuNaLYFQsFDoW83t2-xIJJ6X0-rZae7HeEJLDHsdFzz7y_qV8QTTap7dVtaLXW0NH5jCe_gEE6E49-YMzV-ZGay-L0IEy0INynXMfjc8lLxOHq-mv1tJpIEitXF5coeu6g6zoY4n8Sr7r_p9sghar6HqUMZMeQzkTv1UgJ-MI_l-7AeDNBUEtTQ_bWCe-I2Z1H32Ulec3x96u6Pr09nWb0dTgi0UtGuIkmyHrNISJWlXoksWAqIihEq97IAR8_PntcKHbIIm3m813b6eYKC6x7FIV8kemf3bo9QBerXYcaHGs-kczE5nVdmFmDTXObRflAzvNaqj3onI1M6trTl1MYN8DFfk96gwMlzhU_z3mvujXQDvKTSZ7HzQx-yuZta6JVFAuhscGKKbr-RyhD79t49XIGVFlxXDZkR9gW74okDYgRyz0hpJrJe9quTFlJGSngSU6ooZQL3AKrZygmtFEILyEuGFsFiFnw2u8RqSPku6dn7R2sanmmSY0ZJWOofkwuhgXC2CleeiNh2IiU5EsLZObDiPhFslJlZlrOSvRGm_bfoSPNZdX3vdhvWZ-Z66g;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSkZjGaDoEEJYw=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=CCD06C59BA0B57AA356EFFA67FB40FB6; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtn3Izm-oqiAGr4zCqIdmhGOzn_7lvJNDCbPDx5RTsK8WXv19RUt5vrg9xfbT4xs6Y2VrgxOHFNufZNKDuMSdUPBOoo_oqDI2PYwxVwySgNnnG_X-T2C4VOS0folGWRtV5XZ7e_etXsj_FOdwF81gRpjrY3ZqT2bcUlXlhhLX4-50zrv_DAkUXHnscSlqozdFM_MmWDiOKGIwXkwlRBHIfCqFkzbzkoje74ENHsmPTJ3QsNF8-P4yA8hgZVZ5dzUjyHLoNyCfxsliP_LOBFx0ZBYjnRnVdc2CJFI1eyt0NMYtLPSVroSUUy89KNynu2mOx0krYxWwtNRA4bKe5tJG-BNPqpCbfQ8MGpdjhgt26v3_qzcbJRourdQhFXxTo8vxbr1_7FKKvAN3M7VNNgNriTcdiIOOTEx1xkGe8eU7_lwnSzEKaNJACwf7HPwHLaOm8pa4yF_2q_hhq4GoiCyvNt1xJNY7kt1IsENqjj6scFubohS0E40aPxMIIYF7JiwCmLMZG_qP_1AkRxhnW9gflAgng7GyjnonqHc1QhdMtRjc-TVuyo2KgBfKX5Q6EuSw9vx3wx3jBAXYh7spJnyEzvf7RvrndKRxJAiJlLFNfwd6l3_SFFZoUoSdIV_zaItS90;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSkcihNDoEEJgg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnfTyd1NkSK8TDKV_9fHQRO7-kwGoX9xqbfLoMkWMDgwWdXexsDYj6IWCHu7W_0UAVUpgfrcxJktmVmH67AYivCHFa3IYafwFFbuK0WjnadJlC_qmUBBWHhsGPVmCRCI9IXcnzBpGNdK2Y3kbofo62s5NKkIdbBipSO83JvuT7CfJsSxHuN_7oiY6QpSkOm7pTPIH6t1TWk0x38njdfjjOERaZFunY6TRK-_qABNKgkZ8vlQVsQ-fda3VHnofrnjo9Jh_t2mL-T8ftcI6Ye7ugFAVqPLMafUHQgb5u7D1K-HusCgLvn3sroH997pNRs4G5yJTbydeg7-l-gX_Z8ZZQixMbV3jnnWMqB4ax7fG9Sx_0IRN0d-M-zxvYYn_QUjv0f8ErDDn1vkIxOZd7Z9XpVF7JlDSQTnBvWy5YLz2PHqQowoORVqTUthTGAmubuODsESX-tearruoDur6Dhsel1N-JeJlYBvBc5UgcEn_sle9cPsxf9ShaCG9Rdekr78K1bgXrcyRxjh9594bfXktWoL71TEbKjobdIDqa8YR4JDlUP19LIe26CeXb3QG0YV-dqxajg_v4YQ-6Pnb6wsVaxdMKYIWMZ_s4E_9J8bezEmf4E4l0sm5yzZ7Nk7NOfkukTD5HjZJ4zfGF_ZoKQKlz2YYw8lRAm6SXmfYFcryot9w;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSkehtyjoEEJBg=
     status:

--- a/tests/api/cassettes/test_get_devices.yaml
+++ b/tests/api/cassettes/test_get_devices.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8I9HYxO_M3FJmqyQy6voCjLzCOp4rQuJKZlks02tjIVIIc0CGRJxZYSiaJjZda40phsSIWSAZ2eR7ONY-UkybEKUMZyPCF4VTADbu4ZDFJdvW8MnYIimoT9Vs2xn4qZL3BgnoQwXoR7Y9YB4GUhrMlKL-MTIlH_x-qQYM2yd1QP9SS6IlShtx0zrB7PDhoKmTNjLtQcHxcbTgUaBWn5bxaPeysLz-3aS6-z6ypN09MKb7-I00xLO6wLhdDNsNYK7Gs5hXNAr2Fdg-CIB2fFdTYs=N;
-        expires=Thu, 11 Jun 2026 10:17:15 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.xzD2GKLmGhpAuITUDe3M_a9_fib5ZFgtsXqOdajmnRE=N; expires=Thu,
-        11 Jun 2026 10:17:15 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - eyoiMh2gDoEEPiA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=36f95c84-4d73-4929-a930-f6d0ab245b78; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639167689352780249.MjQ2NmZlMzUtNjgwOS00Y2M2LWFjNTItY2NkNmQyYmE5N2M3MzM5NGIxZTMtYTA4My00MGJjLTlhZGItMmFlZWRiOTBjNjAx;
-        Expires=Thu, 11-Jun-2026 10:07:15 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639167689352780249.MjQ2NmZlMzUtNjgwOS00Y2M2LWFjNTItY2NkNmQyYmE5N2M3MzM5NGIxZTMtYTA4My00MGJjLTlhZGItMmFlZWRiOTBjNjAx;
-        Expires=Thu, 11-Jun-2026 10:07:15 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=HeQn3YtVSr5yF2e-ak0-MkJ-CQq41sS-YtPLpJDlpY8&amp;code_challenge_method=S256&amp;nonce=639167689352780249.MjQ2NmZlMzUtNjgwOS00Y2M2LWFjNTItY2NkNmQyYmE5N2M3MzM5NGIxZTMtYTA4My00MGJjLTlhZGItMmFlZWRiOTBjNjAx&amp;state=CfDJ8I9HYxO_M3FJmqyQy6voCjIvSpuVq6wpiB8X8xWoSJEBq7Cpglj5s7srIfH76ZqsGUIZJa-0eebRUGWYio3LIgmJVoC7bwkOVJ9Z-4NjJpxo8TVGddu6XyRH214-ieFm1WTYtBHnkHaBBsNJ42FCc49CMNqVbRU5OrZiT_O27U7XIYZXlup21lZ2zEvTaP5hCpwBxgUQCBK9G-SdRNo2x3KpznMCXR0ujPtFME46G8pVEFllEZn-BlkiXE4gx6Fq8S-q7njJ4txu8uK5qXP8hpP2HKaGQ_wATW-HLEPfNZhV773zc9ke1U9LQQCxwzJmdPgynOOU1KL-4ZvmgXhtSRHrYqf5zbccbrsWIK554WVRWPwy9L2rgE-vtYzqK-rCGFjrvnH1P3JH7r_JnuXSsw_JW9phC6uXnjjZJRAu8z2eSBo8P0nWg-nxHIDbIXZYv1TkY7t-Cw6Zdvtd2UGDDltLEK-IAqQ1thzmq22xlmZZnywxqhaf_JQBmqA6e1ciJTmg7Pln9PV4xaMBuqQA19USNlZ6fSecbyTcxdHJvjzuPgrUFIrYK-KQE4xI2f3v7sRVdnfCoyMppYT_2QGwClvoLcqx4BhuM0d5XPX14JmJV0A4Gy_xJKR5RS4bRdYuGYfOLMzzSe3cDZOK50OC42V8sE9BZQhJC7tCXY7XL5wx\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"36f95c84-4d73-4929-a930-f6d0ab245b78\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-6ebebcb51732\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=HeQn3YtVSr5yF2e-ak0-MkJ-CQq41sS-YtPLpJDlpY8&amp;code_challenge_method=S256&amp;nonce=639167689352780249.MjQ2NmZlMzUtNjgwOS00Y2M2LWFjNTItY2NkNmQyYmE5N2M3MzM5NGIxZTMtYTA4My00MGJjLTlhZGItMmFlZWRiOTBjNjAx&amp;state=CfDJ8I9HYxO_M3FJmqyQy6voCjIvSpuVq6wpiB8X8xWoSJEBq7Cpglj5s7srIfH76ZqsGUIZJa-0eebRUGWYio3LIgmJVoC7bwkOVJ9Z-4NjJpxo8TVGddu6XyRH214-ieFm1WTYtBHnkHaBBsNJ42FCc49CMNqVbRU5OrZiT_O27U7XIYZXlup21lZ2zEvTaP5hCpwBxgUQCBK9G-SdRNo2x3KpznMCXR0ujPtFME46G8pVEFllEZn-BlkiXE4gx6Fq8S-q7njJ4txu8uK5qXP8hpP2HKaGQ_wATW-HLEPfNZhV773zc9ke1U9LQQCxwzJmdPgynOOU1KL-4ZvmgXhtSRHrYqf5zbccbrsWIK554WVRWPwy9L2rgE-vtYzqK-rCGFjrvnH1P3JH7r_JnuXSsw_JW9phC6uXnjjZJRAu8z2eSBo8P0nWg-nxHIDbIXZYv1TkY7t-Cw6Zdvtd2UGDDltLEK-IAqQ1thzmq22xlmZZnywxqhaf_JQBmqA6e1ciJTmg7Pln9PV4xaMBuqQA19USNlZ6fSecbyTcxdHJvjzuPgrUFIrYK-KQE4xI2f3v7sRVdnfCoyMppYT_2QGwClvoLcqx4BhuM0d5XPX14JmJV0A4Gy_xJKR5RS4bRdYuGYfOLMzzSe3cDZOK50OC42V8sE9BZQhJC7tCXY7XL5wx\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"36f95c84-4d73-4929-a930-f6d0ab245b78\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-6ebebcb51732\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=757ab14a-70a7-4782-9cab-9cbbf123cbac; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/sCxHtqk0+PhvsGcAq5m8Yhel0YPZPoHq5G8PtKTrKh08XbZ4KFbW9lKAVMsMfiHNIt80rurtoizL4hAkKrbemjGVOj+arJD26r9p1NRs3OJUEmgeRrDUYyXBqNQm7SRP4xPLPK8ufM8shuJ0xwKGX99ohY71eJjq/zHh3biBtORoE+tf3aTESlUJfeqgq2WXkUA9Q8xuYAI8z3wiQbP37sgQ5X0kx/FUANkaO8NJzSH24ohflTZNw5HtqsqDoR4PUgKLmB9yQngvcar52lvvvhJVvu6rkxoRDk0ALauC1BdOmgn/rN7iAAAA.H4sIAAAAAAAAAGNkFbdZedtM6ZrhpLtJnWpzZBcZpL9+PpNVx6W1Kjvu4kQAylevDCAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Thu, 11-Jun-2026 11:02:16 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.xzD2GKLmGhpAuITUDe3M_a9_fib5ZFgtsXqOdajmnRE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8I9HYxO_M3FJmqyQy6voCjLzCOp4rQuJKZlks02tjIVIIc0CGRJxZYSiaJjZda40phsSIWSAZ2eR7ONY-UkybEKUMZyPCF4VTADbu4ZDFJdvW8MnYIimoT9Vs2xn4qZL3BgnoQwXoR7Y9YB4GUhrMlKL-MTIlH_x-qQYM2yd1QP9SS6IlShtx0zrB7PDhoKmTNjLtQcHxcbTgUaBWn5bxaPeysLz-3aS6-z6ypN09MKb7-I00xLO6wLhdDNsNYK7Gs5hXNAr2Fdg-CIB2fFdTYs=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8I9HYxO_M3FJmqyQy6voCjJTeK5re9M171MUWC9R_2yAZNp2pQk_3-zyzqeUOneAP5PO8evANjgqDg_NuBaV_Lo9kpzsq2rEXBBgWYPoBLfamQ8REcEWfC4UMYRv00tEh7EGlRC-vAEEjnMNNtF6-CTasjGW1CQqMlGuwjNb1Y9CKPPh-mDmUOXhRZ_qpiXPJfqutw6vmBE3DgoF0Oc22aeYkRTw9h20Oz2QaUMjUSBXqh3zBzs1EEdIRBi2qaKI0LoXlc3JIhWA2Rn4azdc6DUAooeicb_RSVxFBwiYbzcMo7CHvRD030ijF-gsuUhCuck4Xjf5SMbfu_xUsu36VPQQkLoQrj82HNG_72O8u7QOqoxDs_ND_kVpxShFT_7LZGaZVkCZyNdXQkjYpFADXTd4nNQA0uz14JQClvEH-qPvAAUBsqf0ZiGjua-fb8XYyVCndHjRz0EKQKFiQ5uhpm-3h77VwX4sSrfopTACUBPI-ULa_8FvFENZ5dB3fCuINkkkX-Y5a4NfdxheY75JJsuPjINLIEfM3S_crIdbdr_nRqg-teE4paIY2cHoeN7jSlW-7lWHpul0kDysMIwLSf9Rfchh2LwrJYVxbf5kmr77zf4ivETq4XTOz8QjXFK4XJtZFXY8pEI-EulodP3LzBR0_us6hIzOu7209l7kPc1rqPuLI298zD6raMTwcsRIi0qZdvHpZPSHIkdSfiFW2QzzPMcWgISiWFzJ5ZjzrMGSFAUBU8H-JUuQe3hFTiKPpda5IrAKLHi9RPZNtv5LGH9sptaHWV8Si6pe59lk42l3og0dJyfPhUkQRwZO6Vbe4uIqT3YEkstL6zDRWPAesWsLM1OALzHjJMCmRfV8veT1tvCOz7zOcZhBIq6P3LKOS24iyFptjG55siceTofXGRlgdFXp2d-RQKkWi4XD0wXFHgMpIYMahXsL9zBzxxJLd0oiuVi6gpvoQe6f2wO47ZyQcxBGPqZQJ8--kOqVEZwfhqc2YmRngxDDYl3J9pSDfGXBnxukPmAteEkOlar7Tah7GIKwQtIyfo3n3audu2MTtNjduBaw0XljIEzSLWvLJvjVop3EYgKKhnBMH0CZOZeb5hOEjKDjx-wcOAlR669wVnKMLyKQ3844wyRHB30Tg3doFKK1qyDted1r4JJAtoegL_qwFz1maT_bBNChB5hr3S2cKmNqTppyLkjbcZod3sNQ2doaiahx-M7SLnktN2_Ag8n13pvSHSTmYJSqdLyZXW4cuGrO_LBlmHlC2nFYpJIzuQdRr87R_tfFlBsNQ0y5LAgt37xu1LK0LpOQb6Y9IcmUqABwxpBL4MrJpNxqQPPoKJ8tawxB5o_NdJv-R2dRJDT6mRCOfKHbKpg5hea0IiINgYJPRLUXKkLRzVcLYYoEOCKLzwH0h9FRIE-qcsCVu0mqX0MIAQ163NeS5tIEYNCWUBaguzST-QH7Gf76A4tv0KID7ogJYHZwAhXG0WBMBfKNFgZEOCmXPwXcYDaNa9BzErowQ_UaMXcFqNtbCQR3eq1eXMdvEv8_W_Dge-D0elcD-QZGJgF32PI3ejsaxLgqmHyJ5Eb967rKxZWxKMF6J9RdHwFNWfWVDCrx_G3khlYBjKb85RtCjSz6Sm-Wg6cMAfNr2q9WjdzOmikj7Pyk-xkpkEcLCaH1-o5PI4oS4Beh_V4-TcEp4cr70qF0mPMTBiSJlvC7NIIp3QpzhCP1PKSzO2rKNhM23N2Ybd9n5dr5pwnHcjhzLblsVb74HAN1PFqh7RcW_dElVaxmvypsNGALZzijnA1yAAVSjPn9NGl0PxB5YXVG9IFFFIEPn2lSiz9F_x_qkxcvV0g-bFlquIHQyTA-ytT313TVQ7nyFs04bWWTYTMCxI8TPC-134KcJWsjfLxtmEiJ1-XkG2LtIvKO-SXNFUSPvMpe1VK6S1sQZ-BolKt8aXuVEnzdkrzrVe4aBECSJyDLIrBTEGhTXPAbrLcAcZMAy8yfDlQwhI3Yr2D7OSYzTdxlPgRZRYk5dgAXgaQjMXa0yLHnX9JJxDSmp5ZNNUMgE0SWrLyS3Geb0fR370Q4bKsMcJPfKkzvLylJ61Qki0jdA5bEhtgL4jLHU9yn3RWRHvuJuRfg7cZHeAiilxrxwEHtcdVGQ2qrpFs6cEbwKO4SvKg2ZY8epPwCKQrMs4gxqGAGMM2Q718axlr0stdiarIRgmbtPZpGZ0XqVgFkFDMhiHTe8-IjumsR6-kGZ464bUXLkqjNP1XWgmjJbGgX_Q4mmJkMNkEsV4tvOGtBXs3l21MKvhJ0hTDvFgcdrsrf-w9epx95OZQEc7cCRLLAhuo3_GCCUhFThNfwAuSan5mvW7kmPAck73Lch6U6iVVbmYUTbhxHreZiX8YnURHKMhcAjl30gghsVgmMb6ExwoAZr4y2NSI9jPwV_VJLqGE84tiwsyfaFWr7qdTxxy3P1PJLvJL-AX8qYCuHkCCSgygbn-Y1xQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - eyoiWgSpjoEEPwg=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=6CDB985ADC186C11CD99FA77EA203297; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8I9HYxO_M3FJmqyQy6voCjKr27YC5bjNW0qYPW03jUN4ooollh4c2S3xEvux74n8S4HsSjqKaioux54RwRGy6zpCxE3XXX9HU2bxrfnhMJE-BlciBCm-kxVeXLQghv61Ys5HLBfEazSj1hM9AlU8nzLZrez-LmHxRJM_gr2UJ7N0fSTYj1V_aOFBYEVc_UZokOkkhQlTILuCNGzt-iNhBSm29mriholRJY0fyCNkkGAAZA08DKPJQ4jrNvYS5WXDQyF_dv6GNJE2uRqwXTpjApubb6irZGka7ypBlzqXxufn16TCr4BXd6XxtFYYiXE5LDPC81rKlbgxHpWkbwo4PWSUQnwtodN8ln7nlbSHC5ujRZ9XZ1NhvbjBhgw8XB8jRgEJFZhRbVCwlRBrn7oHxbDeLGzoHPGGiRJdTA4tudXEih6U3dwfVgj9zWyoVQCXjYxarklSTPvSymTEb4G5OoviiXe1IZ08G_fb5yJH4t2EecYmX5Th7-ZitukROI-xSUYu8PzGwssrydED05_BwQ70WGf-WVg2n9ONjqh1-Ra2JyoAKBQsLMz3w4n0eo0Ax8x30EnyFsdNfUmcR1zfUsdtnEKQroIrqjTZ1YRANjBWrhkr5TFQvUEEXyKNrU7CwCkkEa1tspCg7o_jTFhAQ_o;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - eyoiXh7IjoEEPiA=
     status:
@@ -602,10 +577,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8I9HYxO_M3FJmqyQy6voCjK1hJm7cgBXEEB4PreR69QPew8C80Ui_MdvR6enhlppph7ZRGiNSJVtbnRr1Nj_3mOtbHBCgLdcD06o5ZBIEF3aDPyLSrCchRHostc63RTDVCO1_cKyd9GetQs3zrZ3sJp6NeM0lk9-oItx0R0kt095NnuQBpl1SNUzOuhAGYHBOq9U_A4aBEasPBCZsNyklWryXj6k-fRNzzBKFAHy34R6tBpvYGSoywf32cFPuEJduBUcY68AMvqekW1Ono0Tbb2qkvJmbd0UDEajfgUN-HOPTDkBKEsS-xoKoGFKfSLDgBFj8iTnsyTsj6HIzHu-9YYa7dEXV_QAbH_5xrsAfoFuArbta1j5KYfOn3sLe2n_Xm1Q3uQ-AZegz7YusVWbbg72mwYY5jJEltREkpM4sqE35Z3ojGT2LiEQ4QHgYazz9rYgJSUwu0wa1T_lqqjnavSnJe752xbG9kKZvjupZuY_jmNIfVa5rOcZ-IvHCUmj487b8CfB112L2lOzbCp4F2GooYGoJu2CTZIwFRsbmoWrGiRypqARVKwLuHEMaH1-OLtTpdy1BpfYDxTYQbXTQ6YZM1rnxCbK0I1CoCXf_zWhlrb9fds_obmHuhWRnAf7D2yDg2EBWVQ2cCbYPpPGdLVSK5A31P6VSzwI19Ert516ru94paWRSGfJyHSxIH9bNw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - eyoiZiWIDoEEPLw=
     status:

--- a/tests/api/cassettes/test_get_energy_consumed_daily.yaml
+++ b/tests/api/cassettes/test_get_energy_consumed_daily.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnPnoppiGO8oAj_wqtxJ-gyWuovMXCpcDro4XhpUt23cG89Ug8hlrZfG3XqrsxR70vQ2vKIQABbbEHkdQTYfxKATgPqzhMnEz4syxRfSE1ouGYCd6zPTubHQdQGfZulwgSxTlJ-zJSQjAuU7qUMVNw4ISNZZhC5QmJTS9POsKn1uvXGebFbWsaHWz9rJ_sGVyH47hUPba588Ixgh-R3qn4-ftc85Kjk3l_tTxhSJz8NXKwiOQe8Zhj0j4-jp-DbnH4=N;
-        expires=Sun, 12 Apr 2026 13:35:45 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.oK2q_yYLV86dMjpK0rsGWTvxjk4tQnHL2FPonSn6aJ4=N; expires=Sun,
-        12 Apr 2026 13:35:45 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVXLgl1joEEMsA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=d50da73e-33e0-4df8-b10b-97b2dd0ed86b; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968455759490.NjQ0NDQzNzctMjc0My00OTcxLThmOTEtYzg3NTJhYmRlMDJlYTc1MWY4NDItMmIzMy00NjEzLTg2OTItNzk5ZTNjZDI5ZDBk;
-        Expires=Sun, 12-Apr-2026 13:25:45 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968455759490.NjQ0NDQzNzctMjc0My00OTcxLThmOTEtYzg3NTJhYmRlMDJlYTc1MWY4NDItMmIzMy00NjEzLTg2OTItNzk5ZTNjZDI5ZDBk;
-        Expires=Sun, 12-Apr-2026 13:25:45 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=osdk1H94oqX7RahWoNMt5gY7sJ2A2tN48p1yUVp1yOk&amp;code_challenge_method=S256&amp;nonce=639115968455759490.NjQ0NDQzNzctMjc0My00OTcxLThmOTEtYzg3NTJhYmRlMDJlYTc1MWY4NDItMmIzMy00NjEzLTg2OTItNzk5ZTNjZDI5ZDBk&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlGMUGN9_YgZ9FyUJAoTqWYih9ff1y3YaYHlC30M03CJH4WADdfIZXsyacLGQZUu0-9ETUjO67ee3YudydRUy8TH9xuhqUVh4p8DoWPQKNRk1R-5e9z6KHWRHINeGKqdfbtQkJtZIoMrLS-bNELkLwXBO7tivZPd5_urYWUzKs7H87UgvFOt8fl1owpyAhe5S-qqzx4iSes3WdMgjMPEu4kAy1ZDyUUMst56aXAAVeDmNWesnYJEpX6AAvaSaSgNccGH4A3wtod75XuF8Hulo3qgcC6DHED1Q3qq37qBrsFSodfa6oDFnLKLmElRWQZ7k3njtQj8HphzzINdvuRA-fZLQUoOnQyJ_pVasJbX94OWCBAbO2TiYJE_mkn4CJGS_tx9Tizg6JQnPBZLQBzyaJZGgXXjTMh7k7alVK4YxllTxsopoGQgAy81vaYivjCpBbpPx2V47S9bmMkXeavqb0Y-KpnQMegoRl8ghNromDi3P9-dIyaf7V1-vzq6VusiIrX_yQ5j9hqKMcUXv6RFMP24xA_gGjWZcrKx2i72WL27SghQLvSblFglE5_DDZArV47JU046ZGVGb72Q7cV-g7DaGoR83v8ZEbImobkZBjKVNN1S3Cw4rtgGsBd2vvzbbbS7KCIgXMsgCXbg_Iky2zV\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"d50da73e-33e0-4df8-b10b-97b2dd0ed86b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-446347d057f3\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=osdk1H94oqX7RahWoNMt5gY7sJ2A2tN48p1yUVp1yOk&amp;code_challenge_method=S256&amp;nonce=639115968455759490.NjQ0NDQzNzctMjc0My00OTcxLThmOTEtYzg3NTJhYmRlMDJlYTc1MWY4NDItMmIzMy00NjEzLTg2OTItNzk5ZTNjZDI5ZDBk&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlGMUGN9_YgZ9FyUJAoTqWYih9ff1y3YaYHlC30M03CJH4WADdfIZXsyacLGQZUu0-9ETUjO67ee3YudydRUy8TH9xuhqUVh4p8DoWPQKNRk1R-5e9z6KHWRHINeGKqdfbtQkJtZIoMrLS-bNELkLwXBO7tivZPd5_urYWUzKs7H87UgvFOt8fl1owpyAhe5S-qqzx4iSes3WdMgjMPEu4kAy1ZDyUUMst56aXAAVeDmNWesnYJEpX6AAvaSaSgNccGH4A3wtod75XuF8Hulo3qgcC6DHED1Q3qq37qBrsFSodfa6oDFnLKLmElRWQZ7k3njtQj8HphzzINdvuRA-fZLQUoOnQyJ_pVasJbX94OWCBAbO2TiYJE_mkn4CJGS_tx9Tizg6JQnPBZLQBzyaJZGgXXjTMh7k7alVK4YxllTxsopoGQgAy81vaYivjCpBbpPx2V47S9bmMkXeavqb0Y-KpnQMegoRl8ghNromDi3P9-dIyaf7V1-vzq6VusiIrX_yQ5j9hqKMcUXv6RFMP24xA_gGjWZcrKx2i72WL27SghQLvSblFglE5_DDZArV47JU046ZGVGb72Q7cV-g7DaGoR83v8ZEbImobkZBjKVNN1S3Cw4rtgGsBd2vvzbbbS7KCIgXMsgCXbg_Iky2zV\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"d50da73e-33e0-4df8-b10b-97b2dd0ed86b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-446347d057f3\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=de5ddb56-0886-4d0b-84fd-023572153417; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/6WXfOQKNyOJfSQiqdeK5kxaEyXftKO5sj5R2khOcGJUrDimChHhZwa9qVVxhhO6Z6CzK3/dbzK3y6wKd7iFOZbBcQzIY3W8jLX27rS6sgl3jz/pNzHsaj3kuZ9uD2Y5LFNH6fZHJ+Ng24qSTq6KyNQpoJvnqKaU72KBnASVL5njTRy6hDGsjEOQwaUgPaWhXRCBI/TA7AubzOE180I2yu2xuWMh8gJhAd7JmQoSE+gH0dEwyv+MnZ7ToIGsSn0qjil6yeBokz3OjAwu0eNdgMuw/NLyKp1XWVyqr7Op9aCkm9Tpy/PDiAAAA.H4sIAAAAAAAAAAEgAN//vyqpAsdq8ilBjt4s76fC2Cmu0op/KCfFMtR8P5HxVWVCHu+VIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:20:46 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.oK2q_yYLV86dMjpK0rsGWTvxjk4tQnHL2FPonSn6aJ4=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnPnoppiGO8oAj_wqtxJ-gyWuovMXCpcDro4XhpUt23cG89Ug8hlrZfG3XqrsxR70vQ2vKIQABbbEHkdQTYfxKATgPqzhMnEz4syxRfSE1ouGYCd6zPTubHQdQGfZulwgSxTlJ-zJSQjAuU7qUMVNw4ISNZZhC5QmJTS9POsKn1uvXGebFbWsaHWz9rJ_sGVyH47hUPba588Ixgh-R3qn4-ftc85Kjk3l_tTxhSJz8NXKwiOQe8Zhj0j4-jp-DbnH4=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtnSQvMzEvyTtgjT6dO1Yefwzbaek3GuX5MPP-UyPbhKM2kxtiIMfuuafuQ_-wjhSBM0t-HDr3QnaUFj5g9-XgehBHNCsKdC_XUBEH5Q_0JXh4ykPh2wJR0Vy5nSmEBJhtW9EsH-xgEytCEedz4XFH32sNSyvHkVrBjOGchJgJLn6ehKyFVfkgxhepa1i606B1kuT0svR46ptpVr2kLXrtqr5oz1OcvtFUU8NV9UmhwOrdGBfNsWEz6VGdK0O2JB5SZ654se5WFhtJkaAG-ZzBhVZnfELhIK39WBZ5RqXQcEGZcH1UWvdYwrKHxDBToAUmVtGJi7jiLiPnnXsy7QZrrw4h2XtNdBZxTToghcA8mJLOZ2jGGby8w2-C5uDKdXIMWeoSCUBYqNkvsVo7L9hF_usgweVtGkXrY-m_qHTEPJ877m6Ib9lSYZqcIl5gSY9cHTo0pO61whL95vczsqjHrzW42T_l4iYxOPKUtUtKQEHtld6EuRD1I_6yaBgOMkAeUC75hEKpUQXIvXAagFXboaq6ujZrxiXo3VDKY7VEZymKRDUZEo1vsQBwfPj1b31S79YG10Q_Bopmrl0P0vsBMEwuwsxsW2AcktjU4MmVwSWO_rfuRn4XhjRi4UycVIdNt2kt457LEVaQ3lb0BRLMHh_MXUHbk6eJR8qlci-_6jN9YzKjAdszmRYH0HJvRw7H7K0VSSxr_SDXAZZXVjXdEUsbC1fPeDvu_g5V0lZhTAYzNQzrkV8PEsevu1uraAJ5G64cPd2IDn6AcgcBNd9EcXqU34QM-WGuJOSdG26dX-v2UoBQN0qp7vXC1uMQtBLL4KP7H0RUzw5TaFmmUj-325EcP6taIxzuqLkIy3pKjPPu157F9HsUqv0fY4VstgpHAon_tCUTiPj-xmeeVBL7zdkSu7OL5XelI_QkfEhtsL3Y_j9PmGzxgvC9JyroYZCyUyCyhdfZNJTZJntOVeKrtvu9SLIdggWDXjh_1UAlxHIKoJAT9Z3dfX-1ZgBZJc_Tr1e9qJj64hV5Gu5Z0UQqldCKjeLp_fweaUM33x7QzBBP3ve-4GteDqnBM0aky2cixuKuyz7kj-a8BlLqO6jgLQkEgpY8Z4KM0YSFAmsgbTT8oH-4EOiK8wZPgDbQBAbMWAoW_9bJ5HqpWIPL3HjxByk-6qMkjoSTEOHtN9zEbB8yHQ3FMDX6bJsGqMIHjejuarN1Vsc_YUBCFbQg6Iwt120MyGKi-TogFLEBc72W_OoqrX8A3QeedJVc7psOhtyLZNS5LziiRCXYwDV8rDpy-XE6dWov_8MKV-_5haBtS0whkZD5oOaZB8miBSOoJot6WUX37rZbM8iggczzMyYWoYjP9i-NQIuiO-bVDsmPbwLoVozjgWTTRmr3iGCYkN2F-UOJfduVa8cdMIWBU4bgoEOqZmiBtyXFA4aPsQHQvenX8O6wGntjD9NpXuGYjoQoygGePJnJdqO7Ssw4C5u_yFbwF_7wUZ0HSuFjjJvNoCvk6bphHI4h8xHQFNaQ8-STyRflIS6CyVkJYMOr2iB2FC2dQ8b4023nioAZoQ0UDifvsWmDdfmzN4NS70PvheUNjYx4rxSUFQaoyFke9fIUHi3n8fpnE31LFlOhphDXI49XT3PyYUopTQ14VDFTyD0iRdwR_phK9yUMNXu_s6DmMvOQ3Ilj3T6vbOtiGRJ-Nsr3pLKXD3dv-Vu_qdOE9XTgnbuxNfO7sHAyoD7Yo4diiGCgo-tbpcgdeu9ZyFKHqFabCqMtRhnSquS0KsLqlVlaT_Bdd6LGv-xSq3LgBaOZW0iFo_lbVFYekPtMUuq0YiFdTQM0Rg8gO4otyDsu7y-9aKAimBoI0fCyvqh24nlH1F9sZHmPa8686KOnv1nt2nPUsHcbgApGq8xNpnLLl4-Gx6BsWkIzE9t-0j6TW9jHt_hg1d939-QEAhXM6bghTii9MTj2mhASnOnps_8lP2nphUMKDlpsIEGn2-cTDuJzIsX2XbSnc7qLkJnHpsjBHB65X4tzy71BcmA4vQ4h3Y6ZxQpgzLr-0CueeDgbQrYSXbINhs3YCoXhC3WhKxUSMBZ1f41ckvppoDXjqxn56qcwsL9fnvH5wjQk8rTIpbMKhc3wav6ksCA7ADkEZLX5vJ4WSZ_gLcc6Z09aUEfI1LI5SzsIsDSV3tAQZV1j3DaqpYXXcDhmEUMIRiAT3YDZgJ0fgsQiyBeL9GNgeeYT0rGUSIwHZG5jo53ubaJkhWRwHcHGScrsJlPXuUK6ZLx4dA-cGWhGE6hZMBIqexl9b0c6vGyElFfrqNgXDCXpu37uGoypHS2J4OP10BJlyIULGUzD1_ysde3nLGVQEIuNw35_0oJZEtGf4voeolOkp8-fzSRxg7fcqxy8ORAOPhEQy-blfHRiIiTi7Sfw-z5-c8uFWjijv76eQvKhAe6xBpoN81YxuccjnDh6Vd-PGP_VjEjg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVXTj1AjoEEMgA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=AD85B9E5B0B41562FB82A7922BB43E9A; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnclY0ymyoCkeXQ6N6JD60V160N35UIHABJYI42nr6arxeHz_XoVpmzygl5eclHnWUYUM-YELxujdlPgcHlYg9Ncj0eM3_o-ps81_NZ7x6b9NqLE7drNY0fJ1ffO7RXuBWCOPcu6p_XUt6oCSDCcubbmWq4dP7tOr_56Ncvi2jPqzK8gGiKNoLtUNl5m6PcOitGBjLIiozzETdeRV-V6I0qrTVuQlEKTdhzOf5Z1ZAY5EoT0P34kSEpKRXg9XllshJasfqV2KgCNjSyodtBN-LKljY5o8snMp2OlzSbONIIlK_5BgTXC3QMkHXpRXLVu09IveyLHvFyvN3OX3oYE9wcBE1bJ2-pwBGQAMyGvppTv4INjKWDgpoRqiCtyvZp2HK991Hvf0Dgg9xSiRboNB2cA2M7GrdIeSNtKHf3anrwmA1kxnjgpIVmkQkJ881ilXfK2gT1eOzXxAU98jhovOfgj_8hQbxXLHZcTkr_dP_fsI-CnELUmoZfpjRO813bTbtCk6aUyhaZuxZVw0opniWJmPV7AuHsqitq1iPwREiEKXlVuYFvd-4b26ZBPR8VxwMVhcweonHORBsUEuKw_Abfm7uQha908Lv4MA3QG5zg19FU-37Ga-N3Z6HGG4e6tsE;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVXVgsTDoEEM6w=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkEcxO6Z60K56c-9qk1aoKXMJadAiyct4q5I9hCfkZ5_mbnGdJG2tI_m5MRCLtZawg8JuY17-K4qWLtbig1HxIoBORjn-8fkPwztdU5jH1wQlTW7zxR190YUkP1fLR7UyMP0cw8h2oFDkzO7RWW3DCYhLQcgN64jS1OWZBPiwA8Fw5GA3Ngm15vyPYiCclwyYtl_zFYZVtg3ww7gFQT4EwOxfDmNUPsqRHAcGqogoIoJYONl0QkHhh_S08BSvNRjGqzg3JYwjV1PUbA1GZprw-Z7wCsy4M19wDfX9E54SeqDCK0_McwHecI9vb8H9M8VfFiZOv-1FscqPpzKbJpdpGr29zN9HV_5_OzlNyttTDJFW4jXqKGVwR7AvLxxEJuiBk9yDK7nAotZfGb7Af4nqCzV0mQsKLGvebJegPjePqKf3Sb6i-tPU90iu0qPtCvCJdnUe8k7VO0dmHR1EZ4Y_hYWFGZAmmP9GBeosWRimfInjr-B5myylj6yT6gd_g2XAbHiXC11b8JG1P_qXJX8qZpwMm-ErAIo5NtESNiMIGrKpTJSgmTigqBKOzXVtyHFC8c265-BLthBDS4Tm8G-lZp71uSr_nLlRQ35PL7ezx59zseBfJzfrGkHsRSgcabPRMDrTkgcN3RSxwIF1GCY_UPOTT0mgL7kC_Epgv_l8EB6A;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVXXhD3DoEEMQg=
     status:

--- a/tests/api/cassettes/test_get_energy_consumed_hourly.yaml
+++ b/tests/api/cassettes/test_get_energy_consumed_hourly.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnR8BacTTR8F4sKnd_ysijPdsoh_VX2aT6d62_RtNgrVcqHO8xeaXYmu7sy4sYxyeYAVdwQOANeoz76JnzuXzosWxWoA4G4P5HYOZTmnFFAUrUJGSkUrNm09EEE_bK1Wlv3LDDYdt44i-iKNgZrjDuP0pq6P_uEBxxoIY9QTtELL9iFlkm8ap7ob91_hK4vHJl5ZmKvcNlUcsZMPbI-9p7ok_MaOl5BZbHNLjLm26PPqX9JX38k_Vpqj22JPNohSc4=N;
-        expires=Sun, 12 Apr 2026 13:35:40 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.8X1i4LDMQ0UU1CGCUZZSitd3ZsWpu6NrPdc8wRDcgYE=N; expires=Sun,
-        12 Apr 2026 13:35:40 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVWYhqxjoEEMiA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=5d6294ca-eab4-4fa2-a35b-4cc16b59bd22; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968404639602.YmNjZTE1OTktODY4My00NmEzLWI2NzYtYjVlMWZmY2I5OWJjNzY2NjM1ODYtODQzYy00ZTJhLWI1MDctMGU2MDMzMWI0OGFh;
-        Expires=Sun, 12-Apr-2026 13:25:40 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968404639602.YmNjZTE1OTktODY4My00NmEzLWI2NzYtYjVlMWZmY2I5OWJjNzY2NjM1ODYtODQzYy00ZTJhLWI1MDctMGU2MDMzMWI0OGFh;
-        Expires=Sun, 12-Apr-2026 13:25:40 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=S0EyNdj-uYBlLCHdqNAOJ2i00p30STLlNOYDQMx_tdQ&amp;code_challenge_method=S256&amp;nonce=639115968404639602.YmNjZTE1OTktODY4My00NmEzLWI2NzYtYjVlMWZmY2I5OWJjNzY2NjM1ODYtODQzYy00ZTJhLWI1MDctMGU2MDMzMWI0OGFh&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnoxgvUGjnTC6tKRfrXvzMM-FNxb0HyDTolSfjXua6qPvktadY56KiV_Fb_fr3E5_WbGnj2r_O4hlH1f_mAioT2htSI0-5O1ZgO7aNXRzz5d2qxFqCHaf26iexhwKU4-Gswrxz1OjfmtNNHmVMMHW3qc-yI3zNsRrIfi0SVL2Je2xoQ4irJQKxxGJ1mD6t7DjpaqIGZfBr3aPQXjcH8HiVL51AcPGT3pTcMC8dcI7XuQ7R0gfhNogMUaObxUUfnBPPCx0_2azRHsMLU9eB-Hvuv8tWs3wdBxnhU4V1KTplAbyiowBSZljvb2VtQVmwHUkN6ztlZKBfenXhsSrnQ5XeeenkGNnCRWBKyy-hTtkGl0WEfo5UR8pVhxob-zzkqRelkLx6btlompo1yABwwHoFdFB72nWv4pCxfnOSYbjkLaGUy6JJ7e8JIldMXafrTnmUMlsz1j0nEhh2LiW7A0X0_4NY_DPbLnttlm1yzRzrCI5JiyHNCxQciIuuiPsmrgwmQUFY6exVgqr7mNkJwqTr7rc2RaOsNgwLeyfBd75BntD9tNVlZxx3PbG4rmCUjg91lIL9thgKr7wcZ4Tbe2hesFlgWzBVN3zylN886p4HKV5LVjwN1PrTfFqhgVvSiiCRccHUTk1Un8X2GQtwm-Usd\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"5d6294ca-eab4-4fa2-a35b-4cc16b59bd22\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-c86bd12e9173\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=S0EyNdj-uYBlLCHdqNAOJ2i00p30STLlNOYDQMx_tdQ&amp;code_challenge_method=S256&amp;nonce=639115968404639602.YmNjZTE1OTktODY4My00NmEzLWI2NzYtYjVlMWZmY2I5OWJjNzY2NjM1ODYtODQzYy00ZTJhLWI1MDctMGU2MDMzMWI0OGFh&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnoxgvUGjnTC6tKRfrXvzMM-FNxb0HyDTolSfjXua6qPvktadY56KiV_Fb_fr3E5_WbGnj2r_O4hlH1f_mAioT2htSI0-5O1ZgO7aNXRzz5d2qxFqCHaf26iexhwKU4-Gswrxz1OjfmtNNHmVMMHW3qc-yI3zNsRrIfi0SVL2Je2xoQ4irJQKxxGJ1mD6t7DjpaqIGZfBr3aPQXjcH8HiVL51AcPGT3pTcMC8dcI7XuQ7R0gfhNogMUaObxUUfnBPPCx0_2azRHsMLU9eB-Hvuv8tWs3wdBxnhU4V1KTplAbyiowBSZljvb2VtQVmwHUkN6ztlZKBfenXhsSrnQ5XeeenkGNnCRWBKyy-hTtkGl0WEfo5UR8pVhxob-zzkqRelkLx6btlompo1yABwwHoFdFB72nWv4pCxfnOSYbjkLaGUy6JJ7e8JIldMXafrTnmUMlsz1j0nEhh2LiW7A0X0_4NY_DPbLnttlm1yzRzrCI5JiyHNCxQciIuuiPsmrgwmQUFY6exVgqr7mNkJwqTr7rc2RaOsNgwLeyfBd75BntD9tNVlZxx3PbG4rmCUjg91lIL9thgKr7wcZ4Tbe2hesFlgWzBVN3zylN886p4HKV5LVjwN1PrTfFqhgVvSiiCRccHUTk1Un8X2GQtwm-Usd\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"5d6294ca-eab4-4fa2-a35b-4cc16b59bd22\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-c86bd12e9173\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=36531505-f7b1-43f2-825b-5b7321214560; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/5WP6ZK6JfI1VxtcDNWAL26825MeRN/ovzhtXZuBQoSKSxfINYfrt0dljJv+OGIb5dtRQeLZKCOwDOCznaw9Li+f2Ojd2/TKSCCvzPUSpLcgrcEzWFCGni3l+2/URlKIAlWXpDRP/mwmq3Wq9bvZHir1d7szeUh2imMNXbi7emjfjs78xPBpb2ydKUiV+YtWDqJY4TjcCYelHuHr4ddDyPM+fHLk6fqrwoE1OjGWOPYguKgrw45FY06wonmcBc4vck8xHvkCyBK15fsDzcBmadcVLK6aQUGGCaBW8QeT7AMxx0c7Cz4fiAAAA.H4sIAAAAAAAAAAEgAN//y/nTSIPwuMAGvyhfaHSPvwpaJAuR06bAOX/LROh1K58f1EW6IAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:20:41 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.8X1i4LDMQ0UU1CGCUZZSitd3ZsWpu6NrPdc8wRDcgYE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnR8BacTTR8F4sKnd_ysijPdsoh_VX2aT6d62_RtNgrVcqHO8xeaXYmu7sy4sYxyeYAVdwQOANeoz76JnzuXzosWxWoA4G4P5HYOZTmnFFAUrUJGSkUrNm09EEE_bK1Wlv3LDDYdt44i-iKNgZrjDuP0pq6P_uEBxxoIY9QTtELL9iFlkm8ap7ob91_hK4vHJl5ZmKvcNlUcsZMPbI-9p7ok_MaOl5BZbHNLjLm26PPqX9JX38k_Vpqj22JPNohSc4=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtnUiYJRSf3cGGbqx_nfqMfZDLEnFd7ykxNXs8ISN49QbR2SJa3ko7dMborxrRHvOKexTUWpWruEcin2We30lOFk8__U9L6mKrf47a1bPaZkCO7kkuzzbnXa54PGhufpOpUdnWLi8JJv5sqAo6bmzbrfeA5PTF0Wm-ZAfYNzeGriuiu7R7PpisaPyXkgZHAXw3ObzVZd3J67tefyMtvv18RxCrolsOnV1mbEVElf7eKYHnF2-t76bbe7r_gaMvP_wJSKoXb7L5dMKa_6MgYOMUduRXkeRWdjSzxbjdQ9h-he0FeQBuTtaeVXOCNrL9tjfHV89Y1zjpznive9TFELgotgPyuPmXqmOq-9j9F-siziUzQ1KPhquPt4I86Z89jrfMT2hSo1iaIyg-LPuTMsFJAcAzQricfKLgbZqMnIJGKdaXtchcEs3iGKW-KgbeR5Fn8j4wfH7I70yPHFSKt2_smakkZY0LpF_1UUDWgPsOr1Xa3K4VEe4CDKDkS6eYSKbL1LReCnW4WCuBDr0fHwcQnxv2va7AZucUhmpSWjkHZbPOjq43iP6aqxrJz3GBXCnO8otgjLchIbBYjlRLwqSForOqonNvGxRmyH0_sQcbU8yOhnPD2AKqlbqx3eEDC2YCxEwDdSFNcPozKatpAzVFuW3dlETAK45P20d9Wd2GxsMUMF8TDXhun7B7pFDcUIlyp6tdY1LNQ1rmXMBPjmXVimfUdsKiwMVZQpYpgn9fqEy-egQ5drr2pz7acY5fqan3lDlkU_EJnwAKGNWPdIW0DTpEcFZbodXpJcZFQarYC_nqYKU9RNzgIdr9eXzMU1JwStm99Bdigq06pIzW4GwF59ZIUm8AFCykyPtgWBfHLwlwNvVdacd_PUiw2TivkzCwgy_MYKWvidokKvaS-ayBnwPzEL1ZjYOJQxZmM3IYOr6VStcmRwbFYK9mz6bzKgFyKeeRg_AJORS5XEzgIMafMeiwWlggy3bDAU4C3xX_CqBbKVagV8x80Bqzh84OXJpideGS4535-5c2dHxNBXiwGmmfDlBwXmXweF9-78IQb1jDznull4oWfQIDsDSBmmVTaALVOimid5u6klSjPF02GOieaxVR_sKWVW8cG1lrOQzVSFYLu2Twst3dKK71nUL7DAAxff4WFo8CQrp1vBpoFogPUiy5rYuwUrkKddMoj-DrB-9F8HZPDiR8cOd5D62nlbtx7B3X3Yk227llYU0w43gNSV8rPMcz8-EbxnRw-6n-Jr-4NtUrTDnss18_WtgJWfiBKBV3FbJOXCB1gEZuxS3GZVUSR2xJpkXqm8ak-MTs38NVriCljFbK9dHzEYvry14fpSjLvKPQllAMFWHArxuXJU5_7TYKOFoXO1H0V0hibgIY806Nwh5JqBkKmSjziWSu_oKI0IglvmMtz3zmctUn7m99DLwkA12MN2JTfIIwL1H9iiqaVIxMXTV2Ltx7kzGfSGTb3_FuJIiKxUMa0CRgD7VK8zUZ8F63LOiE0JSsc77KTmUhYVLJ_DB7VmwVKsMUlbeXPdJIFcoaI3JArAnbA-B_V4991Dx3tRTDxdqX_lVXZi2XFsNKlBzkU7bGRw47AOqWEC__3CW7FBkMod5C4iaKy3x0PNUbfHtwN1VRxNwKsPw9atOWaWxLqFrfxEAgUFNYHu5Pozi8p35y5FLcyVerSaDWeO4uS5emr4vQf7KhhQ_fYj7CkVvYjlJSVvpLrNnarZxn1OSAlgilSQEwSTpECX3_2RRnesXQ1oDGYYeicQe-wp97sPrCcTskFZx9m6yijzMAPQGYaiUEDSw9X8i5grVH-7wzFBTQO-E-XFbubK8Aby-tSElV4qgnokuSLQ8PMXZyV7oy6jPa6LX1u9v1nROinSTBaeoixpmKeQl9OH1H4S_ucYkAGPlPc0B7UGXixIvsenj19gDzfpfLdPXxlsyauut0WMubjLXGoOfIlIHYRAoHdPl7O7ZZtnpfNwV6LXS2PL5x-eCDi3JD37xEbaCKmFg_mU5UCrb2L4YzNVCAc6JqE5ti1i49r_XkM1tHefwWZoEzqD2k8cFsfY2VHwkz0dxnYADoK4_Qj6fRGuPe62Hc2vkxb3QncHuWAcZNMVpug8tHwPltEM0KR155YSIxIZwgS7YfwyZUg9vukjpYmgF1qCiHKjd_rakhUPV_cPcU7lxsBaW0sekoA_cfO1ZYbmiik9z1xGmeBWK4FfXMVJNMo51jujkcFsevIuXRy_AiRJdMN_nBeRYmHMOWHPmTkbJUHu0GCiGJ7ozcsl6koZ9Bzn4-Blv26J9J2u4DNsa9QKVap9MKLT00xAYD6O3pZ2sI0ueIXomYi8upMDq-cSDGdWX06ue8v4HyzYVF1E457mRxWtHEyByIla5Z_S0wWTKukWoUEZqSJ106UdbuU-bR2zTs9worKY91mhhS9LGG7mobj5p0yLiquwOoeDz2yCbMOxE2A1dg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVWfiY2DoEEMTA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=8A04E65B0AAF283D81AAED80B4DB48D3; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlrlKLUWWuKoX51EPKiC1jnC9JfJxVmEhd_gt9IydhSY1EQKwQoV6iEaZWYqkV85mZeLWFxhLQQ6wcHq3oFrsANXS4logR_qqS3itAWeMFolCyvsNcbzFE-JcZF3LeJk9Uyn2znn3TloLd7LhVDnoWxJkuwTQxMuzsjPX77hLb5FEqLTe5kgpdX2wXxJK3wqVEgzCs7z33W89gR6UMJPdXtWVYUDVopEm1AwB-f8depdU_BhmKztWHEOZfPEpSpJB1kwqE2SXFm7cd-CyWjKRa9mRfRcjEiEus2EjdPL0AeAUOYGJB6YGSDyeNJ6xy_BUvi_kJcLs12h1ue6KRYkm3QKVN7zNpid-3CDYVO4d5ix3QtQTbxW__HTeZEXxvFBvUaWWkzZDIYC_-KqL_U4u1cMC5ny1j54-l4yvMEF1P6eUefu7-yX7P3f5qeWgFXY0jTQwkvKro1Nm7weesqMqgkjPepOicpgmbYTUL0r_iVg4yW-vMTu8ynWTSBUljAPBT0OV5qWkh6yx-oVTKYQbwPcDRvHTI7hg_FkHGQSuO2qNHVQNJjjM3j_7-ONrNUfTdOYC5o4OlMywCvbDh83hm0SdsIdhRI1h7kh16hhgJs-o1khNaOCwoWgTZQCptM4dM;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVWiiPaDoEEMYg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtl_AhYnR7GPIcqsrGxdrwX5fcUHzH6cc9ImGvW58ZvC-x-m0GB4UQAvL4YJ42wxJjd_ntgsZqX0DqfdMTcQXjfitPArYRB27GMWOBD92xW8lagjC9m_QAWxMxTYoa3gXkKx5A1oFhlpidMtVQHZmcOCwAtdeu6d1oC1lBn8gmDWNj3C64b_a6NwT69kDvgMNKk0S5D4C98Ly9-E15r8Wg2yW213YpSoObWr2DB9HbtyyPmMKV1aAxJThhBbDNwXH6kZGAlBZ3d7I8a4Sai5VxQim16_lgN5DkTdgwyqxSfZAbSeewi96t0OyBHW6zkKZaNZNwCimeadHaRU_iRon5_O0hAbn1fcc1O9QTQRagXVeJleZMI0kF_2fTO-IwGw9uYSv7oB-qZFcrg-4yvwqcGVAU5K4IkRBKya624hDNYSB0cGPBKQTV-gLuQ9IPRZbGdYwVg5P9iCFeQaSDF9dQBnYoiWsxyHJ-e2j3pV4OGtLt80y-BAa8wq-X5cv79BcR_NCn8IwSBVN8WcBOsNsVeX06EDC6c-HXbfvDhRTGQO6ug9A5R2evoSGVEtYW6Nh9Ay9zeZzrx1_FMl1B2pBlcE55-bsJo5-W_Ob9-t1vlCmFwgNpCissYakfXsstwPUBdt254jQPpnzXRoJGFtLr7OmxltiezQLA9wC9jpvv0PaQ;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVWkgMpjoEEMMQ=
     status:

--- a/tests/api/cassettes/test_get_energy_data_daily.yaml
+++ b/tests/api/cassettes/test_get_energy_data_daily.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtltndGVwfzyzzXq36cvVMNd8AsZSnezRT65vGsWhFbFg_jaCBChSq_6f-IcsPn-adoz627OR10aVaWzfQ5chjnCP-dlCrb4vQd2E-ZdxhXhfSvReYDlDoHvTmmDnypOUNRH49cb-wo_V43E5d5xhpGZ5o_8-zvwovgbTsZiUe8g3bWr19OJ_5aDTudZO2X0eNkZCNR5PwgAlTA8ePjFGcfkouX0iHCb7uQS9yTFgBsALg7z0ZCpKgMXIzACVAy5Ruo=N;
-        expires=Sun, 12 Apr 2026 13:29:17 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.aDqB3IgSYDZwvAcgmtcEsKtT3sxKp3AHrkvP9WVKNKU=N; expires=Sun,
-        12 Apr 2026 13:29:17 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btUanj-2DoEEJUQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=f3516cd3-96f0-4b95-af54-93480424a1fa; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115964579480988.NWY1NDUyZTAtYjk4Mi00MTkwLTk0NzktYjU3OWQ3MDgzNzMyZTY3OTQ4NmMtY2I4MC00Njc1LTljZmItZjIxZmQxNDFhY2E2;
-        Expires=Sun, 12-Apr-2026 13:19:18 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115964579480988.NWY1NDUyZTAtYjk4Mi00MTkwLTk0NzktYjU3OWQ3MDgzNzMyZTY3OTQ4NmMtY2I4MC00Njc1LTljZmItZjIxZmQxNDFhY2E2;
-        Expires=Sun, 12-Apr-2026 13:19:18 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=dohXLFePfmoor0IjzhFDGGfNS8tcUTZjDG-r5tsoEwY&amp;code_challenge_method=S256&amp;nonce=639115964579480988.NWY1NDUyZTAtYjk4Mi00MTkwLTk0NzktYjU3OWQ3MDgzNzMyZTY3OTQ4NmMtY2I4MC00Njc1LTljZmItZjIxZmQxNDFhY2E2&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnYjwfOLW-UHcjS57BYvlHWYGexTR87oHR0smxr9NUBToPJh2-9QrjQK0B-aBQ9V1qFzSIEq1tIH_dAwFCh_VvIdikNTPSXuSmxezqofDRQE40_Evh7b6RweAuTlWpDzcJElvMgzfWsC6lQjRVTeSsanJt8DBZ7r-oyKug3EPLs4hF1XuSJX9sd2MpRB_SppjnlY1JcHqyZqIWIqNXv0aFUSwbCWnxYON2ypgZuj_IhR9eHXNcpLkJIlquFEWY-nJWYpDX4Px73A8JwxkAvHopxQQ1g8LB1hYoLnFM-ghJZZMK50l5wGJiQ96HX62yJ3gj1fr8bMh8ltrqpHxXP2eb8pa5CbKl6IFID8F1kP3HnaWG4hL0J5tvGtYANRkFYlJgGo5Pi8OfOBchHns_ZzNNGgI7KWaZDzVtLXEyQnHGqUt_XhrRq-JvoMxcc8g-zRK_lXBusWVyZdHC91WYKovIU3730UVN-wT_KL3maUKSwsMIhOKx-UxZXsgDXQW_Aphh46cucZx8_DFyWwsFpA4UDQyILhGCWhwU6ruWzMTPmt5ViV6QWQ4szVqtHl_sxjML7MZcvxrWscldIs_9AMVp-feFlT_GggyasAFWXhF5hOUa6I04QxHPIShDMJhOHoMVkFxfjMlPHdGheTK-gSQvy\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"f3516cd3-96f0-4b95-af54-93480424a1fa\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-ea4029eca5c6\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=dohXLFePfmoor0IjzhFDGGfNS8tcUTZjDG-r5tsoEwY&amp;code_challenge_method=S256&amp;nonce=639115964579480988.NWY1NDUyZTAtYjk4Mi00MTkwLTk0NzktYjU3OWQ3MDgzNzMyZTY3OTQ4NmMtY2I4MC00Njc1LTljZmItZjIxZmQxNDFhY2E2&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnYjwfOLW-UHcjS57BYvlHWYGexTR87oHR0smxr9NUBToPJh2-9QrjQK0B-aBQ9V1qFzSIEq1tIH_dAwFCh_VvIdikNTPSXuSmxezqofDRQE40_Evh7b6RweAuTlWpDzcJElvMgzfWsC6lQjRVTeSsanJt8DBZ7r-oyKug3EPLs4hF1XuSJX9sd2MpRB_SppjnlY1JcHqyZqIWIqNXv0aFUSwbCWnxYON2ypgZuj_IhR9eHXNcpLkJIlquFEWY-nJWYpDX4Px73A8JwxkAvHopxQQ1g8LB1hYoLnFM-ghJZZMK50l5wGJiQ96HX62yJ3gj1fr8bMh8ltrqpHxXP2eb8pa5CbKl6IFID8F1kP3HnaWG4hL0J5tvGtYANRkFYlJgGo5Pi8OfOBchHns_ZzNNGgI7KWaZDzVtLXEyQnHGqUt_XhrRq-JvoMxcc8g-zRK_lXBusWVyZdHC91WYKovIU3730UVN-wT_KL3maUKSwsMIhOKx-UxZXsgDXQW_Aphh46cucZx8_DFyWwsFpA4UDQyILhGCWhwU6ruWzMTPmt5ViV6QWQ4szVqtHl_sxjML7MZcvxrWscldIs_9AMVp-feFlT_GggyasAFWXhF5hOUa6I04QxHPIShDMJhOHoMVkFxfjMlPHdGheTK-gSQvy\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"f3516cd3-96f0-4b95-af54-93480424a1fa\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-ea4029eca5c6\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=0b32a3e5-294e-4ad9-a8e5-fa0e6abd03f4; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/VRufXRaQD+VBjib0PJbrScXwRWsDfiI/WJTcHwL1EO7VyBDYcnk45BHoo886K9ySDYFZin2oTiAoJE6jQqAVcNBe9FXaax89hkIR08lxT3joOvHzHE0XbKorLHKqNFrUy1faUlQjC/uAVtrzqPsoejqMNhDiW2p990aoRxjOxkki9p0GiAcRSitY13FxH0VykvBBw0e59TNc+2zTU6q1MUskK9UY+ussHN3QhkcGChoOUeYvMtzVq/TNq70UdKp76b2EPKD6u2vZlGxNRhaYo2vMlAh+CIdNyim/25IQgnNCUAcQEd7iAAAA.H4sIAAAAAAAAAAEgAN//r/hNsUls/Q/AmxAIh0mqRdHfeC0N50RakdFozLW8rgeCYYP8IAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:14:18 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.aDqB3IgSYDZwvAcgmtcEsKtT3sxKp3AHrkvP9WVKNKU=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtltndGVwfzyzzXq36cvVMNd8AsZSnezRT65vGsWhFbFg_jaCBChSq_6f-IcsPn-adoz627OR10aVaWzfQ5chjnCP-dlCrb4vQd2E-ZdxhXhfSvReYDlDoHvTmmDnypOUNRH49cb-wo_V43E5d5xhpGZ5o_8-zvwovgbTsZiUe8g3bWr19OJ_5aDTudZO2X0eNkZCNR5PwgAlTA8ePjFGcfkouX0iHCb7uQS9yTFgBsALg7z0ZCpKgMXIzACVAy5Ruo=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtm5KF9hiSwiLTwpuxKJ5IKjRmR6ChmMPiYHRKd9pGXNSupl89_OwHUpMLVsbRIpWF8v5IqkV7fC0Z0cRZ_z2_uV9ltRreFrrapjcXsO5z0ddKjns5tF6vKGuwsi0fplhxYCAOQi7JJEkSAb3U7_E1a4l5ud5rPqJ8bxM9tbo1rlSUVH82IM2mGpfrIZGyCN6XtujTwEQJr36Tr6nss3JwMcNOH16O1mSsiqEahaqxHBvKdvTRkqSvCpUdDhDeZiLYQIb5lkLmlVad-jb-Mo1Lj0DI8tcUC_nCtl8AAgPH-OhW--W_hT826tcMhk7gHTcPGU_LkZn4DQ01FDPRbw6n_VkyAqMeCia1Cyk8gJ5GirNGqwEWjwM20KYNtcQ5vA4F2L5uhy6OZ4MbQF4wzBjMfuMI01_rB6Y_XUmhsxGE7BVzJw4NXtxHx9JIjET_VngQ8mH8maAKqBxqccJTrqLNCpv2eQc8zqJT66KJmJGbhbCA_lZPUNkQSZ2RK0EGjJl_nn947dayJgDpgnx_tWGZxpr8-HvzvRfo9MUGWq8RL7aQfPOZNUnUVX2EtWQYBASdcNI3OrWoZ_qhZuO5rzlCW4oD1J8G7JvFYXl1Sz7A7xiYIDdpb-thxCaB0wNlDxaPjml-8NOsU6wIhKun2Q5sNDJkni0N99IOOeyFRtmA9qTOoicd9SMWbXv1oDapVgN_zwbfV5lwk3roFa004eL8QOe-nH39uhiBr-Rq-RjcEkEujZko80-uW0kMmY2ShCGyfDO9-sJTdAq3_9emz5jFMNadbxBGT3TY-DpR6T7dysFi6uwIFBF0k1ws4_gH8B8Yik92SVNt8_IhRinq7npeEAm7ip_BhzUPHgFcwGXmoI06Y_05VQNIU0oHABp4bfLsyVN5vcwCwXGCVNrhj7nQMnnZzfewkDan-4m6SjmTf1BWvwUbFvTAoM_Wom8pBn2HdhAVSyADHZIq7BYc5wsj8BUloDcJAZ6jr_1ptQ0txjNbcK9eHcqAYWdc1IRwa557TafmPerIe9CEppH2sMnBtr-kuqBQASq4nFVQUFKmyhw6WkS_Sht2l2QYOwdEi7UAMX8XFJw8WzqXRoDHWB9zthLSX7Jrv1eCYomvvFsKqqfAmKl5rQxQAxK77kn6oum8jZkNK2WsIXxWeqKJ_wI95EyG5cPYC_bTwOjUnSdyZqGj4L6mjP89d0ktmDUxiOA9q2RSh4jwNYqeuwjyJYUkLCDsfZgs0U66yjzqiCYKsF40ECi_UyGQ77b_LSy1qKhIWkK_exQder_6IwJFbmQ2Bjget-l4KvVQj73zXvAq6IfRKnpBvvcgNzusp-ldSZO7MPra6d0X6v_MuwXnELgj_jU3K7januqmo-anf0GII1P3tVfwQG9NRci9CFzlwVLIS-UF-pNYBP73F-abC87W828gAbvtGJMTUW3rUH6K1rLI3qaxxbLPxteX1cNTBUQ9Dc1fHb_eLHF9GxLFQ-itAfSaD9mLiHXaXt8kdG-QgGo97JIcbrtvWmre2JYFAfRIhxnSmtOA-kkIyc8o7vHOzebnqqRYIoghk84wr2eUeNogNaN9Ekd4Y8KZGS-8Bg5BKcSYe5t4mpNkWAHwNN-Pgq0YEng1SD5bZdAR8ZFEc_D8ID2c_uMmxZsVhmRFracXAz345SZ6v_Hm7FN6Qkxolgy-eL_vj4KUJ3SKk5L795mdN-C9lMYIa9db5wrfVRP7-AHoEMzZw3NQhYYILbkyhdcVjlYBDyh9UNs2c1UYriq-Do_xDDuyUmzZbA-01FHK00M83gMnVKh_BP5R2WMSfW_T9byJavFSzrFoU7IzBY0vPia8N18IU-g8tWR-bU0fGTd9oq4hVn0ze_sFOVUsQL90nFWv6G1nTp-TDvHdlz7OzyyTF1V2cB2XL9x0XSoUpLPGhU8E1s1ECsdK9hJAYY3rtoRj3kqAUUn0l63slF38EibQdMcA9sTS7VSfV6GbEnGTMWzdt81ykn4Kog0j8v6uQAQHFRWiHZGWUrpbxnMCJTHKJO6THuHmXSVnNOpB1jvGUjjVGl1BW8LOyjTmQI9LcWlfAcgI22Ikq9svDWvFjOhYaEXOtsp4yvfV3PP3Eubzf2HV_d6RwmPTRdIv307_GPtPXwtZZHI-GuLJ4eIm1pwshmmDUDxwFjy3PFXJ9MFES1ZZqbtF3iGNh1WOaxFXWZ3849k5wixFWEz4zal8zlnyuOxH1k3a6xnzWel1Rs9yUqFaqExLzG1SwGqH99vPgqZSaEBr40H-e5hhcETXNfHbsV1CNXHGVuFpVl4C-pkUmV4BRfGXoZ-ECCzGQAL-WNGMJOsK9a0Sl8g2RrHnxo1OWfKJj-b-FG3cHwh4yE4il-Azc-XCv5wCPgr6-aU_6FhpwVRMBO8VWYzIHdBPZBZbtgK5ez79GmOcAzLW3xt5xHN9KUbOeEuhQCVKHu_yCjL_yY37M2CUOe6YWaRA;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btUaujXyDoEEJuQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=E7DFEBF5288104F3E3886B0B1B06F976; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtk0Y0PnUJnxUaCw3DWL_cxEObtPczcEJLA4MnyyN8aG5MyKKp3m7MMqJhIFiiUQdnxZWPIewB8fak3pT4SHQtZVpi138uV53po1T-bZZinEADyC-u4A4_WqjqJOVBIUjqISTa0FCqaJPCz9_52OK8qtRlwmI0epnAtbJWjUGTjQwP7gOpHSPbg7480MgjkplwBCvfeM5kMCsG6p77ur0KsbbdWE8JGVU4aKz0uKUuJEo98JEU6Oe4teMWwJwpZCZ5B-Lg0zKBW0oPUSN8oq9EmZBtcZt8axSTPg-nXeeSROkNgwE_uQggZXtOXpONHSeP1QAsvRqaa1CL5Q7AaiNh4xCq4deCnWOcnbk8IfRVg8JEILgrG5FltYx2A1oOiuuzuNhXbexdiVCtM5PfY3_ckLs_bMVofCxrxrBJI1t3RJ2zvdGRZ-Ra2vHskAWpHZO8H507fAwEn729qA8DZoP17vlxzIlYxbIeHXXK-9QHMtYb-jvnEBY9hASEx7t_iD0bxpy0RbHJbGfBoqa46q92JXxHicEOul7QAdz85wT0DO_GfwtEtEI4fxabvqtm6_J7I0RdMtabi8oAAmEcOQTWyfhsptEBfIVk6KP3rbPVa8ln66Jhc2M05HEwh-9kkDAJk;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btUawglpDoEEJEQ=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmP0TWqNExrUq9rlQxoKdFuppuDTXZ-93DR22DDEc0Fb5FvyEC5880O_XHk30rxJ3YqCYDMJwsEwF7ZGxCmRpb2Q_AC5WTfHLHrQrUSDc-V7CA9tgYVPvt3_mWCGusxypmjh84uNV959k53_dExpSxYFufU4G4PssksEF3XVzvekVy6X7agqAlF5xONSWzWlnfMH6GKQXmOav5vDBJDbbhOgEAXQlP3ghr4W7_rhU5q6UdmN1EocXTNbIOKuUIK-XbW_biRgZURTfISYK6qgY-el8l1JTFnnpaWQzCfEOs-G1mO1YeudT0S_uusUSC47dL2kzxZ3Cm8dVOO821aLwhbnQajOU56MrxnwGxBdE5mDo2F3pYrO0UyGW-hqaq4dRcNqdgwlhLQBKpyUReDFYkGkbbrrdHG5hr2madyPM79yoDGe2K5LAT7u7QJSOaRF6pQVdlGBiPRgDw7MtfvWHFiwFVZjgm71Eo_W_sTEA2E1xFqlehTRuIUpqzFT_Ci-tbnvGh27hTsFU_rp69EhwJ7yNTQC2Wp_j8cD7PYjJTW5vH1c2UifggxtskTr3CR6K9JuRQRrGhAToLqtkzZjscU7yP5LOMKRRLG0dPICZls0FeXj_qzSnij5BtTx7szByjNMEskfUpx9XqRcCvGorRTFwb2zGxMncZ1JS66TiXW0g;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btUaxjTvjoEEJQQ=
     status:

--- a/tests/api/cassettes/test_get_energy_data_hourly.yaml
+++ b/tests/api/cassettes/test_get_energy_data_hourly.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtn_0seaA8BAT5ilVyaY26CZBdMScF7cpStFn-xdW7s-ScUbPuW1i4rxmaxE-4TmP75HSfiTM5QrEByarlmzBdWHT6kBB9AAidCL9LQ5iAfkTfO3q9ErleLtK7lfydWvG1kmld8JchrdtonDVYcQcCLb2iVKh-hJK-2xau380O2-XsuttwEiRFwHLR_g-QrMRVbZZR6WqekYfdoNI39427Jkj6a13ep83jz2MzRAnBnL2zv5STwBhtDDofHHWk4PowE=N;
-        expires=Sun, 12 Apr 2026 13:29:14 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.bzUv-fX4_JsyuPGO6iEzcQiPDS1EIiOBa4uylP9ReiE=N; expires=Sun,
-        12 Apr 2026 13:29:14 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btUaHhm_joEEJyA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=fe2f9884-28a6-4675-a939-7138020fc78f; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115964547146265.YTQxNWFhYjYtOWI1ZS00OTczLThiNDItN2U4NmY0NGJjNGVhMmI2Zjg5OWItNTYzOC00OGJhLWIxMzktODdkOWE0NzQ3OWQw;
-        Expires=Sun, 12-Apr-2026 13:19:14 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115964547146265.YTQxNWFhYjYtOWI1ZS00OTczLThiNDItN2U4NmY0NGJjNGVhMmI2Zjg5OWItNTYzOC00OGJhLWIxMzktODdkOWE0NzQ3OWQw;
-        Expires=Sun, 12-Apr-2026 13:19:14 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=TdfDGDXAukxp19FMCSVpdRQF_zFMrI7pSFUWsNvAbLo&amp;code_challenge_method=S256&amp;nonce=639115964547146265.YTQxNWFhYjYtOWI1ZS00OTczLThiNDItN2U4NmY0NGJjNGVhMmI2Zjg5OWItNTYzOC00OGJhLWIxMzktODdkOWE0NzQ3OWQw&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnhJx4tOiWdxiDSa2Z81GEVXEc96Iuf42SHsH5KFUgNv-S3LdykN-DE9gQtlhDiRnSkDflbkHFTJhA1aFnBGnqF4R1Bl_P1nlU6tjI9k-2VSd5LMP8YduvX4InXLe_b6rpwYbha2xQw6hJWvrjslmIiE3QT8qUUh__wo12v4cTA-zE-ZN4ruYBBt546-OoU4vzZxrWdJCBdFF5ZPbStg5VysxqgWP-QEviS3pOgJzIs7oCpaPumE5C-l7e-6KkFdKHM6dai-CeUHCe_rK8_8Dme8EI8YqUalyqAvXszqN1hHDQsQAayTPjStiOPXqHXgPqfgevuOyRMV_IeTTEB8DNI8OwBnsLKSy_zJhxzcrFu7ur_qRXWLDgYDZQ5jhqYvMbAYcQu8Q5yLciwQKgYium_MgZRQbfkAbwY_zJ-T3Y4LnW_5M2GZM5mq_SRFwSeBNQR308NTT7kh_ypPf0O-NKTQfhn9EQrP3n7wJ3mBe2CMZR8LS8STsz2Gkke2snIGMsBQrPBffCAtro6ihRUshfGSmTJnJaQiTrArMc7r7FlKYv9orhV9h37WVcCNWcpmZwtog6hjRQea-Km_x1FZmXXNN1jdKTzJhicjmDITV7AfBYsOPgHKy_4cBzwepyJw-L9dkf1Ie540ndAJFGKqPG6\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"fe2f9884-28a6-4675-a939-7138020fc78f\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-5f897c0ce1e6\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=TdfDGDXAukxp19FMCSVpdRQF_zFMrI7pSFUWsNvAbLo&amp;code_challenge_method=S256&amp;nonce=639115964547146265.YTQxNWFhYjYtOWI1ZS00OTczLThiNDItN2U4NmY0NGJjNGVhMmI2Zjg5OWItNTYzOC00OGJhLWIxMzktODdkOWE0NzQ3OWQw&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnhJx4tOiWdxiDSa2Z81GEVXEc96Iuf42SHsH5KFUgNv-S3LdykN-DE9gQtlhDiRnSkDflbkHFTJhA1aFnBGnqF4R1Bl_P1nlU6tjI9k-2VSd5LMP8YduvX4InXLe_b6rpwYbha2xQw6hJWvrjslmIiE3QT8qUUh__wo12v4cTA-zE-ZN4ruYBBt546-OoU4vzZxrWdJCBdFF5ZPbStg5VysxqgWP-QEviS3pOgJzIs7oCpaPumE5C-l7e-6KkFdKHM6dai-CeUHCe_rK8_8Dme8EI8YqUalyqAvXszqN1hHDQsQAayTPjStiOPXqHXgPqfgevuOyRMV_IeTTEB8DNI8OwBnsLKSy_zJhxzcrFu7ur_qRXWLDgYDZQ5jhqYvMbAYcQu8Q5yLciwQKgYium_MgZRQbfkAbwY_zJ-T3Y4LnW_5M2GZM5mq_SRFwSeBNQR308NTT7kh_ypPf0O-NKTQfhn9EQrP3n7wJ3mBe2CMZR8LS8STsz2Gkke2snIGMsBQrPBffCAtro6ihRUshfGSmTJnJaQiTrArMc7r7FlKYv9orhV9h37WVcCNWcpmZwtog6hjRQea-Km_x1FZmXXNN1jdKTzJhicjmDITV7AfBYsOPgHKy_4cBzwepyJw-L9dkf1Ie540ndAJFGKqPG6\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"fe2f9884-28a6-4675-a939-7138020fc78f\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-5f897c0ce1e6\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=13203360-f524-48c2-a8e4-b444ff5acf0d; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/A7Ol/WMXRLgYopwMjtecU8TrrZtNhQn5cKsJGUZ/AFIB+ulMLGe18ejnNh/1/SLXCNYxDW1NB3dBrc7s6x8rtvxawzT33Z+kVyg/l48sYWUW6m5EnulBaBQbBFcoJ6x0oSjjcb5ECZR7RbSbs/c3hy0Uz338c+0HaBIWd9Q8cww9hU3Wws/g3BjQjEVrPb443ajBDxX6S5Bvn21hCWTft+uBexyLVtdDdHq4SUdayMGuJPWkbOjaV+QT8IUAW7nIla6wn40euSdDJn/IUx1ogA0I2yNF73XsHSrSyYWgE/N41I9zC2riAAAA.H4sIAAAAAAAAAAEgAN//M1MS6m6e0OfV/O1hEdxkZWMFZD5uuC3zWPvwnx5vmeY7w9ZvIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:14:15 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.bzUv-fX4_JsyuPGO6iEzcQiPDS1EIiOBa4uylP9ReiE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtn_0seaA8BAT5ilVyaY26CZBdMScF7cpStFn-xdW7s-ScUbPuW1i4rxmaxE-4TmP75HSfiTM5QrEByarlmzBdWHT6kBB9AAidCL9LQ5iAfkTfO3q9ErleLtK7lfydWvG1kmld8JchrdtonDVYcQcCLb2iVKh-hJK-2xau380O2-XsuttwEiRFwHLR_g-QrMRVbZZR6WqekYfdoNI39427Jkj6a13ep83jz2MzRAnBnL2zv5STwBhtDDofHHWk4PowE=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtns5MYs9MhluKQWTriGigWUBc635_N2rmz1etu8h0Fjg-25vrycCrJ1zxm5Ut-VkETCvImoD740XLQoODMfKv9Tt0DP59bmUas_8qocJRXwsU92WRcdLyK0XoQBE4nB3s0SuoBHqsqi49qMO3jMIO6tMvmgk_ea89jssT12GDVgp1ARXhp7qKtYw-voGPVHB738JHaWRRNAVkd7rZ7eh3a1zK6dG6QlTo5H6fM-MDym_WFMQGvKqRR1DsJqlR8YBS7qqsz4Zv47e6t8glZ5EE6B7bBjVEWPb0QOb6O3JXWAOe7dkue4a3GzEGFpNv7vKb41kkgmlUcCsCO3ctqS8_rycO7Ha7cAr8nnc9mj4KUrDEgFvpbKPjBv48bmwOm5_Ri5EaqzjNtNeoWyTcFdy4_9APuqg5bMcnlLDNfrVis4s4_M2O3nLeLeBfp1Y47DSn0AnfiSdAonOfwAPS-gym958V8x8AnhkpgQM1CK4B0CW2LKx-rWXpUwNij-qLrqE19PGMDXApr1_oGoazNYQNRw8grn5by6iNWt6stMH79ht_O4rkFmzqk8Kv4lrrTVCC7wsIMTUJKP7EdHoxRRqv1NzjBTV_jjoeefwShwhnGoLKaif9-Fp3fxMFuviin8f_wrgw-_WYmsyduhPIUNRvxFyWt-2YVQcOP1BnlBagVzimI2IC3Ru1hwwJPN6Rpa7kfza-yWcybD3gyagDNCvUEmS-mlQMvicQjd2B5CegQ4YEjnGUJR1reUcJFqquoW72taggQTleIG8aeg74ZP5XJI7zo2hELVVgQvjOQkOxJYHIjvXbg5IECCCOcn6VEIT_z1UK-oUW13WhlTKELyzjAtr3ZXRV9JC0tOzU_OiLSdtuVbwc28qtumdQhP7RGZj8Kq1yAaP7hQm-7sjnDM_SXZfcqy00axFEn5lFu8GEHcHQX9VMZV098y4xDb_e2HcEzkJYwAdipwZKbN7rXANSLlf4qnvB6IJobgN7Qajh6uSkKHB2VOVtN9IuRKy3KySkAEdidmZjNvianrh-Ntr5fYKidGGId7rh2PG7BCTJCnklxomqNx_vs-K_CZWG70NBPfgIqaFCjfc_cPujrDKSheH9pYHf7D6HMqyIJM-cMkTYvGX-dN-SC4lqkekyKWzTwTFmjico9MS_mWCzXCYD6nuNG57Eu6lnz1MwUtJIu2T5xIAtruguU3J1ei02q5jUk41o2yBJHzX--zyOHdBeYHftFNCwwZsUMnfXN4c6d0ct3XRb5LDmn51a1CmxACQ2Iseqp-YUGjd3lSz8aA3RlA3zTwAmPaJsiWUEX6RtPmJTwWZPVfNVl98qD15EhkwW6JNXQwlO2ccKAPnpAmXF2Ya53bhV0R8o5dZJ3iok2X8x3YkDi4oL5hHXIZvgt4p1400bIms-WGcmizHdxPZhWidBb6ohjbixpP4yr7dCggnmqa0EmnKTgVFz4VXi7aKAS6mOXLfbKzFbhEcH0iaWBJZro6KHuZQyB__cjKdBSd2tS5IcU3IsFnREbTyetIvaEg_0NgzfkMItqosdn7Knga4EnKi8lgtXYv8tqNUEcU2yRT0_P4fcLc7--ul_nqXnOlWum2ISEX75XPzqbZhRkINReqsvnQiA7rX7vfzkL-ZbpN7Xq_LY8IP9flXiOqzZcM6x8iNjgBGPCInyrmnwrMjB0N5YfvkSQan_lyCs84POiydW9_UNwhTVBcMQFXwcUH6B99af-Y8LDGvwSC06dNUQEeeXQKRFzGQo1Jx1VrINt72iCihj1cjx6FrzCd8a283dtkXYOxaFU5sRPA_TINNSdGBFNZdYar3hc-Yy3PHgrrkSF0mvkHiQvtAdgbWwZQOOsOYtJMDhUilf-fah7lCUC2MjQhFQ_q4hwBgOFTdJp85YqUyZPXV_IriXB8hphJij8bdqlGTLep1kiX5wj3g8SMfFRv7ZpDfd0mXJ8hmS0BCI7-shAwz7IvnlR-ncIu_CEVMl1Kc6qEJINd5caIx_5IdWghNfb7t8Oa2LVNpPUI8AJrKSX67aAUaMb1ZALn2ZNpqWyIc1BAssCd0y5j-YuuLJAxasZnLnMRCBpFTMVuDM-JJs1OQpFn8IvOIwr3VsRGBPmDaApumxf6D8HpOdxr55WyjC5R2GnuUVB4qlnOY-MaiDA0-seuVlNG4B0b3d7P_LmACjv4XxmwlnanQMk6iN6yCNjVKPILbNqsJ5BzN7NiNSo_KiwYdj5qO8trfuqr6-or7jMW5RZvCkJOKXJKoVgzcc4ElerCumarNOusjTs8zJ129PxdeOflf0Un3bjIvjgIcgIInaHgc_GxO3SPWWQ9JRSuljhuTxKh8stbkSFsc53MCJjFem0-2zEbBmlN_3i348Ng3DfuCWFSNiWkqNgNHvz4Y7cFBNmOwWKUZA-66cd026xRZTPQYdzx0hCZk-I5ISOoJWZ2Dpe5QoXP411jNIqULOHUdfKRYg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btUaQhqbjoEEJyA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=72B4CB2C79E2A96A5E16752B8E617AA2; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtl_wRXhrI-tyWpuKM1TStLET_SCjw5ITbOR3bqKkVq8_XtyS-s1NQ6oq9iSlS70uxU2rrIvAQI1X0wzxLrhfcWmFzqfGrGQTdFVzM4_1XZO7zoaUsjirdTYlQMoE8ioFgkKX1Ht9QH-Y6eA0a-tt8U5TTxJFbTFvQkj7niGCP7M3CfAb1lbbiO7bDWAxCPY9y8u5pDaXTYlCrFMnzBzwDX3SRWSdqngiathdhW7ar1UrIjRI2eyp25UyE3RKaq1pfVaIJONXEmzgE3X5lpN9cYA3oBsGoA7USRMZugx25ZwaFdg_KmoN0m1U_v74ZDvOGXH2R2q1ZbKYDOusQkoDDlNz4dBGtdjldEZXTEPnmBpDjGmfjkY7u0VKuXBfgharzSELfNoonqvbQAn9eWhUYHYyrTbeQI3QVElHYtQsRM3wFaGU2A0LJWCHb4Gm85rr_a0RpSXRHPRJS52_2A2iDoabfAyNlIBAaf7-bjzisZ5rP9fmX_xMFttimya5VmvX5YDNsvqGtVnD8c6Y8gEoD0KAhbGVAYjKIHqttlVXGkn7ezlguI4McCxMCwztUNrrSDMLWhQ1wIWfwb44zVkANKN3Ug3PzqEGxsD053Gy0VRbhI-7zm3tgi_ta45pAgmkDo;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btUaUjYGDoEEJIg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtm9t3VKMg9lrM2f3TdYhA7qzUxoGNf5e46P7fIc2oOior3w3CvDRk81powgBvCqaGJmnNG5exKHXYgfMNMBTwNkInAva5tzeE2_IV9eYoO3xtYFi1EAUpLFZb-cP38FPB0pX_EA0cZD-OMjpewLlwhThmdgIeBbuRQK6daxX0yeOUoMm9gEOW5bSbWJQdvawNfaG_Ta7tQg_bo-PBFYFsP41i6yWAogNbZ-B3bWDqwxWwmTbyw0z9zDXL38_g5-cCKflze3NMwrAGqWfe5jBm0dgpBOlUUUzJlCHkYpSagr_Jqe-YZPn524tk-CgcIoA8wesCVx_29gYztDKgqRH27XO2vqNHz91WRwcEo_eeh4WR8s9M8Jca0ljvJrri_lbUFDoj1J3RspMSdNC23DnJw_N48foK4j4XPeyaOfYatGszuVp88exCrK4_gwqaEB1bhyJ5CLt861ep9e66tX8tr2QotAGmFnzBBWMDF6F9pFC8nrN3mVrc18y0xgllr--CW7_-jVe0Eg_zfpyCuTTmPmo8C0kjtUa2iLZBMNHhvcjyywZmTQZdzeHvyWPcyYSavf8nKRP-7V2gUd8FcCSKJ2a85OdjDioatu2kImuoAOrrtbFgQ1jaNcsTN4crnFBvhJzrpXTXQy2cOvhVq6sWFW1IyR5krh1ilXRbuRbxpjEw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btUaWj7xDoEEJtw=
     status:

--- a/tests/api/cassettes/test_get_energy_produced_hourly.yaml
+++ b/tests/api/cassettes/test_get_energy_produced_hourly.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmZFRd0pMA29vH8V0wMm_au3V2rxobjLTX701rvGnRqsVdabt4M2Wi5-19oN8Y4Y5imv_B8GRuPsS3Spo36pmuXPObe7E0K5003zxjgT8tfz-sC6KvXfLjmUsg6C9TIy94zUEjh-qKCUfcILK-XZ4JloNu32tDwri6S3nDjIZgw0LUF8YC_yVzyHj44ZJQnHqD7qQXS5Oqdry_XNTkcmBUw3TUU9D1MWFZUehfng_OOrogBfg5XuE6Nzx6ShG1unGE=N;
-        expires=Sun, 12 Apr 2026 13:35:43 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.l2cKLTgkPQT4VTmxaParNKffM9cebZP8viVECR-14o8=N; expires=Sun,
-        12 Apr 2026 13:35:43 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVWzgxHjoEEM0g=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=bf1a70a1-3b32-473b-84a1-48be654990fe; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968431645721.MWU4NzMxODctZTU0Zi00MjQ3LTg3ZDUtNDQ3MjA0NTg3MTZjOGY4ZDE0Y2EtMjY5NC00MDA1LWFlN2UtZmU0MjE2N2I1NmVl;
-        Expires=Sun, 12-Apr-2026 13:25:43 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968431645721.MWU4NzMxODctZTU0Zi00MjQ3LTg3ZDUtNDQ3MjA0NTg3MTZjOGY4ZDE0Y2EtMjY5NC00MDA1LWFlN2UtZmU0MjE2N2I1NmVl;
-        Expires=Sun, 12-Apr-2026 13:25:43 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=Z-n6D3D7VLIzr5g1pinVAYeQVGT5vhaf_adA3wzDt9Q&amp;code_challenge_method=S256&amp;nonce=639115968431645721.MWU4NzMxODctZTU0Zi00MjQ3LTg3ZDUtNDQ3MjA0NTg3MTZjOGY4ZDE0Y2EtMjY5NC00MDA1LWFlN2UtZmU0MjE2N2I1NmVl&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlPoIAVlw1DzLBGZyWpuaBKWpqqInPpBZwqzNnvtcZSpkBy8EeKF-Huo5I3G7MRB16yxmEcgl9Fs7aj2y2fwgk31K79sel752loryPr8Rnrn3vHbiDkOcSm59mX_W9GQtTeCMWtmqRduxcI_QIXEiGOEqNQ9_KBGfxt1o_6sTCMO-EMmQfs3cudtTOhuqiyfL5ephBgJpOH1KuhCdGpxjxxM1x0d45AsMyagVsgiFX9wbtjxDNG-MfVBUnZKH8yqQsvGTrfzdRTXWLcLqGiRbZvAlEz5xwzfaQEYb2eRHJiU6-kvi9a6silcKZ1RftmXQLdTu9fHTqX8Bhn2CvTQWbQbqHZSs0kAHdf5wFZ6hWzFvAMQsFCEN0d3Fx0WAmFjmSKsdjg7B9lWpUE0LXj5gto-vSJbitE9NBlxA93fAiLPsHV4leO6GIrOBtYLlouw7PSCjD_6GbhhkpJ5fFa3yd6oqrB6776i-wgR9CHYD1Fz4SCH2CelPX57eRurmKbqKyOXeo9g-h5WUo88EHGSdv35wswiKTMIgFNylrBAKwkn2Fq1l8ut5kGGIbDINeNDpUpmNgAgLkwpfN061d5zzYM31-GfKaUifB_pYcTFaLGR928P-mZUKo4yTcUM7rAE1aYqHFUJVv8-frsZu4Fh-VC\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"bf1a70a1-3b32-473b-84a1-48be654990fe\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-f83273f2b622\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=Z-n6D3D7VLIzr5g1pinVAYeQVGT5vhaf_adA3wzDt9Q&amp;code_challenge_method=S256&amp;nonce=639115968431645721.MWU4NzMxODctZTU0Zi00MjQ3LTg3ZDUtNDQ3MjA0NTg3MTZjOGY4ZDE0Y2EtMjY5NC00MDA1LWFlN2UtZmU0MjE2N2I1NmVl&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlPoIAVlw1DzLBGZyWpuaBKWpqqInPpBZwqzNnvtcZSpkBy8EeKF-Huo5I3G7MRB16yxmEcgl9Fs7aj2y2fwgk31K79sel752loryPr8Rnrn3vHbiDkOcSm59mX_W9GQtTeCMWtmqRduxcI_QIXEiGOEqNQ9_KBGfxt1o_6sTCMO-EMmQfs3cudtTOhuqiyfL5ephBgJpOH1KuhCdGpxjxxM1x0d45AsMyagVsgiFX9wbtjxDNG-MfVBUnZKH8yqQsvGTrfzdRTXWLcLqGiRbZvAlEz5xwzfaQEYb2eRHJiU6-kvi9a6silcKZ1RftmXQLdTu9fHTqX8Bhn2CvTQWbQbqHZSs0kAHdf5wFZ6hWzFvAMQsFCEN0d3Fx0WAmFjmSKsdjg7B9lWpUE0LXj5gto-vSJbitE9NBlxA93fAiLPsHV4leO6GIrOBtYLlouw7PSCjD_6GbhhkpJ5fFa3yd6oqrB6776i-wgR9CHYD1Fz4SCH2CelPX57eRurmKbqKyOXeo9g-h5WUo88EHGSdv35wswiKTMIgFNylrBAKwkn2Fq1l8ut5kGGIbDINeNDpUpmNgAgLkwpfN061d5zzYM31-GfKaUifB_pYcTFaLGR928P-mZUKo4yTcUM7rAE1aYqHFUJVv8-frsZu4Fh-VC\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"bf1a70a1-3b32-473b-84a1-48be654990fe\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-f83273f2b622\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=cfa596d9-ce21-4c09-9d6a-98bb23dc78d9; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3//eipdjKP7AYkpteAnUIekzfurj8tMbZTVGPmySHgZxf+j2RGl4mOajqD3BxKgpujMQ4fIElnyUXrUl4ln+dstT/eiw6BELgAM+LLE0XKLs1NPc2YVOJOoC3ybI6WAWWgEaglgyuboZfoNt9mN0sVlN9YZGaccCCHzTTh42cSx5vuP1EiL0x2mPKSGi4EoVVJA4OWyvmT59GjGqw4j40gADn5PQHicKrGgAbnWuscHWgpbVc/o7Q/C9SBtChBkbW3Ec4Fmpeq7cFNYoWbgvQDI7TdGsKg2BJAexrfm2CX4N6miCiZUcviAAAA.H4sIAAAAAAAAAAEgAN//yh2YXx0uf7KCxZBKQoqnvV/PV7VDB9tmZvIHmaDQtnc6eqIXIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:20:43 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.l2cKLTgkPQT4VTmxaParNKffM9cebZP8viVECR-14o8=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmZFRd0pMA29vH8V0wMm_au3V2rxobjLTX701rvGnRqsVdabt4M2Wi5-19oN8Y4Y5imv_B8GRuPsS3Spo36pmuXPObe7E0K5003zxjgT8tfz-sC6KvXfLjmUsg6C9TIy94zUEjh-qKCUfcILK-XZ4JloNu32tDwri6S3nDjIZgw0LUF8YC_yVzyHj44ZJQnHqD7qQXS5Oqdry_XNTkcmBUw3TUU9D1MWFZUehfng_OOrogBfg5XuE6Nzx6ShG1unGE=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtltKlobmjAbDNtSuyT4r0eXpevpoJlo0XMYaj4QKSKLtaCCEPj5cJfTpGYjgSNEUgwDolumYzWrwwDLHrZ4aw_hV-bvBSPkjgDUlrLibTCihcSptvosGj-Fl1Ih5chiFQDA9SuoGeOSxBJ3MPwuK2W-h6Lya5BmupAuzmyU-hhxYnN2RMWv3W4rcIrkM1UKLDb0AyTTDUCFgLgSqDjaEZeisxPS6togdQUXbVCgArLyYt69hqIqr3h0kxEsWn5IFj--DYLg0OAMoF91gV7n1dg09yKHEKaIAGSa5EJw0lLaZZVnHg5eaMjFfrhIeY0GyQf9NwgoNDmo0cEqPeCIIQ2X0v0n17Zv5H2zMNVastt2IrFWcf6AcyTPS8N8j9Cp7yMSAPd6KbYwNumhzNJUtUhxYhjKPF9rAU3ids9yxueKv60uB3Pg-7qGTsjjze0SZG_WrEWrpPmIHFuttIjvBPTkal9JRwTQkNeIX9iydxewB7hnKAbrtf2n-eLFbxDoaUF0zjuBqxFSNppYKbN42b6cASQFkhrxMXQjYIODo-R9aUr9NFi8Mal9QpNFkm1jcN0hisSm844evx8T91m9R3ST80rWJy5qZi3R80D1JB9PjbemcvPXd0HrSUuV-nekvzCQcqI2GvCDAZbKz-KMSRtw0r6SdXdjrIXyZ0xTwYNgRapoOttvaeI6cyFV7PgqXRo4hUoWmGfaImo94lIsWLZlEZXv7R_EDtuS2m3aoGT3oQWVON-4CDA1aH143_hym06cKZLsfe6cV4Zv9imzBcSjcYk03iXtFiNpj68C7e6D6iM84pfUxOylJyqaVPmSIznUdIrYBq2bAqkq5Cpyr_gPIxeCLvISmqeDeigPVfRufWT_efVjn35v3WFk14hc_XWKXxH8SBOQJl88xPViAN2WQxwXsddtvWAxnrMZrC4F29so3m9IOLsVQTGDV5mcuCzH-quJe9emmXRD8AZJ8eGZvnT8onFRXe3ReqR3THiEhoz3Dbj6TKO3XRsPVZuZTKcnDlelrEKa0JDeXuxEKjsEU2i25iQZ0fkiFIBedMspB4FnJBcacUGa_Nd808z2z7Em0xWwrJ8ANyW0HnRz9YSbmSVfV452bDHMGiCjacJsr5ea0uBj0wJd4YGQVnYkMRQU1FtYHIQBqXOE1eQ5pU4PShb9AoaGTlfyCsIEO8wDDRHUlZKzfw4cpNwe58AAvmOfgfJmVE0EgX5vxK_xwyulSgVPdoVuhHyOZ03_BzEULxc6B-G0jfJQwYPYBjAns0RLiqXTcrKe-z7MAg8Rqm2p1dBmQPWu5eMo31UfdY38zOMgVeI_nsyGBhq2csncvbMJiCQ4LnFSEwvUeWWM-oq0t3NIluhKf9kjNFtBCu3iPGbmq08vuM2xuZhqyRVHTHtrGABTwBU8NZU9BAI5zR5r1ISB-NFT1Jv_QqLEIQ3f54wYBLW0c162vN4jaxoGMYz2zvrtBqg0ll0c-LcmqPVd3UPOvWuR0o4pkQfy0WsXxOf5trhHu2BSOrXjvmeLHvcVNOlJvkLqmnjeyWCc3UB7VnXVNQ2kSLHVRjuyLWEnfQ809TfX4WUjB1AStHXzaBzx-uptgFpEMnKwhliVOMnMo3Z4kqkihU5NGNgK9MCdNQ1DnmkdeGvXrzdybU5mS2U64qGSG2fHCH5GjV_HZjDqLHnXdyFAOSiaPHijjCOLyv6n5yaPfkk-ElZiebclu75AkXtyJzirzEyhaW3TeQux6RfjPAthdnWVrVE-Ky5KYroZLFZIxL1kJDLcfY2sjj4vTRZ_GA7iongirz7GedEvf6eaDxCPGI92OydIx6b5sbiZsZVS_isgBjEtTKn69ipSaaWKfMgfUm5lSaW1-yBWzkiUtnp1xFxjy4aK7frkjgesVDxMktkUkjw5SVou0lls2dPJGFedyF9YJgToyhZMmh67R2ZP5sr3VbsdBUFzT1OnGzplRtcU5lhBNw3CPu1r0mINBK1N9d7WBeLVbXdK9WUyrEZpDNJLxNH0BHtIl_SBs651SPP5U_fiPjgok71mOIH1bNAnxHVwBeJTRaMm3GUz6ztgArjrWkduDQw7-NsI4UZz66leYRlKIj7a4Xkm2qiY8t9VEqKbJ_k4XBBF2gHPtWbsTptJLsFkTt1OlNX4jaWyt4OwZMSLogJDIAl79sQsz6QVv3V3TfdH5PfYeJ0pxl6Mcj129u0z_CriitCneK4fGLNkshJWu10XkZFWWXMWiEm_Tq5gw1AiVYeaHddZcmLgplXhwZqQ5YwIO7PbymbYI955addWBEHAYeZ-wNfXfXmLVPUYIxREDZoNJVNNiOu5BdzsoTDA5czcc-ALKa81K-CsGHnHdpkx2GkFO9e9p5N5FU7LlltiiLz9lv0GCL8E8Y2qJCr5vOb_tofcUjA2oG9lTZkYZ3irXGuFi_00JyUriRg87G9vM3bu6o_jyrvKXPx3BvUZw2o_Qg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVW6hYwjoEEMgQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=5652DC275C0D5DAE6A385563EEE3C8E0; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkMCFG5gtYzvozpwz_gMmFviQ-hHBbw24ojtIZ3Tx4eUnHZU9gmy_QE3koZcU9AwkI67av_ULcvX1_kz1h-DRoNh1ldbTnLMvnhGEWrf6hwBdVJPv3zXrhXLrgbuzFUVlghQgN2H5qbFPOkqBWAh2akqLsJEzX0tii-t_3rfUXziab1hFYRUGBgtbYCRCXtDhI0FFrVJVRSdC7Vhr4pSekwh9FHvSW6WjmphlEiILQDGbkAG14KT9tAXQI4GboDTOlfF_glnz3Ro4xsxGgjSBFYbGJoQGjS6FAe3J8aWVfp4NFdNUPBC5NaDvPMS1rQubz8QG-QPvorC5InFQ9swvRfTWe4qnbWv-oz8Vi7Iek3s8tkvibUlsRs9jhsEJzJ9YzoqDofQb7DHt5tKqJc0wQ52UNWiBtSR3rD7RBlwR2vsqpeMLNFWcGU1r4WTFWB4tq0uj28oJAIYnY2FDi0FuZDq17cczc0KRaIgX69kYluYUYpseqoCax8vN9c9QO4-_zwjoPZppfBPPQAXbvVcVoyawb8SIT94bN_ZVGfdM-HfTypJJOpov83WkVaumhUmjc4BzTBNY9-y6ajyxGQjVdl9_MnAru8sg5CgINVfUSB6zcEPJlia6mvm1N5VsRl7sc;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVW8hi4joEEMrQ=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmk3PN-Zi3kwF1YGUv-OXmCS_6srZTQ5Uj3K9WbsCwiZCNYjMG54fJyWvwa6liui7Ni29ek1zTJupQSatxPUXurNsV2A7qatibfo9kxNR3t4YzLgRBRLZoNXHSx-Bvts3QP1tKXovcOn4lOSUsFe9aupmyPubQ517y4kUXWEl8HnqvxOTtPgagivsLCzxWqQPnj2oL-kluBoMisQcakutt_Qg6nQfk_UTjHfwn52RfCcFt0iXtlPImzYicC_O1X7FydfTrB_3GpwM_5kX1wYrw1EhcmxTblf91g_VVrB8LozV7H_jgKtLRHlKQqH_HmddQPQXhPIgCkrquwt6MtfYispiBXrZaSXO96YZotjzMvV4Heu6UchWRmYHPc8o--bJFUn1QC5h-1BTSNLPF_ov4kdPUUbDp-N7Mat3dh7htTXoYa4OoDScmQQteg2tRbVcpojKUNoK3PBgYuidmZyPojOe8Lzht66lztxzLGBwzr4JChU0qTDBX4UHWheNDu_yhHryyOERq7yng_5-QJ7Y2VMUPFo6WKglRI2w-A0FYwt_zE2xumflCzADwnwxLKTlV9XdMxkK-rJ29lqnqy_dsM_Afb3jYmNedimO9yjyubc7A5M_SlzgRQxrv8LyD3DgYQrLe5AmJpqSfE2JCECf7-F5viNbCOqaIodxdGPdvUdQ;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVW-gg4DoEEMXg=
     status:

--- a/tests/api/cassettes/test_get_outdoor_temperature.yaml
+++ b/tests/api/cassettes/test_get_outdoor_temperature.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlkXe_QZFd2U_VN-_ZuE05W5havCwYbx7bfs909ennQJuEdwMyk7lCDZ3Im6vMBM5Neu8kS9YR54M0G8lk_W2jPBFBthJj6BOj9jT3rkuGxxTayAcZjKsdionSN_cWXSLaRYQsCZZFma9ud2j5NBQRLNFFh_hyfDnKdGrqpxIMNN0mFKE9J8iKEzAgvFJNeaDaA1bQ-mjqaNMBqICrQfitP7jJb0PplmQ5VMTpinc7sxlhHNrut9O69sS1CaSUuEvw=N;
-        expires=Tue, 28 Apr 2026 19:05:24 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.8ayTLmDPgm90FqBs7CRlW5Xr6nk-RxbzPVxAu71SgZg=N; expires=Tue,
-        28 Apr 2026 19:05:24 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - ci0pqi_MDoEEPPg=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=82d8a87c-940b-429a-9352-c8cd3aa4d3f9; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639129990246334636.NjEzOTg0MzItZWI0MS00MDVlLWI3MmUtYTQzMzMxODAzYWM3NDEwNGQ1OWItNzZlYy00NTI1LWI2NzYtODM3NWNmYzI1Nzll;
-        Expires=Tue, 28-Apr-2026 18:55:25 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639129990246334636.NjEzOTg0MzItZWI0MS00MDVlLWI3MmUtYTQzMzMxODAzYWM3NDEwNGQ1OWItNzZlYy00NTI1LWI2NzYtODM3NWNmYzI1Nzll;
-        Expires=Tue, 28-Apr-2026 18:55:25 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=dseR2WnHHLb1S3WALcvtmG4TaKYYQqGOtJLe2CjMu8M&amp;code_challenge_method=S256&amp;nonce=639129990246334636.NjEzOTg0MzItZWI0MS00MDVlLWI3MmUtYTQzMzMxODAzYWM3NDEwNGQ1OWItNzZlYy00NTI1LWI2NzYtODM3NWNmYzI1Nzll&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlRQBIDS4QliKvlwLwt0bn-BD56drPgIQaUmnZMMmXq9QBAPTSfuh1mvHkR5fWk6u294R7OQLZhwFVkkn4URKtl-7hYkP4NacMoF3vDAHeih7IsNUvKJ1YBm1i47lFTeWzKvi8AM9TK59dqT_PBiwBqmAgk2om5HOl0klrNykfR_tt7O17shksUZaYF1cwaxt0B8qMvs9D2bRSvuuxZld7cO2JotzTMG3Kir5kfh8h-u3BLlNLeqF9BsAbLG5XF7eUkr-Yt3D1kg_dTjfNoiQhwQM3UaRpAyxQYASKAs3vTXoO3w1-SFKTzIXXzV5we4MJdHLZ2kjhJ0watvp2N_cgSP-SrSMdUA0fqEu2x8kKHmmHdXPATFQUjHUI-qrOqhp0il6iNokQwX4mMoYNe8HlXq-gTJX268yA0KEj3bWVIt2C8TKO6TEifmMytSLPEceBb9cE5po80TBL2kTUG_sko6-rXfc8pE3Et1NfwkrsOeS_Cy466RoZBbGGbAYWpCSNQ9bFsD0YmIVu_lHjmP2sFWnQJVh9tsthscZ1XCGGXXEQwjzX3h6EfBbQeolZo136_VnBKq6FNqI7jFk3Iel-vdiMcgsH4pMhO1PfwK6Q7ukfFfC6l4OdeIJqKOfcIiho0cVUZ0nWGWO5ovs7klCvS\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"82d8a87c-940b-429a-9352-c8cd3aa4d3f9\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-81692ff0f3d4\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=dseR2WnHHLb1S3WALcvtmG4TaKYYQqGOtJLe2CjMu8M&amp;code_challenge_method=S256&amp;nonce=639129990246334636.NjEzOTg0MzItZWI0MS00MDVlLWI3MmUtYTQzMzMxODAzYWM3NDEwNGQ1OWItNzZlYy00NTI1LWI2NzYtODM3NWNmYzI1Nzll&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlRQBIDS4QliKvlwLwt0bn-BD56drPgIQaUmnZMMmXq9QBAPTSfuh1mvHkR5fWk6u294R7OQLZhwFVkkn4URKtl-7hYkP4NacMoF3vDAHeih7IsNUvKJ1YBm1i47lFTeWzKvi8AM9TK59dqT_PBiwBqmAgk2om5HOl0klrNykfR_tt7O17shksUZaYF1cwaxt0B8qMvs9D2bRSvuuxZld7cO2JotzTMG3Kir5kfh8h-u3BLlNLeqF9BsAbLG5XF7eUkr-Yt3D1kg_dTjfNoiQhwQM3UaRpAyxQYASKAs3vTXoO3w1-SFKTzIXXzV5we4MJdHLZ2kjhJ0watvp2N_cgSP-SrSMdUA0fqEu2x8kKHmmHdXPATFQUjHUI-qrOqhp0il6iNokQwX4mMoYNe8HlXq-gTJX268yA0KEj3bWVIt2C8TKO6TEifmMytSLPEceBb9cE5po80TBL2kTUG_sko6-rXfc8pE3Et1NfwkrsOeS_Cy466RoZBbGGbAYWpCSNQ9bFsD0YmIVu_lHjmP2sFWnQJVh9tsthscZ1XCGGXXEQwjzX3h6EfBbQeolZo136_VnBKq6FNqI7jFk3Iel-vdiMcgsH4pMhO1PfwK6Q7ukfFfC6l4OdeIJqKOfcIiho0cVUZ0nWGWO5ovs7klCvS\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"82d8a87c-940b-429a-9352-c8cd3aa4d3f9\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-81692ff0f3d4\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=73ba3e90-4ede-4c92-985c-6c23e2f389d7; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/jHgEd7OYpxs+mD0XINqPhp93X+m2Qko77XgOSY7UCSp938T56BWbvbAccfvua95qELiaIdHAl5H+bwLdnY6z2PO6feHYToJBw48F4PgiGYtpJkH4jfzMA4cR8IM6HJ6gxDbDoMVkYmm5QDqx7o7Pl4HLmuJmoySeoNG7alfg//EAQhfoEQeffuNZ8KW2Q7vsHurUOUsKYWkjfrhM9apaNG9tiqD2UeRh4PfJW01KW+NFrTg79I3/XvxA11l0zCINrUhyi2FhslNA49TVeSAOOpUN4Vg3VVexF5SNeTgHfXaNUGP0qrziAAAA.H4sIAAAAAAAAAAEgAN//W+viQnOhwanNJUXZJ04CjYL+ize01bTB1D6+zV9pDhYYqIgvIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Tue, 28-Apr-2026 19:50:25 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.8ayTLmDPgm90FqBs7CRlW5Xr6nk-RxbzPVxAu71SgZg=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlkXe_QZFd2U_VN-_ZuE05W5havCwYbx7bfs909ennQJuEdwMyk7lCDZ3Im6vMBM5Neu8kS9YR54M0G8lk_W2jPBFBthJj6BOj9jT3rkuGxxTayAcZjKsdionSN_cWXSLaRYQsCZZFma9ud2j5NBQRLNFFh_hyfDnKdGrqpxIMNN0mFKE9J8iKEzAgvFJNeaDaA1bQ-mjqaNMBqICrQfitP7jJb0PplmQ5VMTpinc7sxlhHNrut9O69sS1CaSUuEvw=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtl7QKqyjfD368hZxXmhcBzXRnRaxhBHLNAcvv115Twl9Ap2XpBuE7qz03OH-3e3ThGc_mv8U_GqB_6IquiYQytRxacniq417chyUu1Dq4sFpGvSCaZUOahQyUODHhVOdw749FPyA495k8GMJISHa95EeI0dk6UmJzkoK3WyuomQkIwHMvIHQo3gGUGBs1CK59DbLhLxLEE5CalcuC6BFDYichFoN8PLKdqr4ylSgb5k46slAz-CeRhSNwFk6k6FsKNUtbkFrts-UTD3z46mbFB5pck3kGc1rEWThY1Vpt8Zhwm6rQ12UIt0KooMhkovizL7ofLE8VZuLBY5DGd_QvPKyobKeBSRZd9gl7-waUD5kalEew-wBnJz8d3QIkZ8e2QsWNuf6oKBYUOfB3mZdki_jTQFuJ19LOiXg7amEGiuJ0NM_aWXOetVrXS33yHn9E-hTgllFmfwN-wmwy1xpSAXfSutdZOr0Xf9RH5G-KnNexoaj87jJkr3hv6ZR-Sx1_B5JjaoJJK7UAB-W5B7P3vfV8gVWv3Zy-22fjNR-YK0S8sAHaqxz0SzwytRb9iUXxl7tpSj5xecwaEoOErh7SYlfhNqFws1px6RQswWw_k5mAYqilD76BvbhSjCzhcjXHfYhLaVDHSVq9RgF2cQZCo9BXdifCmOle6h5At7N-qE22mns8TonjI8KUhvU6vumCRVxGZHcgfszbyStuu4FPkCrNhxsgd7emMl3lqv4RDDtvprNeVVPw8zeHeYdM8jsC3I8jQL0mRiLM7Ht8W2ggOGzLpbIsZ9gM7H2_e6iLSl_FpDruOeYeB2og0xtGz0d-lit77HNfnzwCMIPbjCIiw_JiCYFBOP-lCyMY1bny5KhQqvPTYEQkqeVwtr0m-Yiu1l2hzzz4Q1Qni8KQJDOjTMb8vl5740UuLoReGwv0Ad51h7acoP98mQjDaYC-3w1Tou2nU8MfFm06GO7IsyHs3-q2CwJU3Ag5vyoBzcMvbaA3G7zQX-HDkc5KH3et_G7apg3A_-1UlgMsvLCKxQnKgsX9yPUB7TMzgHeA52zu7BBPGrAZAX8TT6EI9Z5j5jYSP_huNdO5V-FtkQ9OqrBfvLW3xekF_2Ysv3WIn4mJ6ivVWz-6vEVKeNPNa5ZxuQi3vUvMj1ehA2LMUtToll9bpHmRE8kXiOFW1jrq_WD8hPRX4Jk7_733umlMFkTlOAlVWl6BvtCNr3i-pZ-pnV7DSb_zSqFonXQ_EBcoMJ8T4PJUPknNvZSU3mNAZljqwa4FcCG--GxoaYHGKzNWGzIif0Z3aT5CaixP19ekXlMJcGBrG74q_sCg8TOL4HNMTd96vOgJloYitiJ2cg8vAYhnAxkzNFdwJT_vKAFH3ag8UK43HCfLHMEyWm-dK3NYuuAhKI1eieAyXlvjNHx3cxZPcMSOv4CqsY1BLRURQd-02ZwgyngR0q0IRUIdBWw6HH-_wfYlyRTQUwe5qMQHb7BUArDRPiHHw741pk9jMeXY78a_g1kpa1xcsIbmfcQXdKlrTKtA1TQsHow1BtSSnZGj2FtrCU-MJiLWLDJlIxYc5qgtWI8adgRzc9wxMQ0EburpNZzYTzSj2Q43yOyzh7g7sUbKug1cmGozfM3kpRufTXWUsshqs-tc-g8vY8lRLVaM50x97ZlozMNwejfA_G546mZj5xOtOAkBqS10vF5A2QRhYG-JvYeElRDKdfZqt7VprC06qBeoShV0l4oDkiNcpSywEIhrByhBMLOhPIaPIfakVv1OHqV4xjRBxs6h_AWA7_MSIkcF7KTbFGNfKI8ifvx8Ns4glyg0OGpEVql2eV_uC2FA9Q-3tiHMR-aKz9SR8Tjsk39SInyZjPjr7W2XWDjkVdQzm0xp3iekCVdE4ps7vih7P_o2pKZj1e2dKzksiLmt3g3lBCPlr2s43AxoEnIciuI8f-H9i4kLqf8SzNj5v6FVSmoH_EIRtEKRG5IS3k0sv_cgTiGfww3LD56ReGUQ6AVZIFZ7bq-yMCglucdCzu--yvx1SJVztCULmhOw01DB3s-RamFjM41IwpQcpZu74bIRpMls42SdYWHxENfgsuvymWPNs4AZw1P8uPIFGUk-jcBkP_uMLhzeH8OdZcr2s7IEdTig9FfK9O16Ei5FTBHRrGHdAnhoCNRFOhzMa-fmsbE_sZr1PX0PChq7ITP7Pumq649rsywNgGK-hF2ruu-690g0E7V1Q5xOiHnL6OXULddyZnW8serp2QSMAABUwZZDKH5qIhyv1rVN5HPHA_dM_s9VXDBBeX7-FrvldoG2Tayo_F07M4P73d2mMSvLlLlK6dkwdMHZaPYC4GgFQmRCFi-tbEa7I-Db9SLQpoi3-bGF_sFOeEuSvQrnjMASaWwIZvpmMbTxF6ULyJyTW9FXZWbompszfZp2YRVNqEogBTtcbTBM0fY4b8pXbKLQ6Rl5shxMQhBVO3U53o6A;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - ci0p2g_SjoEEP9g=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=A1691044412302E2E9BD2D93A67449B3; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtke8Ax_qtNlQomhLGCOCfS-o9TgglW1zbkdsitVvXOyfCvp_YNCQnR_8GkLpre8-8KVV-qrVDnqvZ9qF1WY7lvRIVWeG2njgRavc8q3UB0SP8a4GsFBEH7A3Kl0qAHkTaK0MORrMSNHrNQ46E9mvr4TPlWc2ookOa350EYctt-9lAheAFqMbW_2hrvIlyu7sxH-AQPqqtappjjUhB57-W-ftSaPUbT0yY7xVkwCY7riDFH1GG3gw9Ht9LM50TqZqjHUT-DP8pZcxezZE7eF2ddvwdpnGfttwVtcFGwWJCSX7knJQ6BO1AIV9myA8reZaiuUo26aBtfJWpTk9dUZ7bsWKVdJGyHvZ7itJDqqLCy94kRCc3OFiF0Pwf70D9_-RD8olGz5iM7-nkMjIFcpWk2exIIXO7_YWHpv7jLgzALEgxxZFSEk4etX63WNxxEPsIHXhp0wt8F5ucZ-2S-N5rtZVa9EWX6H7FxSPqg_CFZKGbt-c2hwV_ck68JbvfGyxZfhEqHIDIiB75tjRsqII2Jy6Xped1d_EapXY3UefKygGPe9u-T8jqa1Rg4m9UVcQ1AjvyPlnW8LWjBDlp6W_9o44VA11PQO95Qsn2Od3DKtuwa3q8xzrpXWejDZnzmwEOc;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - ci0p4hAQDoEEPjw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmbX_o5I8LN4C_O53D0cJbR4WQ_ujam-08XAxQj4OO0hS26A2ZZ5B2a1Afw5MNDtrVoCsa-SsNRLmjIBZWJ22uowpUSDwl4f_Go_q1FqnKG0IhNvcLSLsuXfkyVReEH41PkD_Ja39u9Bf1gHoWChPEw5PPAnFT7pPpqWyDslqWHlmAalQeCvvttyBe8PnVmjYB3-K1XUSRGKdInFJd0RMrqBfTzaNEpTV3TV0fGctKVuMYJayLFRmewi9WhvFm0ILfBrEmrK5XIhElWVITaxZPG_XJ9iwIbhk7yXxx8ZRe3IeufaMugw1gjZ21aoqJwO7BXNnyeN6H1x5DmAB1SIbx3qKRW8rBbOwYWs7ExC54-VJ_-G2gF6qW4CVaz8X3BMWBM8b5LnxSN14YI2JuFxO7GgWKGi_XNSyxoCmEMVR8jDWLbBZC7lUi7mBfbst-dN3BNJiOSIwWKYbhhMQXLg5y7z3KgrydKpFbHzTCTatcnRzYLmLlnaZDiCqMPkBRopgTuT8VHQQjy1ExG5ukQl1ExzKh1elfS48SjskcCkAXCl56iSOl7qSKy1ifFTGjEMrgXozMtybZv0EmiE_4SZj-L2NHFLRhLDJ_bQGmVoHmB_17GYpYGHNpZUgTR-20t8rwEJjvCLYQwoAtGEIVkZ61DOdytA6rYsZrJZ9xt-3bM9w;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - ci0p6jkBjoEEPxw=
     status:

--- a/tests/api/cassettes/test_get_rssi_telemetry.yaml
+++ b/tests/api/cassettes/test_get_rssi_telemetry.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtl3F-m0VHJd7tSEES1zl0UdO-pwkJer6AUSaHXkic56AWVCftJsDO5tiqUW5StbkJr3hkRhOFYTdi5sSVVIufFU6aowHqGJkLfscQU7WdUk2WUpHKaiBurW7npQPBcB_AyhHOcbKKJAUgDFqb_WqQ8SOadW3wgbFcZHpKdQNJOFkQfGVkFOrLQ2r9Su6kQB7pmgBqQkH4RYDNPQQx_ocd98dbQNXOj6ohHSRY5MNj6RREIYjuRJ5XpoZfyUI_Nzovk=N;
-        expires=Sun, 12 Apr 2026 13:36:38 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.vt-c0KCIJCSl4tX53HTs-zGIUNWb5UgtQB6ifh4HSoo=N; expires=Sun,
-        12 Apr 2026 13:36:38 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVfdi2lDoEEMrg=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=be267150-f75b-4c76-b0fa-84d617f5edd2; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968985306551.NDI3ZGUxNWQtYTU0Ni00ZDE3LTk0ZGItM2M1NmI1MmIwMWRiYjczNjUyOTYtYmNkYy00NDZjLThjZDItZDJlMjBjMDJkOTI5;
-        Expires=Sun, 12-Apr-2026 13:26:38 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968985306551.NDI3ZGUxNWQtYTU0Ni00ZDE3LTk0ZGItM2M1NmI1MmIwMWRiYjczNjUyOTYtYmNkYy00NDZjLThjZDItZDJlMjBjMDJkOTI5;
-        Expires=Sun, 12-Apr-2026 13:26:38 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=T496QkC3CmnfliGfwvsAb95ryeMFhhWXIN7YlV8Tjpg&amp;code_challenge_method=S256&amp;nonce=639115968985306551.NDI3ZGUxNWQtYTU0Ni00ZDE3LTk0ZGItM2M1NmI1MmIwMWRiYjczNjUyOTYtYmNkYy00NDZjLThjZDItZDJlMjBjMDJkOTI5&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtn8v6KfEEOy_pW4yypAc-9mANJrIP49KjCM7J51WEGFbLceU4--eEo9YL2gsJvTYIu_tB2DghGDCGMhdVZ4563JR6Ee1nRjAIKYH_8WnnqiQ52vk-DHaC_qi13Rs3ODnRyTobH2T4HADfUODDXwDTVgXBapq1xrwhhojMotOSkHl8rR6DQecg7gJ6Rud78iMDjlcb8pv2sFNYyGcuJgH92LuNJCNuRcuuGvaLkP9wExoUWYdb_-zJowezQS-nFvegWRKREO_iILcuCn_DhB0B3MrUPSMcgRFKKfljRkgjBX15rWzl0wtfpNaSF31VjhbQbhTR_YAZwgI5kW1lpUol_qF2OKc_HGJHyZQQ7_40m-SqpyQnsOnH7y_W9MtEGHlfPfzrPBYzjL-gburR74nUZ3QbfBBwL9osBnN_2k7TkbsJLuyphQr6ozt6IYYPzBT5FCiD-ZQeLQ0xegdtt9kZwp9PBQIhtxLO3iLzoXYlgq8v_WY8FyMx5ixjPty7FuZ8lkLt_axu9D5gm3esZYeFbQmT7IML0xqVZbnNJydlCLRWI35zULX9EAIA0NetJzIyNThd0exhEkbbn90de_VVxxmo4FlzNatS2Ia15QzN8Ec111YQ0lY9EjI7qtekbQulYvf8JBYh-_GsN4upb5VC-f\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"be267150-f75b-4c76-b0fa-84d617f5edd2\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-fb8792c4f413\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=T496QkC3CmnfliGfwvsAb95ryeMFhhWXIN7YlV8Tjpg&amp;code_challenge_method=S256&amp;nonce=639115968985306551.NDI3ZGUxNWQtYTU0Ni00ZDE3LTk0ZGItM2M1NmI1MmIwMWRiYjczNjUyOTYtYmNkYy00NDZjLThjZDItZDJlMjBjMDJkOTI5&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtn8v6KfEEOy_pW4yypAc-9mANJrIP49KjCM7J51WEGFbLceU4--eEo9YL2gsJvTYIu_tB2DghGDCGMhdVZ4563JR6Ee1nRjAIKYH_8WnnqiQ52vk-DHaC_qi13Rs3ODnRyTobH2T4HADfUODDXwDTVgXBapq1xrwhhojMotOSkHl8rR6DQecg7gJ6Rud78iMDjlcb8pv2sFNYyGcuJgH92LuNJCNuRcuuGvaLkP9wExoUWYdb_-zJowezQS-nFvegWRKREO_iILcuCn_DhB0B3MrUPSMcgRFKKfljRkgjBX15rWzl0wtfpNaSF31VjhbQbhTR_YAZwgI5kW1lpUol_qF2OKc_HGJHyZQQ7_40m-SqpyQnsOnH7y_W9MtEGHlfPfzrPBYzjL-gburR74nUZ3QbfBBwL9osBnN_2k7TkbsJLuyphQr6ozt6IYYPzBT5FCiD-ZQeLQ0xegdtt9kZwp9PBQIhtxLO3iLzoXYlgq8v_WY8FyMx5ixjPty7FuZ8lkLt_axu9D5gm3esZYeFbQmT7IML0xqVZbnNJydlCLRWI35zULX9EAIA0NetJzIyNThd0exhEkbbn90de_VVxxmo4FlzNatS2Ia15QzN8Ec111YQ0lY9EjI7qtekbQulYvf8JBYh-_GsN4upb5VC-f\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"be267150-f75b-4c76-b0fa-84d617f5edd2\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-fb8792c4f413\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=9b8a0d79-5f9b-4990-b657-bdfdb43f8341; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/5ar0UMaaIuZpvYlrn239tOxtrJ2gE90botWgG6FlpFmsyt2KFREQJo54CsgY5mX5nIcDzYctosXxuLXT6Hlg/tdD+SxD8xYZhvWi3z8iWRYIqfNEfQgHNYO9R5X5OaSWfkxUELK5Lq6ZHScAvt7iC1t+MA20BVu2aG8aJVxlkwnx2fR4qx9Q81ScByDax4OqkwOULzHgVMkyaxgao70rWkC9PXbD5WUeND9LUkZyP9lXAcDcPFI6gij2JNZGQXthVTotGn8cht5fGbTXyvjhAZY2XmpNCyqcGzYQlYOrKqICC7NxhdriAAAA.H4sIAAAAAAAAAONL4V///fOkgBmKFrft5k320PfZd05ky9Ekjj/9EZ6cXyMBEoVNkSAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:39 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.vt-c0KCIJCSl4tX53HTs-zGIUNWb5UgtQB6ifh4HSoo=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtl3F-m0VHJd7tSEES1zl0UdO-pwkJer6AUSaHXkic56AWVCftJsDO5tiqUW5StbkJr3hkRhOFYTdi5sSVVIufFU6aowHqGJkLfscQU7WdUk2WUpHKaiBurW7npQPBcB_AyhHOcbKKJAUgDFqb_WqQ8SOadW3wgbFcZHpKdQNJOFkQfGVkFOrLQ2r9Su6kQB7pmgBqQkH4RYDNPQQx_ocd98dbQNXOj6ohHSRY5MNj6RREIYjuRJ5XpoZfyUI_Nzovk=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtnPifCUtoVgWD3gIinuKUt3i5YfFTHOCIikB5O403mctdpTp23Yj3a1bFNkPYLCF3qdEeRqJzEK0ESBt1KFWsn6PDS3ktlo9cfkPaJy0i_OIXnmLMvF3WvEi1_wvqUFM7g1216VLz91mMp_4Zv6LnP15AbtmuYJJ2mo5N3JAvHnSZA8Ik2_4c8sAmrxAzcOdIRCJXC_RcgoAetnybeV_JaRz2m1GEYiD3JNm1TNALgiH8CxJ1ypYpy0XCRDqZGQ8Lit9pavaWeAq52QbeXWUy2FlnZCqVAhIQpEvC4d5TdpwqRfovFM2USwWQgQLMSLASL6pVDUI6ctIS-8gfo4JZhNJuAnhvWkzCfUthgQJnuXmvgldMZkUMzE2NYeS-pjcGK-y4m1AIW6q_N_2LB3RqnlUWCCyrIKfL967bjZWxwM6UkrOCE7TrDFlNUhTZM3amWoe6NywmmBz3XFzMAPifBdXlHGjPCwWRJVc_My0ff-byxaGZpLJH9og44SoXu8hfQRa1RtAAwwW4QHd_QanOB_KoOO8CvFV-r3WClOoKIrQ5invLTCv35-H0yQPUFE0oMBazoTHccGC0raaDpL2YxQyqDDni9VIibCyVaW0dBygESRKsLQdFsW5x-q-7RFOSyHl4-1S9m4wAiPMIov0RPiScqrWhasueioUITe90mfCajhQ2jc3ViktghQivXz54yp58dhAaE_za8HHas3jbYIhIK0lRiNOUoS8AmiRnRSxJiHax5iRU8OvLWiF6zDDzgG2g_W-lYIR18sThH4SED3mnX3HcHN25K4EMPPbqtk0xNTBEtOFCILp5DAZoZcitITviIwzPbORwF0AG9ATzXKcMJN2FqPJB_-acyZ4yi9pbdWL6PmN1GpD-en8dFbwm5LpH_9q2K8LvAlE_rHbPeI79Ops7J2zblakICy7NkKw3TRRR-iWA9PWamNrkAazOg2sW6u7mSTMxIYpcTlKA28rjb7462aOE7heiH6UcLKTrnr_iXLrByg4ZXOczcnqHAUIGh8WlCVvmYAgCVNe9XI6BV-QjpNS_drDC4qhIrk1SMhEIpWkGhDkp2L-W9c16m56oAE5XLLadsv31FVuR6YYtotDUViFpzmpWFhKBuxcyMb3gkgx60QS_a6eTT26NYx7wzgS2y1-MPrS50H6dT3tWODX5U9H17LxECNldv6iPCbmhViVIOpHsDZf9iamfr1zIriA8oyz1F-0n-Jve2plAtDOb42Vl-a9qNAyVXAU3PJ_YPbAT7SkQ8b24QG_RDarOWqKXMQl0E1Hc0hUBQwOnZu92ccaT5Tv1rXDB0B_ddpwYCCusSj1CRX0XD_MCWXIrqXsXLd8nocMgg7jgnmpYFgEZ-Vq1E_p9_E1jfO0m8qB_iTr5vP1Lcdp1I1Hr-lEcqhFpSSC8jdqAkxXhb0kkpLUk5J69NNeuRof3_9uZhZa6L_XoXsrUVz7VRw0m6SeesmrfvvdELAFpytR5kMysmGvTU1rbHsK7hYmzEes5EhJQnnFAFxCFOoNU1ZAoW8M-ekWL7XolDlodyLfuTWbMi55awrKw0IJ_fKgS7gg5pLZ6Xs7U8DBSm2UXKp2oxUVzHMMzvxWt4xTbYN2CrTwsWDSOqrdgabEtYBeCxHLvnGKz-I-9wDSr3PJdnsnIEwf23h4_vyigwqVwh4UuBXcryG3QnERr2fMYs0cWkxOCWBwrXOQHLx2HmsBw4CweVQUC4Y1qIZCr3lzNxoKwGNGaA1LH_rs-9E6MNUqEYekSOI8uQbTrgt6XSdVcsN5Qm-A0zcpNEvSYH8iST0YEX6bnZUNmxtTJhFFYYTEZN7CP8pkpLpZzZb6tVrd5NZcAZb1s00AXa-AvMHiOeAPTMXhD5C3fEwzPB_NbpScEWperw424tKtqbgomXcrQr2h6Sfl2zZS4plUimuD8Hi2G4gcANSrFZV-ZGcsYweMKNiXiJ19lV99CFSQhSFkV7lPm7c2V-IAEalfwxLB7O5JTXti5rt365WIMS1Xp8HPHdH_NmAu8Ptsv_jJXsIuELe-3mSoKb5Rcc_JT0oq8tsXhhpe_I61NpoFy4vnecNHJvwwJWKBZaWSfpmnpL25y1e9KIjTxmp14Re0rONX5UBmH5rekhbpDKN48m7ojhFm9kcEexicCtuOLT_ygx7I2Dio8N_vcP3d4hBnPGnfISPyjU5bUd7JSSTBW6fWsIrkX3ts1ICklrKX3wAs5-NIHohUl_W0ey67jid3iL72GLkpyBiNu22a8YiiyTsO8fEqnZjMwMlB4xl2uMwf0PLrBFvTX6go2rToWF0hJNEmiTcZiRlyM6hvBIulGIIr0DSJMhVox94EI1B29cqSsp0qZrDMLBpUC3snsm6_2ZJE2rS1Dc33D87kZUf19-p92RF2JW3KYsuROYKaKhAJdAvcNCiMtUPcHfIq-464fidpr08UfIEm1geEcvS_lB5i7KxW0kVzQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVflgtVDoEEMYQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=C90A67E6E9255F49E037814AE0FAE83A; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmV4YBzgfnHjY0coxxEjisnT2U4gqZny8T3WzfBYUgo5gWsiQla9elUennYrFXvVUz-po_3cyMoTbAALPo0y1aG1b8OXzzbI2sAcz0LyGDOArqB6ypdW9Y_HWboYJj7Sn9u3n820ZKGiOQgYiAvA_c-IjK3fRNQ89JQaWhn_OddFyW6SO_JLDBbag7XV32OGkuqGEm87GUn2mF0n45ni7tty3DiqI8lGxlwp5Qq9xnhX1U-YmpXwSWuThFvEqCySnpZq6RDXHO2u-uzYRZwxyHJyjqh0DKWh4KHItLjvU3sH2zk3pkZTwzh2yh0GOqgAc0AfWRszTNkxahoMt_PE-XVWo0ZZ8Zp6ro0xxScX8YX67DoyBP4Vz6M7sGafDvDFTxKHnZidWuBLp7wKaSDArOoh4eBCDsbr8zVp47AyvpfuyFFD41Y6VU8A7fLMy-l5ABXWSmrjXLJ9C8cWrgk9loX1bLPBpOCqDc1-3yH6oXqBWmqvLmERD5R47nraBG5pSQZilb6RXIp3ifCJ4uX3Dt3CUig6uHBguk4xgyHCoQt4lSd_P0HM7ZZf9Q2Co3aRFRbhNbzOov-APvLrinwnpSE56A9eK4AHW11avBH4o1LFem2gWUVFGeHCJiR7CFWa8k;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVfoiCWDoEEMOQ=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmrzpLxz7p3cDKbvkercsUDVYz7HJNrVdAoCglTBJcYjZk4-o651uHDL4lncM8pJVBT93mjk0XCOBOYPaRFh1syslPQxGWa7FEclr0IVaAhPaeeB6MvLtRqTdUd8lva5YfTxD6j2XiAp93_ExHrIPqK7PeNUN-BJQ86TObCHGJf0xId4PoeLOL1Wc77ja0F7VNB9856yUg2mxZCLd9YZYOG1BZ5JsyQhdKLo7xsSQ0kOMDEPkOMcV6r7vJZWT1vBQxTiSkhOZc7ope-zz14XXJlg1D5cUyMzlNUxPwBhc6Gig07_MUOFy4IMtH9FvZet0-5nRQLhXAM7hXnPXr2D72D3mWmoegntrmD5G2C7LIdjVeK40QNniP8M_aGzl6py8arEh6VBhrGdHW4aPa17QnGhUz052cEZnR-4CkitjU7S7NlN_L3ZZBKFTySOnEoe0xjwfe1ksrN8ZgjH1Uxzpb7xjCDoaQt42Ax4UvZR7u0yEihGkZ1ocEW2htdSsT7pxQrYXkQLg3B6ZB0288SegnrrE2N8JwZUU3gLVLekbsRVGBmTokmI9nt7ZtorPDm7AEkGG_jaRLbckKBv6gTeC1ww6hVktIv2olH2XjWV4xGWUGpuXH7qzRsHpXOVYm39FLgbCQ5t9-2VmmmUu3PFwQGGH8j0XK7YEZbTqzrm5VzsQ;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVfphgcjoEEMpA=
     status:

--- a/tests/api/cassettes/test_get_telemetry_empty_response.yaml
+++ b/tests/api/cassettes/test_get_telemetry_empty_response.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtk-6QRc8uffFtTtYH4JoDGNZ9yb7bEeiMcWz7IxqueRh70tdl2IBSqIKtMrVaHG2PHVeFmUfDNRqovWrBIuEa5V_bh1GWJ9tRphiOiOL_l-zb1s_PMgkYBd1FVj7E702kOdLOJwcS2yAJvl-dLH3vjIStsELWK9sKGeCxUIX0IV00bn-YtemOU1lSkS9itR_6VwF0icFBYaWHnfb_c2XGtzf28-IXlAleNBBCGKnQS715GyWdTc0_kKf5bTSCK5XCM=N;
-        expires=Sun, 12 Apr 2026 13:36:41 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.kuoywd6roWyZmepYcJzfLvY6RPEHQqJk5rjdfPRDMU4=N; expires=Sun,
-        12 Apr 2026 13:36:41 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVf3gX5joEEMNg=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=b5e2a474-97e7-4f37-85b6-da20f881412a; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115969011732960.MzU1OTdiNzMtMzQxNS00MjYyLWJmYjEtODhhOTdiODk3Mzk2Yjk3YTVkMzItMDFmZC00MTAzLWExNjEtNDBjZmE3NjZkYTA3;
-        Expires=Sun, 12-Apr-2026 13:26:41 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115969011732960.MzU1OTdiNzMtMzQxNS00MjYyLWJmYjEtODhhOTdiODk3Mzk2Yjk3YTVkMzItMDFmZC00MTAzLWExNjEtNDBjZmE3NjZkYTA3;
-        Expires=Sun, 12-Apr-2026 13:26:41 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=Ku-r-D8RuCE5LbQhODlPoaqkOogicPNxE1paSSbObbg&amp;code_challenge_method=S256&amp;nonce=639115969011732960.MzU1OTdiNzMtMzQxNS00MjYyLWJmYjEtODhhOTdiODk3Mzk2Yjk3YTVkMzItMDFmZC00MTAzLWExNjEtNDBjZmE3NjZkYTA3&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmSS1aq6oknLKnovXRYfEh47966p1agvPVIdhQWwTu1vEn6G3yYrXRhAlcDnooqJUIGuxmxCjRKthvZEEC86akiG5Vmk1fFbIMT1RQxQSiU4n1pnsHMiTQfvJ6D54D37LlZwb_Po0kgag4fPXkMA1nqMHQzC1y50FlpzOlagvtRtIvoFNIq4mD_bdovrWrHbNKdMjp8g2IFJ5tR30_LiDi0HfdLiO2XJMbkmGmYHjwheG7IBC1GH0Ng3Gy1j3RvV8-8CY4LYk7YvKZ9to-n3aqeCFM9iQ19KScAUWLba1eBe3jgjMN1w42kj9sKJ4EgTMJaXRcNmmi4AlSDwVmE1PNj-OXpceXSDTapvS1Rwktq55P0kOhO0UPlixlzpGVk_VYA9uKz4Fm4gtt3dVw4Iv1tJZE5Ti3JZaNV-OsFgsMDAURLCcC4JN1XdyW-rB4ZXWLCrMVRAG1ZjbxHGq4_KfsafJRPHCJTF6cPndh25DULEhA_ISo4KSuuM4_v672lW1_SHv9xzpFZWEgZE3HxzgtWNlt9ZfjwvuIdUcg3UwVagiGpwmQG4TraTDbKgrMEoCJA5OVYjT8xW09LuDQZqGqXSB_dw-Y8X2DC5zj6jh4BPK-5sJmXSi9cLu5rmnzEbt4V1yCQ0wuSIDL1soLvP6yi\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"b5e2a474-97e7-4f37-85b6-da20f881412a\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-4fc3db57769b\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=Ku-r-D8RuCE5LbQhODlPoaqkOogicPNxE1paSSbObbg&amp;code_challenge_method=S256&amp;nonce=639115969011732960.MzU1OTdiNzMtMzQxNS00MjYyLWJmYjEtODhhOTdiODk3Mzk2Yjk3YTVkMzItMDFmZC00MTAzLWExNjEtNDBjZmE3NjZkYTA3&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmSS1aq6oknLKnovXRYfEh47966p1agvPVIdhQWwTu1vEn6G3yYrXRhAlcDnooqJUIGuxmxCjRKthvZEEC86akiG5Vmk1fFbIMT1RQxQSiU4n1pnsHMiTQfvJ6D54D37LlZwb_Po0kgag4fPXkMA1nqMHQzC1y50FlpzOlagvtRtIvoFNIq4mD_bdovrWrHbNKdMjp8g2IFJ5tR30_LiDi0HfdLiO2XJMbkmGmYHjwheG7IBC1GH0Ng3Gy1j3RvV8-8CY4LYk7YvKZ9to-n3aqeCFM9iQ19KScAUWLba1eBe3jgjMN1w42kj9sKJ4EgTMJaXRcNmmi4AlSDwVmE1PNj-OXpceXSDTapvS1Rwktq55P0kOhO0UPlixlzpGVk_VYA9uKz4Fm4gtt3dVw4Iv1tJZE5Ti3JZaNV-OsFgsMDAURLCcC4JN1XdyW-rB4ZXWLCrMVRAG1ZjbxHGq4_KfsafJRPHCJTF6cPndh25DULEhA_ISo4KSuuM4_v672lW1_SHv9xzpFZWEgZE3HxzgtWNlt9ZfjwvuIdUcg3UwVagiGpwmQG4TraTDbKgrMEoCJA5OVYjT8xW09LuDQZqGqXSB_dw-Y8X2DC5zj6jh4BPK-5sJmXSi9cLu5rmnzEbt4V1yCQ0wuSIDL1soLvP6yi\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"b5e2a474-97e7-4f37-85b6-da20f881412a\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-4fc3db57769b\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=cf950f2b-4a1e-4069-8d7e-626cc833dd8f; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/RnJN1uRwhxW/r810BE+fpgt39prNTDryYQ5QT8diCB2u0qIbMTnBH4ZyYymNnWFBhbBgivWneX7+5Js8obMHaJhIBR2aYxvui4usdyny1tvnEsjVKenZ1L2cW7o3Ss7QQCw7/naVCrXQpdunCmrztFtbu3/tNoJDosHgrS9+Xlz7uNpxXqFH/r30XLJbIkb32sUO4AH5aBnd+oKwt36T+a/M3jzHx6ISPaBWpoMY+pdbxOd1m9IDf4OGx3s0ib7lPLPFzq2su7mNASxkWP4TBn485oHuJjQmr0/YE7EZRQePRKR2tJfiAAAA.H4sIAAAAAAAAANPR17/Ea2Ebp1ddzlAoZFIlIuadI6x/Izjx5+Q5W9o8WABBx0BhIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:41 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.kuoywd6roWyZmepYcJzfLvY6RPEHQqJk5rjdfPRDMU4=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtk-6QRc8uffFtTtYH4JoDGNZ9yb7bEeiMcWz7IxqueRh70tdl2IBSqIKtMrVaHG2PHVeFmUfDNRqovWrBIuEa5V_bh1GWJ9tRphiOiOL_l-zb1s_PMgkYBd1FVj7E702kOdLOJwcS2yAJvl-dLH3vjIStsELWK9sKGeCxUIX0IV00bn-YtemOU1lSkS9itR_6VwF0icFBYaWHnfb_c2XGtzf28-IXlAleNBBCGKnQS715GyWdTc0_kKf5bTSCK5XCM=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtnwV7j2QNR3moKW-AL2BcbCHH2O9DB3DgxZES_TaW_f1mdI4iPbKMRz4jBUpN10ciKuiXD8fCmuRn_hqHiK0NTUxLUsSQ8WcT_KCvp2-9SHN-zlf7K00trBx2SwpaK045qt1AMiY0Hw7mT8tQQupTY-WYfucXLJJYDrczTkFKPPeL0at0E7UxaMLgBw43bGIVQLYaGXtQ3XyRr6vqez9i7ANFq4Uai2ZlDRKI0TNsJSe5fEiHG8VoBlr2TrgmmkSR1JQZSE16g1yyP1YuswTjCERICxcMD1doy4rnNF5omZ876V4iDtYLUTSW3KVC1Ty7G9DTTb1TPgaR9ys_Vuh_4fGifM2S6vMdPauT02AuWt4YzGmSEjWbfTT3mPM_hmKPN-S83MNOlnXR5CkO2UKWLCb7SOrW_ZR1kqIggY6vGY8JoFbMMsTgtIxExrP-qcE3FsHtbRPaTTf1RPtzcPrmpabvT-Ybz6PZ-NXm8KRQstd79BaOQxb-wRlUakXYjNuXmR9J-ISTAvkdxtapd1u9qMBWKw9eXZoCZ3sJ8iAKYB4-r5UJHJc_38V4FE6F527o8-CrjSUaJa1E0P-4h8RjFRtD6vTY7JjI4bg1X4tqq3WGTqErm3T7_Lo1wIbK21jt5KmPc1zrmla9NkRP3O0VwuPvrfcatMRJ7WybjgcK4TNztSseven9mBSWou94RZFWa64i0dbaexT1kMB_q0m-zl2OtWAzYem0WIALfWngrw19KwjvmPIBx6q7piQfcQGlrnr2U-4dSmfbIS2cL8uii-I7fn6wJnPbZPaGLSMLCgUVkjY2IVMsUbjHOq2Y-uUVhtXYESgba8kaBAfxJFKHTAhtmk1uijlPQsCGLgx_RqbN0FMz9CUarWsvjebFpZtSItz1d0kOZi5DtdH7bOaLvnFfx934zkXeSewDh_onUalX2X-3kGhNuezQoQnOgLyUo0khHLQzXabm1bMcP4YFN556TsV9w5kGAKN4B-5cv3HxXK2Q7JPDVfPqu5GINA0h573CLRKEH65liodeAgaHP9hkc-ds1ffkPt1lEMJVokDQNwsw4WEUeEOOKyxEarHJ9JSOLUn80AHMpITsBEWLOTfRrYsGslgdb-TwWbun0p-21qSBc3BNKQ04Z2lVxxlVwVKD6iOf-2AsPl8Wt0levDlIzQeKel0lUBisQTPULpJtieLZIFlCmoFsOedsmDQTL9LDTdwgFivNr0H6lPszOINDcKATM1By3NnBX6qV3FlHnaRSVYdgiKmY2_RY8AEKC5eWTJ4W0Dnf-wo4cH8hrEmE8NBPRr4S2HCf1wwjjOtIu8TjkGcYH3JSSWy-qe5BMJG0cCPsmXnbNSab5b8tGwGXhTkWBq3xnZGnElaZOrhvfFHQqeeisrZxDZVMFaWohEXGT6GfUktWhHd_eHVF0Pu__xMCMz0bGVxa8b_ema5tHkwnnST2DbRt-H5Cn0aObaXvtO4KW_KA2Sd-zl1bYLKwahjTBi6uC9DRgqgba0Kyi9BZKdOjBvCBexPT2FR67HzvIbjC9LmUML8SqhxhmTYqKgegaRSwf7pWC1wvHpAt-UAI0Re1cls6eBFxQOsQalwHrlsDpOrUWZnU4UyNNl-9ZbKMARRP2BLEXPC4ixmQsgxscZ2YcoTBB6brpEUcD2Yp65982josYNs1ytt0rhSenhsodY3wUrIZ9WlK90dwdfDamyjgZeLsiLXu7rXjjKTAcyiNjQQjjAUCXg7tUmFFzW6PdvaQo_OP-4bpofR86-axhwaWoSeG3bIH2MoywsBF2eCNmq8RbzfB28c_oVzzcxHk0Ej4RTqTytzab-ibfe81bSLYGpMfl4tOB538Ej8PfUZzmRdoZA0BUypxW7YzKhyx8BvpYAghn471meqy3B16nDN5pcAtIUeAwpa8N2TeXw1DJ7RpQz97C1PeUNs3pzurgQCT9ugRYXWCLmUw5dbQgbs9aOf66t5qkr6LSCwk6vOXEpRY7hRmBdFKL_-rwDKyiLC9Qu9Hb2RbX_BsM5tWnCATeAHPfk-EdaOYqCMMokTV6O7SA49h4lmiCSrrchp5vafKTtCl6m2IOa57wZXdEQYNMlwwlHlQzQnc1FIuI1wC88L26LA7YYweS7ObfEtc9EDUp2uUXr2EXleGHvJDVWX1VW7c7_sqafaUDsoXnJ2lvunpz7sgyGx-Kv_dh4i2ND_tfkIVgsAk1Onu5Jq4EJIPlscEtijTnwXl953ZG0Ck4EIduJAI3brWd9NeWNtUm-EZiwoDttZPmmhEt0WKzj2ooQ_1H937kXCgIiUeeqaKNYSi9zZJOO9Ve5-nlfyBsVieVXzdrOVuznvclEp5kEkF1pFWv5c0Fduze7QyTWvbWcQ8oB5a_3hja3Ea6SCHmbz_Xm4FVLy6bQEazE_vLsPE2OwoUXE9HcDqJ-0HF-HH133T-5FdKC3VyVEo-8ceG54j_bn4mia4Nz5w;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVf9g1ZjoEEMYQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=6614CD213694EE376DFB15AFDB722738; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtk1J4PaPCB0--f01kihOatKya7PJ5ROzROzduGiflQ0LdS6wRoMlrkAmrp5ETT6sOMOvZswX55SQqQum3P9kN7MVVyizjtBa6zO-HM8ERkkIprw5Q-702nDk43iizjg-pYpcSVwzsx62yq9yCQPNfCLepIDod9Y_n6H7cWeZR93WVzKO31MF94y2l_ADOOs2TRtFaXN5Jlqj6kEHbglX6baFbxTrp67ZSxiEeH1LQepshogYagRzBLpOo8vTcmPQT8WAzKJBDZFx8m7ir89rLhVlCcdgWttyOl7adKgznQgEPFlICFKgAnBarfdBjwwtty66Wcv0hBOhSlOcTxUOWyIzrT_l2bt8st0pW0xb3O8lK54g0pd1JxC2am7PGJPojPt1c9lJP8OvrO1wFKCoHAU2HdRstDmLDq-bmOgYX9oxUosmv2NJNXpkOT_QpcFHf6gGTw3LsKcqDXOtG0-ph4CrMwApBRZ6i1wvG1G1W-HCJp9h7hu7WF18mtIeGYEhQIRVF1_czi6RC5rbjYrAC1BtpmGeM05YmpAs6MemjWgwlIXjUmTxL5t5s_EFbeOrGHiZ-LV_12g76Elx68s5OwlLYCiM3QRrTV2tUsvrahMPyTpd7KEHu60rzPnO9hdVAA;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVf_i-5DoEEM2Q=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlVS56tMDXGIBjanTAVL5ySkPS5BtMxtSkSApsG4N4Ugci-p1Jq3xlpt--qtfDt6ri3Jr0nyl88yTBoWUFA4KAOu-stVdyrHlcf6o7Jr9wMHZlR1iiSXIcAPcITdro9HnWwSMAN7gy6nI726Obr5L9IQjKG_ygPK0IEt8j7z2fbl1wMfwZFX0_NAD2EVwTHqluKDqxMiSln7zzLg_o9vNJ4GTwJHPZs4M4Kxl3P56MAz8rj2CtXd2Y12-c_7GrtctgYtbD9G-n4QG1CGII6WKviW5CVBqIw5Qd4BNNVhzZuKDLqtyz-K8cTSZwnSftJivaZJcXsVtmNj8HNZnaCnPUGVFXx6iA4Nj2-4kOoJiNdZU9WlzL05Rwv3zTOI70oJCGD2KWGT0DhCM2bYxl-pa4us7ZSHIjeA83PJEOMmDQc1H1Kv16YvV8pP2jLndTaw1oJqmAQDgejO38lyt5aryMgvK1llabpfWvVU3QCgRRQmuKuVyrUVLPrlLInU_BXe47T9MO1vvyPxZJ2-K9Zg_b4ovoFlkLXkRG0wk8HMkOn_cubOytnbrjA9e3iKfwKCzSV7Md5WCrHvTcVPXgSNi2d6RIiBk6YjRYGqayl0gq1ljiziyLzWPSqawjZ3ncV7akgUdMy-iCVuL3OV1PlcgFFlILcXYYBHsD_q21KdwyI_A;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVgAjiZjoEEMug=
     status:

--- a/tests/api/cassettes/test_get_telemetry_measure[flow_temperature].yaml
+++ b/tests/api/cassettes/test_get_telemetry_measure[flow_temperature].yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkJIRaXkieZ2_BNVq_j7On8C3e91alw8xU8DhMGzzIboHZEWPVxysA__lFJq93DEwh6YSfG7CbFEq5UZHMeBov8OQ_O3h1iasajWTX5u8JRJ7C2IHfddWSgzS2TxIRYXdHnYgbY6KAoY3ubyKhmMdvbVSFmwXiDIcffsDZKCuNmveWHqwTgnDdJQfW_rAGiBvtNEiBydqNKc93varzCfDFp9FknGKRql_HNN-gS_TN21XeaLSuMRJrfkXjfkH3vqsE=N;
-        expires=Sun, 12 Apr 2026 13:36:20 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.KPsax1_hbEZyCFw9HWeBg4LW-BJ7lEDU3n-15ayQGh4=N; expires=Sun,
-        12 Apr 2026 13:36:20 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVckgY-joEEMfQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=10abf764-2df8-4473-90fe-c91d9a8e1f49; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968801040693.YTk0NjZlZjQtMDFhNy00MjU2LTgyZDQtMWMxYWU0ZjFhZmFiODhhY2YzMDMtY2Y2ZS00YTAzLTkyZjMtNmY2YzQ1NzMxOTUx;
-        Expires=Sun, 12-Apr-2026 13:26:20 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968801040693.YTk0NjZlZjQtMDFhNy00MjU2LTgyZDQtMWMxYWU0ZjFhZmFiODhhY2YzMDMtY2Y2ZS00YTAzLTkyZjMtNmY2YzQ1NzMxOTUx;
-        Expires=Sun, 12-Apr-2026 13:26:20 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=VlsDj71WtT7W6tWboZf_mow919RWtCTh4ekJ2Z5b7No&amp;code_challenge_method=S256&amp;nonce=639115968801040693.YTk0NjZlZjQtMDFhNy00MjU2LTgyZDQtMWMxYWU0ZjFhZmFiODhhY2YzMDMtY2Y2ZS00YTAzLTkyZjMtNmY2YzQ1NzMxOTUx&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtla-FyGP7AQCGKlKs2tcEcLYWo-yK4yYPtoDStmyIpli3XjlWRBmE-zUr8xdx9uFBehWLxqGGTwjZf9BaJzLiqkEiAJBY4g8EU7kfIk8ebAQRt77C33CSOm1-WGwvDhx_tDVGE7WhMiYy-8O60YeeQu5oHwy7jViYeDZ_sV7ygsjIyxBbJg3DON8cPil3AdAjJr68t5DFUrrew9jgo6l0z7zvyRrkzoC7RDDdwRzcK_58VxSvYXBYHuXyAZGjvWhfzp6dqiGl_wqvLceejqSO8ua4TgUX_-ARFpiKtysHbEpuPHC1PQ7aWQ5gG_IkuZYv7XQFUatPkzemSoOQwCxk3D2bYPNw9KbV6PO5d9WFh6hb6cOj6EhhPJPg1Y9WVG-c6AcE-MG_EXTi4wU8bfAIISK4sZ4zyJwV-oRO09r-ZnXpJPfgJmgqLbKeMRqNEvP8tS3Sw58CDRro0Z5cFZBMnKITF4RGnDxJPSfUzlRt4RirIoi8iNzFCrcJWT8OgRVkVD85H-xzhHtbTIPx0K2NMb1-450KXo3I-4qeOGAvcQlOD-mBDL8I393V0prLmCX-PSqphJITGR4A7JDqkhZHYdDj-49vqA_H0pKqcGwtSoUsdTZD6ZS6QDHM5-vyaMTKU1Qdpu3I2RkUx4te1VrvAV\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"10abf764-2df8-4473-90fe-c91d9a8e1f49\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-2b127b61915a\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=VlsDj71WtT7W6tWboZf_mow919RWtCTh4ekJ2Z5b7No&amp;code_challenge_method=S256&amp;nonce=639115968801040693.YTk0NjZlZjQtMDFhNy00MjU2LTgyZDQtMWMxYWU0ZjFhZmFiODhhY2YzMDMtY2Y2ZS00YTAzLTkyZjMtNmY2YzQ1NzMxOTUx&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtla-FyGP7AQCGKlKs2tcEcLYWo-yK4yYPtoDStmyIpli3XjlWRBmE-zUr8xdx9uFBehWLxqGGTwjZf9BaJzLiqkEiAJBY4g8EU7kfIk8ebAQRt77C33CSOm1-WGwvDhx_tDVGE7WhMiYy-8O60YeeQu5oHwy7jViYeDZ_sV7ygsjIyxBbJg3DON8cPil3AdAjJr68t5DFUrrew9jgo6l0z7zvyRrkzoC7RDDdwRzcK_58VxSvYXBYHuXyAZGjvWhfzp6dqiGl_wqvLceejqSO8ua4TgUX_-ARFpiKtysHbEpuPHC1PQ7aWQ5gG_IkuZYv7XQFUatPkzemSoOQwCxk3D2bYPNw9KbV6PO5d9WFh6hb6cOj6EhhPJPg1Y9WVG-c6AcE-MG_EXTi4wU8bfAIISK4sZ4zyJwV-oRO09r-ZnXpJPfgJmgqLbKeMRqNEvP8tS3Sw58CDRro0Z5cFZBMnKITF4RGnDxJPSfUzlRt4RirIoi8iNzFCrcJWT8OgRVkVD85H-xzhHtbTIPx0K2NMb1-450KXo3I-4qeOGAvcQlOD-mBDL8I393V0prLmCX-PSqphJITGR4A7JDqkhZHYdDj-49vqA_H0pKqcGwtSoUsdTZD6ZS6QDHM5-vyaMTKU1Qdpu3I2RkUx4te1VrvAV\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"10abf764-2df8-4473-90fe-c91d9a8e1f49\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-2b127b61915a\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=4c98b648-f52e-4d97-97f7-c0ca8c2a621b; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/VjHmBzytm/E4h7pScaXp22r+A7fYsqPKHebQioMHxWxOIXkC2/22xtwJdOcKjw2txLx3ra0M/UgOZ4fSGFUt7TpgWwnqDJ0X7/PV/OXVozSkukXNvsfIREgQTpMpCGwONyg/L+Pgo+SbsqAreRSu0zorltbtEGRaFSP0oZgAVZj0Q2Rwx27LYfv7zeWEeVatYBu/rqrXbbUiL3jVvsKvsMlJTQKFJndZe1FrbldcTWAjctL9d0zCyy1DyBn5ZITo/ZeM85vx2No3/bJuo3nCxWs+FvAN5kv4TLBDneXbfz+/INJCo1jiAAAA.H4sIAAAAAAAAAAEgAN//rqywvk5Cmc888z8kUnj3jNdzH6IwUehjo37azp0+xz16gOpfIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:20 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.KPsax1_hbEZyCFw9HWeBg4LW-BJ7lEDU3n-15ayQGh4=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkJIRaXkieZ2_BNVq_j7On8C3e91alw8xU8DhMGzzIboHZEWPVxysA__lFJq93DEwh6YSfG7CbFEq5UZHMeBov8OQ_O3h1iasajWTX5u8JRJ7C2IHfddWSgzS2TxIRYXdHnYgbY6KAoY3ubyKhmMdvbVSFmwXiDIcffsDZKCuNmveWHqwTgnDdJQfW_rAGiBvtNEiBydqNKc93varzCfDFp9FknGKRql_HNN-gS_TN21XeaLSuMRJrfkXjfkH3vqsE=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkvPgwwiu_1vsxpjETVCbvu1g9an3FkQ-YMRlMIj9saHPOVCyOg7Eo0v_i0079LBhoXx_zouP91O3vxYz7RJ-OFdk2teFeg6cbvD46kRVUfkLzZF0BFSg7eVyFB2MOyjNlB0EC_5MSJOZJ29G5JM5f_G0OOeE4DT7DgAhZfymTVpn63uGr5j6eIxfBQwVj1NTIGCO_VzUJjad6RrcpvFrc5yzHz0jAsoOTqwdDj9n2kn_FIK6jMBsRMGcJGWefC0Ye7ncPoc9QKVU_VQ8-ZlyMPKkui-ArYbN0Xk2IKLgBR8QVC9bIaH8wtF7xKREoSiZzceRfIiDW1HT3gAxBsH-xOFMUzzSTky_1Iz6L37YPhqKWGPVwnT8D42z_wpVseodxgIzUo4YuW3qnLyWaci74BXIvtcLEOTui2dDIaC-wUoMcyV8Uj3NssPmo4kQ6cwha3AreR86GhueXDwLMsuuzAROWavMkWhOT4XX_tBKTvh5RjsCkUBBjuTZ44Pj1rx_FV_rOeXOFhyfClBMfW_pg2eLgfNn0YSG3QZDn0Pa_vzAFF2U7AW1x2EIipI1wRWqcw_FUPgoXrAm40VpurVIZBnQqEhNGBFf-scVj0a1iFDhiCLmAQItq-GVRBFJ5t7Jm5U6QovZWCwSmy8jss7N6GA6-8ZhAGNsXfAsNLv__xNkEhn5RBCD6EEELow-n65oGaX646FQDc7ZuvIlZfZfRs4LAtfinuX7Iv7zGO5KjYR_cf-UQG42gAAT6cWBzPOW22KCHJRxNR_N2-CvhIFBhKIzfaIp_N3T5baCty_C2SsS_cZUv8tREk5bqhcZBdwGWg1r95Bu9ophdL-ahU-MSbnMYouvQU_KO8-VSbrTfD7wFb8PhJbD8UHh1OAULVkh_-_YvMJNtuExU1JM1X_JnksOdDIpHf5qziEYxmDJqsbeG58ZkUrSyjkGXqotLiNshs1CXQK87dvwBIDlmRfRKXOk2tS4gyIa-rQynuEjkP3FxLTP9YLuFCCNDFKp8ArjPaRYALjoGiYU5riHtQQxlKOCsewFrEsB1urv3ihV944TpTqs4So7c1soZGHgxTf6BtBJ8xt9aknf_LZqCyTdKYH6PnAewctHXOEWNFF4o4dAg5Y2qwt0L8sziv-NCHBZ0flPVRA2JfA7mcX8k8HjR3Oz685Z7E8LUVJa8jrXr_GIkDg8c-tzRHTlldkWNkiCcLwKdpuwSMxhuHxdTgyZAU_KsI1H8KhIlr5qhNHTEfc3daqJ1pCsl6kuHOpOkUD0LeZ0R3Sa78jqgi3VUfYZdd3wFsRAvDVoEN9Jj5pLjZG8YyCl5JlrGNLlheDKJQUqpQp0LF_tSC75q7hlYSf1SlHSgz_bEGYytfQijcEUerbRD1ff3051EmuT5N_ldinyf2VMHt-OpbhITigVfB1VhkgRw17PFDCd1pjg3OZKz0r6hKxSRwu8nm-wDmyAGvuXmtecXCyk9We4xWHA9lmRBng7Dq1e6Wv_A6FNoLLUxj0qTlQgpWCRHldfHdF3Hqpp-djw-PjCJVuf7ShoTolSV9Xl1OFe3beBaJFgHJEgFC6CI3JPYuKKCXlGGC3k4DFEgAuqSjIpyPm3BgOvEr9ERxt-UzIhLUoBCHXT9AYR7TQbmZIHx-P4pRAHVLr8Z4Tci97rmWds68HapPevUgDYjDLREjS3uJN3THcfSFyfg008gb-eXRyx21T_Of-zMpTr0RL1HfgFXuzGBNYSnfNutkDo-xH6q2Mv7xjs9RWsG4SyaPuzC057uVc-CS2MfSQ1NJsfM_g1xLWgskkEsJI2MGTmGzO6tjLWmTYFp60GPkTpGDIrdrqyjI-S9Jvg-JDF8qy-pcjdTLcPnKoVttnK3KUNEZQIeoTJWewFQdDtCyztOxndI_ucGFQEd7zazRPfFyvxBnAax03qjx7RBrEbU0IHAfJBwyWvFU9cbVO-5ySVvS87Yhcjoqr0_hbcB4qLGB11ghnjK-YxE9xaA2p-ZCu3FLnH94wy9958RvZI4lGu5TG5Kc7kLBRPU3G4euB0Jrf013Bf8B0Z_fdVLBWJzk9GUAbtCudri0X17_01Sa1mhsKotYKGvoLV89_GbaoE_6YAcPXgIKBjoKKk8gasMnju5Wibn9BJ9bsReX8-mymn7UJt7GiSnCQw_pdaeI7n59wlPcTeaI2AzkUer6AH-SoJqa2lUidLX82vhummg-tWNgdjMoe_wNdV8lD4rd_nDqrjoeUeI7zfoY5yeUpanPJ6d1G6vYUh2ufD0aqH7B2jEtSgVWHkfv_x75O1GVY1Hzzlg7s_ardZ_m2L6P02lODpEyq3Tb4xpdr_HlcHhzRkI4LnbcZ0Nbojm-481r9OkpONPmIvaJwbVb0Fy5qEMbk0inaci9t6-Ec1ef_PoQnvy5fk2QYnpL19m52GPN2vPx-8wxvm6P5dxAwhWwzLmJbreFhOIRZdA3GbJztlKQzw;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVcshqkDoEEMRA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=91ADD8E041BCBDED7F0D3EA74D40C7DB; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmZxMvre4Sj0nDP6bDIoe67PE9GbUbBtV0Yfrbq7cREoK4-LQH-PDEwRS8MzjcPm9FuC6t09jyTe2NiSEPQI_1L96DVsSrPObdB5wf4KpLwk6bgBe5B1yjZYG7qFfCIYAzGHKrLQQ8EdmmPdcYddJsjwOkFhboz5vJ2kPQFJmVHTDm9ozX0YRoBMIYk4mJmwjQj1pi4dmqh6Hch0aYDwmSBWiadwCWZc_NXUcqSBdIDDnLNQ12MrrSnBIsHHxg5h2RvQO6IitR9oDp-Jugalr7_MfoN6D0z0vXYawif0HBrV2fvW0UXX0O80UwKL8HlrkmrSOTprXgCm377Z-cV3ABcZtfcXVWwKRE52Y0cMF6l1PXyxA2CfftHJz5DLhZ_Gwyar6EsU8Id4_hyX_cFl0tqPLZxV-j9V0C0LzpsVFPWMCw96NfeETt8iMcw3J55pmFzYKRzAMaoXWKi5GISczodQT2BwBLBc2_PCjR0WLmyOQtjyziidDzKDl4PG1R7D3vRKsYjJqCVKmKpzVj2ujXia3IFG01-mgcE9hBSdqcwFFe5zorAna6PXqqcUr6cL0_gpaHXAiJ7D5shdlPNcLKjjENNZYAUvrQoR6O12n4V30pSIfmRAMsMnP7JY7XkLLE;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVcugvAjoEEM4g=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmt14KgJLanosArqb32YUpMPEWr_2loyAyuHA6ey0sa0bnXA9rQfRQmSaFww_qvZyo2xsnOrg-cE4qLrBuGdBEAETXbvxd5RzKi6YgHE8dyyxgMFMap5gI2mTYrgLjprGvJM-XVp4mww82kimBH52xgc8hulYeKF_sSw7XFV5EOsG3Bx-AIosxq2wXxxAF_Ihyi36AWC5zb03OusaK6UkOqAN7U7t2TKBQt5fOQ-li_rEgUo85GAcKflAIx5FmtXRKcyQ-AVx2NgFo23qwmRYpbYLDwbM1URjPUGM8HcZKplUlm3wMHBv0-ceO4o_lmz7VQj1sfwhhJzhYXdhYkx5Kul5B2NmRsWx9v9dsco4QWvEaPzo2JaM0LwyZ7b955ljttdO4_6XiOFhsoNx2D8AWJY3PYNI-pAhmGgr4hHXacgMBUxxaEtdHN6x3t2CjpYtVdby2c-UGrYtUpr5_pXDfGbLO9Mq6o4u7emZV5Zgn51EFdJ6alYEg2vuh7911BcfnRdNclrnJP2j-VjSLg4m4ZtkBWyh-OIEeupQ4g94EouW_qoNXxrj5a4tNwiZMZfhgF92a2IKJmX5sp0DASM-6otXMl8rNm5mUpwAsahBrIsCiPnVNNy3C2N6nC5cAjU6uZ5wsc3HK5Ps0VAPtrGE-T9_V9S3wavFlJ2FsRIZhkiw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVcvgUhDoEEMpQ=
     status:

--- a/tests/api/cassettes/test_get_telemetry_measure[flow_temperature_boiler].yaml
+++ b/tests/api/cassettes/test_get_telemetry_measure[flow_temperature_boiler].yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnvGjVrlBsaRw3x7dz1I__7TwY7Hxrqgurc5ntgXZBSKsvyHGWbEIx5QNcRaFEE5EEmm-dNxQblviTQLft7VR5rAIa2U078vRZ9uzTZa2I9i4XQKDcxjbRF6_ELTEcdNU0nCcrMNwvpO-MqRqUB9cDRc4X1LKudnMRrGcE_tO8MGHL9VJkzNklQdV-auA6cj-_eVdGT5zitu2GZwJg9GJBDT3uI6yIylzPgaTZosNeRjmDXJT3IIF-tuDbbu9S5X4s=N;
-        expires=Sun, 12 Apr 2026 13:36:32 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.FN0w54e-XKfONC8aj2zUpA3I7RB7OHNQ_-nJd0U3GLc=N; expires=Sun,
-        12 Apr 2026 13:36:32 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVeghPyDoEEMTA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=59ad1a55-26a2-42e6-bce0-cb4bd826cd23; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968924229324.OWZlN2ViMGYtNGVlOC00NWQxLThkZWYtMmU4Y2M0NjdmMmRjM2ViYWMzZWEtN2I1Ny00NTk0LTljMTgtN2RiMzhhZDYwYTNm;
-        Expires=Sun, 12-Apr-2026 13:26:32 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968924229324.OWZlN2ViMGYtNGVlOC00NWQxLThkZWYtMmU4Y2M0NjdmMmRjM2ViYWMzZWEtN2I1Ny00NTk0LTljMTgtN2RiMzhhZDYwYTNm;
-        Expires=Sun, 12-Apr-2026 13:26:32 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=bDPGvKxYF4rfzEEeXgalzRdSezTVhM9DAtACUoamDcw&amp;code_challenge_method=S256&amp;nonce=639115968924229324.OWZlN2ViMGYtNGVlOC00NWQxLThkZWYtMmU4Y2M0NjdmMmRjM2ViYWMzZWEtN2I1Ny00NTk0LTljMTgtN2RiMzhhZDYwYTNm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnBV3wfYI_qHBxIeXPdTVct9pWfk-UWTERbZeKpnJAGy1Xltr-TC_B5cQ62oSw3NT1PYHzXS2X-_Skh0Z3fbY-J0DgoyezuaornF_SdFmTFInwCWUAeeHl5nKq7-ihpRPv4cLx8LQ7zFieqZ6FLBw2LXIcednSUnDWJF92nVj9hdtMxIiyClpnryryeZ4zCZ-O4a6czUD0F8M2y85FShRtFEFitL1mAcJCittHvidE3Z_r-jAlvx4KbN6JZNoFdNM1c6VZ3xNSwhRCWWO7E8nwFExDlLuUxcTRk6GgdrjHPAMJXPV3YAg5FqxlEwbjhAydJ8rL1xe9bqOQHCXmf0T0EreNpwRNzKJjcMmeaqq4mvHsUTPzTIa9qGoE2zEocHOahCrm3rooYfMZ14_USxX6gs5vyv0iUe2CZvRJQKBigt0Ry50hq5HittM1D6SXRpT45rM0dmQFCD7HH31Teim2HiIyPJ-GKYCSnYOSW-XTH-8sKUqdP_fOlPolDFiPID3IuNLQ9WhxdPlPvlBZs3Iz6WrPjE1bT9jeI2t2PFeBYLwVM7-nj9Ww4i9BtlZMiNNCOpz2WEAGOpwVaCMBnKRC8ZgolAeQ9X2g0fDMSRTlvlDcfR0GD5NLv8FyttfApvwfpp8mbFWw7BJIpHJuoovQq\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"59ad1a55-26a2-42e6-bce0-cb4bd826cd23\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-71ca69d0303f\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=bDPGvKxYF4rfzEEeXgalzRdSezTVhM9DAtACUoamDcw&amp;code_challenge_method=S256&amp;nonce=639115968924229324.OWZlN2ViMGYtNGVlOC00NWQxLThkZWYtMmU4Y2M0NjdmMmRjM2ViYWMzZWEtN2I1Ny00NTk0LTljMTgtN2RiMzhhZDYwYTNm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnBV3wfYI_qHBxIeXPdTVct9pWfk-UWTERbZeKpnJAGy1Xltr-TC_B5cQ62oSw3NT1PYHzXS2X-_Skh0Z3fbY-J0DgoyezuaornF_SdFmTFInwCWUAeeHl5nKq7-ihpRPv4cLx8LQ7zFieqZ6FLBw2LXIcednSUnDWJF92nVj9hdtMxIiyClpnryryeZ4zCZ-O4a6czUD0F8M2y85FShRtFEFitL1mAcJCittHvidE3Z_r-jAlvx4KbN6JZNoFdNM1c6VZ3xNSwhRCWWO7E8nwFExDlLuUxcTRk6GgdrjHPAMJXPV3YAg5FqxlEwbjhAydJ8rL1xe9bqOQHCXmf0T0EreNpwRNzKJjcMmeaqq4mvHsUTPzTIa9qGoE2zEocHOahCrm3rooYfMZ14_USxX6gs5vyv0iUe2CZvRJQKBigt0Ry50hq5HittM1D6SXRpT45rM0dmQFCD7HH31Teim2HiIyPJ-GKYCSnYOSW-XTH-8sKUqdP_fOlPolDFiPID3IuNLQ9WhxdPlPvlBZs3Iz6WrPjE1bT9jeI2t2PFeBYLwVM7-nj9Ww4i9BtlZMiNNCOpz2WEAGOpwVaCMBnKRC8ZgolAeQ9X2g0fDMSRTlvlDcfR0GD5NLv8FyttfApvwfpp8mbFWw7BJIpHJuoovQq\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"59ad1a55-26a2-42e6-bce0-cb4bd826cd23\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-71ca69d0303f\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=9ef41de6-0fb9-4e44-881b-10f347c879ee; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/xh8QzrTHacV311jxzBJD4593x5oLiAtCIrUGXDIFYPltL8h+W/y2u+jjWrPDSOQDpYk2Q7eYHsP/SSjyagDbHxYrUwGRuBd6n02LHUmk1U5mJu3EGRXFd8dtq7seiWtEZgEg73NcRs+w4xDVGoPWjZUwWRkXZKnyBJ/LBoQEk2ZJ89iTGucPW1r/KZKAqEf84jxT2Vja0ozMoLyMGbmblu6OquobnXQKpq7l9MVTlJS8AurBHafMJ++8pYXI1ODoDJ5oZKMxBwW0jad/G4LTlBEqnnXKJ9BOd1Fd+zU8pzZ8whTnvGHiAAAA.H4sIAAAAAAAAAAEgAN//zUSzVfwjLFqWncUd/RfKD9QTKfUHWMPgMj6fX6I7nfi24QXKIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:33 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.FN0w54e-XKfONC8aj2zUpA3I7RB7OHNQ_-nJd0U3GLc=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnvGjVrlBsaRw3x7dz1I__7TwY7Hxrqgurc5ntgXZBSKsvyHGWbEIx5QNcRaFEE5EEmm-dNxQblviTQLft7VR5rAIa2U078vRZ9uzTZa2I9i4XQKDcxjbRF6_ELTEcdNU0nCcrMNwvpO-MqRqUB9cDRc4X1LKudnMRrGcE_tO8MGHL9VJkzNklQdV-auA6cj-_eVdGT5zitu2GZwJg9GJBDT3uI6yIylzPgaTZosNeRjmDXJT3IIF-tuDbbu9S5X4s=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkW18xRQwuGb5FdL7Nkm213bKyohoDvg8-MyD_GR8loFQt4wa__nPaqle5JOgZXg5lB3THNuk8vBuwo7ItSVDduDSJQlQndEqjuG9c6nwh9_gglJN_Bu-_Il_2UwP7eLo0XffHdksR-iUp11JQt0hKpa_QsEUNZPIFD_8hu7-v9_1y2Vq8AtZh_g9dNJAgmtokVsNUCzmyYbzOQbwPzlEa8qNqs2wNFA--Fdj4N_3dBHjpbYsfBD3GfOiD1FGNefZ3Ykg71pO6_q0VQcNSbByJEQw4lFo_J1Jh6X2cWUHkG1ZFV3NbXB1Y4Edfk8GqCJSf6P-vWPYC70uNXAHTzodTiNzhSV7dgwRtHnjUPbypAaqcWZ6jA-m4_i2QUfMUY4uBpi-IkvzK--0RfLBpteMwOGydKlutYyXWPAgxgNDKKX7AOuXCKoFiedWMMnby-UCN2KCUdWCVJEPKu8IQWg-ZkTMro1vLTV9V16sySft-DRzhCYQdPe5s6bDfr-G7SL2FMWlDl47xmN7mSgqYzhyWJBKyiq6dYVeXpQO92wp08O8NCmfTrq25UUZBGt2CY06EXW0cExGgD5mEfUSfwsfVohOc8cr8uxf56fyIKxR5pnbjO0A5HaPYWYxLADHizzdSYq1id1m--LacSIqdmsnATV4oTRcII_Te7sOSxZbtC0PpWPqi5o17WGeYn7xxzIo8CiU9dDiDBnb9MCssz99kaQNSAsFLFuzAYjha-wGATaR8MqBTTaj3ey6Qcz40chgQQ5e2aeNHiMeYzwcNQAj3J9MO7FvyRLRe5lnvCEDxpmnB41joj1tlHQSDbpzIQGFW2eyMJUzbp422jL7nCs4yx7_wVHMM5p2QFHUANovYu6g_PCtbseBQ8X2OFZUjIeC6Q3b_G2qAzK0F9Dk2LzZGZmCKUqzj-_e_7naRyIi1cu4W6NPqjhsKGaBsqWRrV4LLfYKmjfYNWyeImvdwnp-9dWNVvzkdnct0n3mRk9w5iZrSG0UlUM52mBEAOvAmwVxwWJW_xZ6zaIKkJRqzfERlIJ_zt3TMb1EO1qcmkRfcBrI_XDdPzsw37Yw7k7EdoOlm4gZ3ifA40cZmwAjf82DeaJTo0p8SJyopSvZwuD3nCRPWiti1mMhpGjKpQoGVollK1ZmpnZC6iDmwswhAQWkkzr7aGmxE2VDH4S_22-8DEudtIsclWux-BTa4cwWzUEsY7bv0toSawHvviz5RYpYq-qoWyiRQikffDLbOD2Xr4iN21C-Wh2niOt_BQsnbaAXv1gn1wO3-w3hw8ePAS99hlw91QHeIXrm6_8Y2iblYXC3jvGf7f-1BY5QVqv9b07ySlrsWb4rnKCAtlpyd8WxNmCGyGyWYiZXsOOEbAPIs1m6jS5ImIr4xaL0sXWWuh7S8UYTH7H_raQtzhX72NWsGWvlftNfMJAmwPEPX2034CclyP3bYtKnT9qgHiZbxNlwJNMwzPH9_UgUzn59r3r1lfGvNVwS6Q6GBA8jt2eV5Fv_GSSZrOPXR5vfPY-8U9haXRmX1LGwv_TofOsYlbOvgJY1si9ncokwTlVkDjYpEe5tR5k5IUB03Er-j0xRJbJ1EKskO56WslX7m7es2rT03wRI-wX2AA5LuuATIltXOldowOsJZxw377wEZd3AcGjOBrcQepHOS6N3wsE5VFnU2OLMh8FIo7HeTUstqX31lz9rv6XtPB5bYfdrr78p0r0I1IncjOsyBAcErgVZqBwUIcnH6TC6DnQp1p7HIgYzw9lHzcc74dss7ErX49oXzuPTwK6I8JJS4Gzle3ZtdxSY9gG6f6-uvzzOf0PDYv1HxjOhh1u5BIyMQyL3a7c6xevZmVbRyZZ-vm9Z-uT6H4WPoKPgfK1q73dz8mNxZvb_fPEwlATlfRvP3crbVty69J6ej16n0asdcFVbr0Atb8FjrGRgVtgAVhh0gJ1OBbDog8YlSj5nEb1Y3xKA7CiRx_aTFg42dx2YuHkTtFO3pZZQI2v7Y9KnAn34lx7z-JDu9tZ_9Mj8teZffoACREbBE9_7mNgG0j1J2z6IppLkvmFv31or28eaD9BL0qZ1I9n1-FPqqd1JMblx9bIM5UdlfTq9ynVU5PIZoqy7nBsdTpj7rHNhPWoToqVlDmkSZtvyIE2_BuARbHlvdI2D1HYR5iUOpxGr8wMYGdCRgy_lqPLq_5sOuVMjj1bDnY0UnS1hWB3TRzSxd7Xbb5xUqixqwcPWpgKrVrFOyOBArHkQjbfjgozhscYtpv2sRJS60dCL7uo2h05ab-Urj-Yqx5_ZRRlNt0FfrtCzUAH7VGoTPVDYMlwoh8gLuvpe9nhVNl151aCEEhU7cW5gEWX3n09craLZ2IvAOSib3-y8qa4ioal0WQ6EZSY1wxWaa9l_60-iMZw_6M5njbNaKjwiKvtMLFJAa2UsQ3uJoJh18cQYblqkYhJBsio32s0L0bTX2GV_Pt7w;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVenjPcjoEEM-w=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=6C51B81556EBA34AA549F090B45D3256; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmOPr5B4zg0C-G7YynsVYWNjFRr4MLWi82Wt9eJe-eySjlVlF-G6K_NiOQmwRz1R1DWIhI-ZTS9Q1ITVkMaVckYoVCK60czQJEwNN2BF7bD7xgpvhDzYGJZ_GWxv-52mhXb8cv8kW3YT8qduvp31i1-AfrjOVrBp9_v9fkDXe4r7iFN1Qq1H4a558SvrCr6ix-DGY4yHqvtEpONB2GrRRuMF_IoQ9N_rbHURDmgJTmcE3eMc6e7dzRIGjjvxCwRK4ZNfOAZ64u_-fJeLYyW-zV2iT11cLHYBvqSfJBkxg7nqEuqvAfgIt5AdqFm70KWGjti7iSSVv5_T6tl-Gco3IjH3Uzm9fEW2x401iG1MVXiBxzAqf5kdDzgIrezcb6dxv_VhSmUqzCHXfQXb6wkyUDQYnZ1Q1Pqm0zQPFq_ES7gHUFJIZYtx6iEkcJZG_1fpv69mR5BkFk75Yfea8b6B19YVsBSyFbg1dzodQMp4-zs9zpwNUu1rfzOQZIL_yctMfnbmlItfsYMAwxSE43FPh63rBnXC9tJknGSdH80Xf1YMstoHruLOqG99M0_6PORTPOI1HBz_VWd8HZnYCGkea-x5wu9nGWYMX_ddW9ilXkkBIbIi4ekyx2bWfjE4KQ9VyI;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVeoj_bjoEEMVw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtla_3217PbqloGuVxafWUf_aAX6J5TzvjhQ-6QQTVcgyCuzuzFarTrRX8xzgL2pa79yr0Wo8JgdR8ontAhhLPdUtEHELPR7ZRnxI0xq-ha6IEyvYOWFJZ-sP1cbd5apqVS2J-rCjpKOZ8CgNQMH-nAU76vVCaB5vzsH8LOMANwGOq6Rjr1iAB8QoSadMyLA7k1wozHHKFU017-AZaYWFrRpjQw34L6cy9AdbLCX24_U366SkQhdARzvwkkqTlGwRamymoRpjSIsGR7QUfR9GWC1v1Ce0yibliqpxwYz72lL1RJlUB90mYkhh0JRZKx5GE9Y2b3SzPOIovPO5PUu-Sxfh0jrPmcJtVNX0oJNK7xh4TGzdaEpE0T07Ch5oVQsDjAp30gym5m-PZNTwINCGZKemGICeNwCJzYX1CtpkTQf0dLCF96XX-PqK_P1gCJjFDM4ePInYfxIkRJN0WaozCCcNim5M1S0lmSl_TcO-wWC0-HkZV7u_hRF4o7wYq5cKGsvlsRuo_GpBIyHLL7zOako97m0MqmJgfYHDJpgdQbpFHUr6Ir1NqpYTqXNNEO4MRtqj3sjb4JZz0Ua0AIWazSPCApLwIpE0Ri1qCnTeZcV0EiE2IH12_B1WRlC5u78VbekLrsAQt8iltXlH94vSCgmtzG6SbRfEBMWH1Lp8RlljQ;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVerj3CDoEEMRQ=
     status:

--- a/tests/api/cassettes/test_get_telemetry_measure[flow_temperature_zone1].yaml
+++ b/tests/api/cassettes/test_get_telemetry_measure[flow_temperature_zone1].yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkj6VQfUqgO8Ki6Tc61_gOoEQkceKv816WX6BINvsZzjFXA6Wn8jtDvvXypb3stHk4EKJW_XyCGxC7Gg3ghxXeDtIbuRbQNxd5QDjVtmIZxdRHul--wLDH-YJENFpgokhzrJn82Mln1hwoDL1rtVd_BYuTRkIGZBpYUJOA11QNHkIBM1DZrwAvKEHvkRr8b004ltTbbbJQuLL3bQQUaniCWuK5qWXBm4TU0SK9GE0U3PWVXcVICiEszdX_QdTF7NvU=N;
-        expires=Sun, 12 Apr 2026 13:36:27 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.S4iOtXd_17o2tofiYn72AF24kBlra0o6Lgd8aMY_zyg=N; expires=Sun,
-        12 Apr 2026 13:36:27 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVdsidWDoEEMZg=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=6eba6924-d4cc-42fc-92ed-7e627faadb3b; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968872870549.NDYyNmM4MGQtZjU3Ny00YTM2LTgzODAtMGFmM2Q1YzVjMGM4NzgwYWQ1MDAtY2I3OS00YmFkLWFiMGYtOWM5MjEyZWI4YWVh;
-        Expires=Sun, 12-Apr-2026 13:26:27 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968872870549.NDYyNmM4MGQtZjU3Ny00YTM2LTgzODAtMGFmM2Q1YzVjMGM4NzgwYWQ1MDAtY2I3OS00YmFkLWFiMGYtOWM5MjEyZWI4YWVh;
-        Expires=Sun, 12-Apr-2026 13:26:27 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=PZAvUFXgeA7u8nxFmKkcBNIwCgmJiJAJnuMNY2xIhbU&amp;code_challenge_method=S256&amp;nonce=639115968872870549.NDYyNmM4MGQtZjU3Ny00YTM2LTgzODAtMGFmM2Q1YzVjMGM4NzgwYWQ1MDAtY2I3OS00YmFkLWFiMGYtOWM5MjEyZWI4YWVh&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlAU0sbxdGEC8bNKajSyAHLNatZ0PGFgu16yigx6fZQcJLpcSFeEbEj1QJoHY1Vj_BidHWLlEUbxq-sCF9fqDD6KuioooMG25VzmYdMrLZYS5w4I-pvaVKdX8vA6iBuN9LgYz5oGmOmHhrS1heKQ3E8hzkmgH06M1XwGCqqLGHiMXDj3c178BMDoI6pvdyuoUpaJtvyLlYmauyEAYtNMUTk_Wxpde4Oi9J8RsVJYVUmwh40sJaP4ZZfa69U5wKSENKSTTXhfBUEGSszLWuwBYqfRTybjDKkAMaylmrsBebqEgR4wx0UmDT2mQi5jzYWnnUqYrTNm05-toXxDdXKSYr-fe9SkEsht3e2KvceaR3Nvd8luV70gEWSEvJz_3gOl5746xHnMa9nz9tl9FKiZJt5qdPHSraIqkq1PcV1RdHhd3CnZid9bOce5WMNP_S3TPKg5blpLPMMzCqgqc7hxr6SHah6xYWbs3OVcTi2DYeUffeK3xGRnxP4q0WfI5bbfE4YwNoP5UP9M7ZBQ77W7A0VgzHhHodBSUtZ_6U3w6AGAbE0_U9JFQqCEzYPR5AR767SnGlwPNCHihraXnxP83EBSFhVlu63b6MFvdF7p4VJmdncSPmj_I_kdbNHMjyN7TrvEGizolzLtS8zT1fMIAg2\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"6eba6924-d4cc-42fc-92ed-7e627faadb3b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-529589c2c773\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=PZAvUFXgeA7u8nxFmKkcBNIwCgmJiJAJnuMNY2xIhbU&amp;code_challenge_method=S256&amp;nonce=639115968872870549.NDYyNmM4MGQtZjU3Ny00YTM2LTgzODAtMGFmM2Q1YzVjMGM4NzgwYWQ1MDAtY2I3OS00YmFkLWFiMGYtOWM5MjEyZWI4YWVh&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlAU0sbxdGEC8bNKajSyAHLNatZ0PGFgu16yigx6fZQcJLpcSFeEbEj1QJoHY1Vj_BidHWLlEUbxq-sCF9fqDD6KuioooMG25VzmYdMrLZYS5w4I-pvaVKdX8vA6iBuN9LgYz5oGmOmHhrS1heKQ3E8hzkmgH06M1XwGCqqLGHiMXDj3c178BMDoI6pvdyuoUpaJtvyLlYmauyEAYtNMUTk_Wxpde4Oi9J8RsVJYVUmwh40sJaP4ZZfa69U5wKSENKSTTXhfBUEGSszLWuwBYqfRTybjDKkAMaylmrsBebqEgR4wx0UmDT2mQi5jzYWnnUqYrTNm05-toXxDdXKSYr-fe9SkEsht3e2KvceaR3Nvd8luV70gEWSEvJz_3gOl5746xHnMa9nz9tl9FKiZJt5qdPHSraIqkq1PcV1RdHhd3CnZid9bOce5WMNP_S3TPKg5blpLPMMzCqgqc7hxr6SHah6xYWbs3OVcTi2DYeUffeK3xGRnxP4q0WfI5bbfE4YwNoP5UP9M7ZBQ77W7A0VgzHhHodBSUtZ_6U3w6AGAbE0_U9JFQqCEzYPR5AR767SnGlwPNCHihraXnxP83EBSFhVlu63b6MFvdF7p4VJmdncSPmj_I_kdbNHMjyN7TrvEGizolzLtS8zT1fMIAg2\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"6eba6924-d4cc-42fc-92ed-7e627faadb3b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-529589c2c773\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=77139691-7812-4e07-ba6b-5bdfce129edb; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/dUaTEGu1pSSzZyD2yW5peraEsWau/HbnLTLoqwhJly8/FyZVNGf5wfVJpn+HMk4WAGHw6tlTJjhSUKEdRaO2Ku59Nt/Yqwh8n2RUv+h1/GSyhUX7huSHGsCTwwhmEjySHg0WvRFFCcvcoGtk53QV1iQo1KNSbCGGQ5OAgc6HTkmMOwRIiE8lJ+zyoBo83DSfTqfHfEqcA5kOIW7WMc+C2gSJy4Qjrvs5OtZMNC384izuJLP1D9cxwTLG+CDBAtELZ6diRHp3ucZYWawGEyGaseaJ/+jETegxMmfZ/VS06dhqM7IM1PriAAAA.H4sIAAAAAAAAAAEgAN//8MyUqaehvV8qZWaHRpFRXAfLALKu7I1fLJFwi4nL5hmfcTeQIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:27 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.S4iOtXd_17o2tofiYn72AF24kBlra0o6Lgd8aMY_zyg=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkj6VQfUqgO8Ki6Tc61_gOoEQkceKv816WX6BINvsZzjFXA6Wn8jtDvvXypb3stHk4EKJW_XyCGxC7Gg3ghxXeDtIbuRbQNxd5QDjVtmIZxdRHul--wLDH-YJENFpgokhzrJn82Mln1hwoDL1rtVd_BYuTRkIGZBpYUJOA11QNHkIBM1DZrwAvKEHvkRr8b004ltTbbbJQuLL3bQQUaniCWuK5qWXBm4TU0SK9GE0U3PWVXcVICiEszdX_QdTF7NvU=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtlTJb12zLiRfANKO3D9lFyBzFoUvcF58xdeD4KvUIoynNyiSJAEP31rFj7N43GNg5e7Eo3v5HkFZU48b9fzHNmjXk7F41-1a3XvJ2nbtLxhdhHTuaZFkxUptV75M4X0lh1mdL3xgQWAGColQnGa6pYZdWNMDkemzrSyHa1-Y2rQ7Lj8-NcBhiR3xyE9pepEUUm8wbYQ5RMSfCcvJ51waJR4oxO3PEiqOrxgPTcFIXcgvmihyGCxKgANACqa0QFWtP_mTSbr6quYMvr8bqYnaf8KcqXoEd8w37GjdL11i2XB45jTQmBdoUNx1qxqZ5rbzCUILqw2DH3l7z2_iUxHuWyeFUnXzuMXvgTbhW9djJnQSIeKn4lqViR9_l1gNb2620iTB3nr0K-p7OYUKUadAalU7EWMb0gokagBtQuPtcls7X85g0vUQzg_0YBvUOZp8dz3p8AaAPHudstOQIlDFE7tqTpF_qxmFvF4OU3D5mIOqwM1rbXJDcAk_9nqGH7hw_pMdbLYjEElQFokUGAKo_gfIFnVBwNAWqqEiUpaqup0S54VWFJHUIijX2kPhyQPoWONjd9PjWQ2DLcMUIdZ-57tooPKyImjG9JT709Yuf-9sO0dLKJLh2CrjFEQeMWv1R_dkaC_DpF9M_afXiNo0GMUQ1lkaJ_UNn4dvH_UGlb7tGaelXDJ3Wf_FlMP8lviicQU5jmNtc_Rv1SE39mysz987L1agCm8G_gEMvRmq4Jj9mH6tNvs0GAFJJjD8ttLfS3MKPy664MyANMS8N0cxgQH69sWFp0WucTyivdVpZLYrx1IlkapVFVrdxXNiUGL2oeHmdHAVm3nwW3FUSvKAejJtPwAFZWov23QQUTW53F04bg1_ttoiVz4Uhdxh5FN7eAjUxPvBkNKP7rX5hESjK1jxrF7lcHs8mxRPfjzWzJiouVBHLmTgodNdMd7QHaPZEDk6_lnsY2UmlXHLl-iZCwSlg82OyNZPuSMueMnP2WgKdrK3NCRji2hWhZ_4Ypz4sPx2y3I9US7P3JsRyrsK7xAJPTJpCB0H4N0jgj0g7vIYupR0G3ewtnJI5GpEawKq40c2nrHTAQix2ArVuuBcMi_7q7iEjR7TlejZ-V7cKTYukf7jQjrW2paFLnINPRRfH90PRFVv6zp99aNWClLi7IGZP0_RSQdm80j-JBSP4GkHyAZQ19MadwMKLPCsGjgzB9VNECS0-dwtX5O81rjq_dMW4MKTNjxPXb9pXJWaHJRgjegraaKAuhp08L4V9zR2MxmCx8g_Gp8-TJ1KskFIbeE9nvpd-k-26QaNIakcilTF40RkoO6BhUB_oEqWJvfPoMBew_uEtzpk6fiLz3rjpBwkzLwxsnUkvmISoeLcDWS0mAs9sjhIPIJk9RxJASNEwuMLPboAsqt5grkWZnRNEYVvW-WXK1tqw3Xe-RDByS_Bd5ir0eO94BokrZpuPqnCZ-JUrM-m-u3VYbzTKRVk9C5V7kRd5J2lPTJ0peFplOt3cA9TuELT5OgWLCorJ61OiD1SSFYf-shnTIHb6PSje9nux2FMJ7fGsUX-Cu2VcPPXEBOX20quRrwKoEbZRzkxmB-FAHDlc0bAePY-e2U3ITgpVc_uGqH6nQgmlLxCyVwXjVeEpbg0SkcCzFrs3bjNsta73YxYpFcmT0hbGoZ2AN7w1fu1TGgad2kpV9DwG7xzfjyny4LwVF4eznF69V1z-r9gd32yMsTHu_WB6qieC0VsDLx2AIxhrPISD66hCHStZUExU7OSEHjuj5CdwZslL6nU1AlqpCbaksfTgih_st1F-Blpglkc5Q_pPfYQJ9pSXn2MxZy488rrV44uiDlWEbWfcKZcgmfhjlk0PektWZ0zuF3hChQ3bhs2Iq5ldS_1uqZXu-ubfL4JX1LA92Fq3GEY1gBTyg-jNGALb_KF_TNnGC4Bn5nhQsMpfZQ7gSkwUolyKYJqkonTCp5daunkSCfmFU7HhvoxYXDkw_BPFJCOu1ZFA02l7olz1kkVHtrU2Yd_xDtfJqxsKnIwQsw7zYu1pGN4wWN54R_0cZismd_U_ndRvQuuYWpH1_lOYnFWKqdF7k5rSF5fAL58TS2-ICYZMureTB3QIbFBdJxDBurGPSQZpXeupQ4C-rdkjbWlqVtwDSPWN5R7vrPdtGiAyn7r-vecdgNsKJNYHrcj3WnWbXJtUj4aoZL9sUsDcErMuM1uLfOMhPK-fax5035wZhqcFOkDdTuCrLs8aSAxtQ7r6OcbZCQYGN3LHhV9Bvhejew1goz5Sea2EDMBI6b42t7Rom5hEQ-RDt-eh4aq7U4IKce9UBEFULVvHlC3u6wkUQbZkto8hZO0OjVs7xQo1L9F6QCGM8YBnWczG0KcFu39sBV54uFsY8JZ3RZypGMHgAIR-m98lNUhfs2JeHoivlUHxoQisVBL-oSwaZv9EV9Ft3Y56t8tnZYEqXdVT9GGQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVdyjRfDoEEMkA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=9CEEFAA09BED91BD2B457CEC31205AB4; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnAXe74nRmrHz05_UyQPCcM771sQ6PgzEyNTIOUBM-IaP5c-1xY95LtVIgN3HplwyTGO8EwhGP3FJ8heFEW5p7n7mNF81tYtOqjMN5nCrLdqK-J7pLnFL4R46qhDwZfEpyMJbG8pBDMhzQhzJ_PwsLHLeILYocHkVInYW-KZY3zHaS0lJk3HTr6QELQLkivtayfua4w7eVhpX3UyIgRSM9d-h2etu7apy0Pbi2YlQtv52ihex7c6PUyU1oRl3k5IF9Hi7f9nG8AJSeBgC8e3CN8lI9dPVNbupP8XAmgNLOfeVLTB6Wd859_qZFyeDE-1VXyQGQcXy_GiSUj9RbtdCAMmzLLYvpmfYVV-CtIrIk0ektgt4RPbaLfEBi4x-Jc2Aprnuh1e8FvyY4WRGrI8pP2JD-lJmIYlGfu_JwWYAx3gZdpvb7X6EdUv3yUL-OKtL5D28h43Fcz7M2kzHcPm166EFqQrsq8Xwak51dxUrzhRQhXsGf5sSAZ9YBcYD2PXwwJFko48HoMdbo0yHdkjG1R88uuldN1pQwqsQ_LmEptm7X_K-qxWtL7OSAp1xc00KmJHQWFUkAkK8XdpsCdHQMhYOD38jM-tGfDw8tGW9i7JgTnkW8mTSbThyxeUJRrVRk;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVd1hX7DoEEMOQ=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkGX6Z5eE8_kpt3weO51v5capx6vy-1EvKzbiONjKJcjj0gyVQdda11E7s9U4wM2DfQ8XXgcWQmRwgatrZHgiqEjmoZ1OJ8UHuDD94BOvMEP8QHy_n1F3RLTpyeWhmN526d4EQrcg2AIPsg4YgnmO4MowWlKj8yZ1MVZOwKIdt79697Mx89dAPGsQ86LYFt3iUNsI7V6Kbuq5EsrqujvTel_O-dEFZBcaFsjqT41xkjplG4qZXh3X5CL7W6xdhmJ22cQFK_YJh3q97cQQCbPW57H9xS62zaurBLci4uDq9jpUrdc6aC8ab2TZYzyPYWyaBQVm6AEw8IYc3XrMRLRgnt2oyKmWQ6AC0rncVI02hZonYU7MydpsxyV_hlVtuTeRiyunme5xcI2dFwYPZMwxiJhmfMW88ue7cqyck5pCQLBcjy_y50h6LcUVJPTk2RNXhPYYHCUVKuVfhniMhW8OjYW75P7IUl8Z5zPlbq9qE6gXlEaQUgbFdV7ltCN0vJsHw0V9AVq9MwT3CQHI3OdjO_xUPCRQLFg0Gyw9xa19pNw17YvmlpVo5WcsikXOxj23bpoAi319DmVM0xe2PvvXiZlONnPHXUeRUA5zf-7Hjo2-tnnDxL3FyB0rJqdAjHZtbcI21GfdzLL9PeTz3rueOZ652ZAmlrqQEpfhpjy2EedA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVd2js0joEEMVw=
     status:

--- a/tests/api/cassettes/test_get_telemetry_measure[return_temperature].yaml
+++ b/tests/api/cassettes/test_get_telemetry_measure[return_temperature].yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlV64ric1McLlMn650syQnMDTMcTQVdwdygjSZ6xx0ytQkH_G32A_bTltj-Ivjj8654QZsrWeHaCJ9nVmb7TGRBZCN68gWJ1ESVfrOsMQC244RSJBVwXlpDH4Q_YFD4jIHTcQs1wsWNp51MWHr7bKhtmakLXDS9LvqaeGg14Vnmgq0kzyP6G-a2_VuO6ITnoABxG3vIqdVAyC1_54HJ87YRDdVBkWa-uKGhrS5bk-MHX5xosvT0tCjK6si4iYtemiA=N;
-        expires=Sun, 12 Apr 2026 13:36:24 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.K-ru-tg0ri_-92fnE_SH6XTAJ4qChgJQkWTIxJw-ULo=N; expires=Sun,
-        12 Apr 2026 13:36:24 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVdSgH7DoEEMEA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=6df2c5ce-3709-44fd-97b0-84d35645f15c; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968846939812.ZDQ2MDRkNzYtNWQ2MS00Yzg1LThkMzktNjYwZTY5Yzc2ODM1ZWM5ZDMzNGEtYjU2NC00ODMwLTgzMjEtYTgxYzMzOWIyMjEz;
-        Expires=Sun, 12-Apr-2026 13:26:24 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968846939812.ZDQ2MDRkNzYtNWQ2MS00Yzg1LThkMzktNjYwZTY5Yzc2ODM1ZWM5ZDMzNGEtYjU2NC00ODMwLTgzMjEtYTgxYzMzOWIyMjEz;
-        Expires=Sun, 12-Apr-2026 13:26:24 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=NA7u6DhFIgI1W17m91jDvZgjU-a9HzZripfMAgkuhyw&amp;code_challenge_method=S256&amp;nonce=639115968846939812.ZDQ2MDRkNzYtNWQ2MS00Yzg1LThkMzktNjYwZTY5Yzc2ODM1ZWM5ZDMzNGEtYjU2NC00ODMwLTgzMjEtYTgxYzMzOWIyMjEz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtn45Hisl0UfmIH_RRaYIyjUtM3l1PlZFureEtUroqPzBbpKbTqpjFTc7amCfcB7PjiU3H1LEmgaD1cySwGLUEMV0INCEn5wydebDUZueA1jkbahAFeto0dXP6iWUjaZ_PFyXaGNOqzc8U6G6Epc3wLP4rvGAsF0CdQ5HJxbR_PdQbRn_tgNDHQd7TK4HsRoBUTtGVN1fpcIDvQ0KAGkMlA_wNddyWH1ZOeaZ-WZsOZ9MG3NgE-eLSsRCQwqll2BSMolD22i4MtvsE2XKw_HIlEv685xtMchnKDbhIHdnosnwTpOHu3wbrieJWBsgjBKOEaAnjAwd6nHw2-utXPIb8c87U_lEzcoT1ViC8Kea1RE85oi7LHl7ZnMPd_wUzlTrTtkslv1lupzZIXSiTvBR0FhMbjuUwsGVMKbgZ_iZnjkWQO-moj8IpnfSm5G5_G7-AswrdKUfpztAm5DfxEFzXunOSVN29h26Qmanqh5FpbxL9Q14uwMUG_4KFKLWAoxEmIJrgRN1lah2SIoRMl9DW3A0at3s0pBSabT6xa9LxCdxj-MmZvCNdcLXxObHWPdXOYkxonzmqOrlKdTAkqAEFwCK-ozsq9TUalqR-zxCVBjjJAkGSKa2TI8UK-NnzINulFhquuu7ZLHZk5qeV5nzFPW\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"6df2c5ce-3709-44fd-97b0-84d35645f15c\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-371225c2cda3\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=NA7u6DhFIgI1W17m91jDvZgjU-a9HzZripfMAgkuhyw&amp;code_challenge_method=S256&amp;nonce=639115968846939812.ZDQ2MDRkNzYtNWQ2MS00Yzg1LThkMzktNjYwZTY5Yzc2ODM1ZWM5ZDMzNGEtYjU2NC00ODMwLTgzMjEtYTgxYzMzOWIyMjEz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtn45Hisl0UfmIH_RRaYIyjUtM3l1PlZFureEtUroqPzBbpKbTqpjFTc7amCfcB7PjiU3H1LEmgaD1cySwGLUEMV0INCEn5wydebDUZueA1jkbahAFeto0dXP6iWUjaZ_PFyXaGNOqzc8U6G6Epc3wLP4rvGAsF0CdQ5HJxbR_PdQbRn_tgNDHQd7TK4HsRoBUTtGVN1fpcIDvQ0KAGkMlA_wNddyWH1ZOeaZ-WZsOZ9MG3NgE-eLSsRCQwqll2BSMolD22i4MtvsE2XKw_HIlEv685xtMchnKDbhIHdnosnwTpOHu3wbrieJWBsgjBKOEaAnjAwd6nHw2-utXPIb8c87U_lEzcoT1ViC8Kea1RE85oi7LHl7ZnMPd_wUzlTrTtkslv1lupzZIXSiTvBR0FhMbjuUwsGVMKbgZ_iZnjkWQO-moj8IpnfSm5G5_G7-AswrdKUfpztAm5DfxEFzXunOSVN29h26Qmanqh5FpbxL9Q14uwMUG_4KFKLWAoxEmIJrgRN1lah2SIoRMl9DW3A0at3s0pBSabT6xa9LxCdxj-MmZvCNdcLXxObHWPdXOYkxonzmqOrlKdTAkqAEFwCK-ozsq9TUalqR-zxCVBjjJAkGSKa2TI8UK-NnzINulFhquuu7ZLHZk5qeV5nzFPW\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"6df2c5ce-3709-44fd-97b0-84d35645f15c\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-371225c2cda3\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=11244598-46a5-4937-8b55-fcc7d874496e; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/Nevf6j4sX68HEYWpxtDIIiRSRrCxc1QeiMNifOgrOevy6bn8829rY2s2LjtxwTfDWZKjbK5FuPZk0KfiHOmznuPjENUWIsDsI+7ZH+6n8sS7gZ27FOPdGimJHHuMMI4bzGca9LRcZS0ROqM7oDW37Zf+miJaW6XZZr/Jt8ZfFdHOd4s8pvmqOHPPG2gNyfK7DVSH9X+XprjCbcvIV/4sdgq5gkEVn0/YdP+sBP1MGP4y+N2hmDQi57mSqb5I//jjO1z/L6UFpCjeek/Qc2gVe0SkLrwq+oqOyuhkuVAY002+l5wPaWviAAAA.H4sIAAAAAAAAAAEgAN//kKc9+zc3BXn9Isn9ymNy9G+hH1npGFUKBeNyMumlwcJL59Q6IAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:25 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.K-ru-tg0ri_-92fnE_SH6XTAJ4qChgJQkWTIxJw-ULo=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlV64ric1McLlMn650syQnMDTMcTQVdwdygjSZ6xx0ytQkH_G32A_bTltj-Ivjj8654QZsrWeHaCJ9nVmb7TGRBZCN68gWJ1ESVfrOsMQC244RSJBVwXlpDH4Q_YFD4jIHTcQs1wsWNp51MWHr7bKhtmakLXDS9LvqaeGg14Vnmgq0kzyP6G-a2_VuO6ITnoABxG3vIqdVAyC1_54HJ87YRDdVBkWa-uKGhrS5bk-MHX5xosvT0tCjK6si4iYtemiA=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmabn4kj-_AsDS_kx9INZ_NBxiBViRqWAqUTKN4mC3YM-G0lUPgDHfLZ2lHOPBMV3SoNT6uoqHeKOik88VNvjyByxiKtYDAlr4u89oY-oxUAgZ2zTiHCxH8mqjjz1XnVi_65eHtxJLmIqL7aEITv1QU8-U7RoguiF9TXpzVcK6GLVcarytsWNCrNHwUj9IEiF5OetGNO2YBO81Q5K0PMIQScQGdp2B1Y_PZRuqy1uLv6yzh_42Okd7P8mhLgFY-3N-Ka5bGHh59Pc5IEYYfCaQXtLx70_q3tFZB-wlDHFB9iNoABztr--UrIEsiHZHcMhcrEQZXTAuT2yo7A63P5cv4fS4LvgyQEeMQbPykcu1J5P_kp_RtTJMSXBNsX73ts4h53rs5eEfAvQCWP2Y6uc6l6deHl9kPskpKhriSyzQLNfO8UCj2o49OvGn24BG8yQQX8LU6lByR9GgAI3T1EDztlYCb9Ou7GmkQln7N7Ty1AAdphsumIjq1f6_C3Kw2jNG1rdc-d2ifV8Qr5OE5xIEXyTcXGfhj4_68USe2MrcwciP1lgfBBwkDrtITLo7o4T42rlEjWtu_xl1Fdu_m7mz4M4XFj6leCXzJ5h2aXhSbaHH94zw9_S322pgN7bNJZNeuS945EsCHNrDyyFvu9OKMTQ0xACUqZS-czRtFWwbvcClIbNtUyIoa__VIO7lZRKC-VJnHKPSa-y-UW8MzOMw01UOHwkRgMvkgEEskiczzr49lixyN1AW0IlQVTzN1zwQxom5E2VXM5OZOmj5SYE2iHV2I2NYMAt4qhMFttwG-f4WNfe_HXRVn9H-qS-pIXIYHm-WwVuJq0i0hABnOYwyomUBaO2GSPop79WGPuwyIGWy209r9YEtNTOJRrLRnY8wH5rf63uxXl1cR-303bJ2XavLR41N7LNLopP9lYEEApotGzpcdmdDPkBnjgmGdbkBOezCmRgVywecKm4hdHxGMBY63NYF9U60SOTPV_uzstE_uIoPCndC_Ua3aGGaFhFpud2wIFK7DMwzRoq7VVY6sIMhlXyMQeBkiYOBnlbO62KizYLm6LDME24qdcqm3llbWr4Ema4f5D3qVdmme5HWlz9j9fjmXdZlBoWjacOhPuOIWawGRAsu69c6Ap6-6OnK6XTSWKJaOtHkaH9OWQy85Kes6R4Ziz3xRDoiJZSkBQWsC9S2axjkrglCDypqgjsIFDTYMn4s4sI5TOBpUaRjwaDTLaudbGZ0rexbX5KUULV39ILBjSB5k3Wd68a6zYxQPMpNTelozbOH-kWoyuouoRF8ObEmzAcffbDCwMnFh2LtBwOE6eI61syyQwofoIw2Rcft3yL-OIBhsM2Rf0S_s1frqHcNIxmHNH8ZrZd9npIcNLkIse8eyHI3LdqS0HcTehT-NoASBg8kovC5Ag0Tqx0MqtTj_lZZ6HtuJpuLuG1CLvCSwKbQMzbCcLGizMYBzbdnAPfbJnrmMT8wNyGwoFOCYyI1jyQeK-MJIv8p8pvI96Q_HahXio8gt7T4HfDzHJixZiPapKJgq-QMpnR01FNHP6jSYwC9nCN0-HcEz_lj1BDx6G_b6XNWE-lSva5_4Nah7x77ev4Sp0URGC5cHU8wHr74hnNtdO7l2y5vbb74RlbR-Z-De4a4Hmw5nTBRSAHDJPwEAr8MIVQYwU1Je4v4mXApmDlQ0Lj1_5G8yB6eghq43Q4LJB6iw-h3bSVNuwQZoRWgDvZVjJoZOhsS_pk8U20jx1iwfXIqGxa7gV29rhiA-LXqs2FlxWuaj3AQLD0s5GRPuxCBo42rm2a5jo9nIrpmPujasBQwyqAjZHthh5cPnovT3CnvJ8eR5NL6JnTcTHDsJD_9Jf0TeVvj43XXwc-HYzwOGkFBlWJSlvZWFyzMmp-99_nrNcAlwZC9Badkk6o-_lHZLEwQhg9Gj3517x-mnpnhR3q0FB96kb11OnYClUYV5mIelfTfHRyXAsZUBFFSs5jmQpObgeTapTyDHJ8pxPB48y9tEpOCKFHPSCK1AsZaxNKUYCOuNLUPYDiaKysyZWWPs5ntYyQyV-_4Lx7HZrXdUxyiLgknO_ZOiGQGnrV4amSvMPu0mN23W-silLz0BHLqziBbYIJHInIsejO0JxVJ7JSeI1_bDqclk2lYK_z-14kxkJTk0UIMi_eijwo6-hb4Q556yG9J0TNF90-R2MhVGrI_s8hPKMTyFDpqAZQ1f0_ziI7j5f7yyL5xeIgjNfgF0TlgUuK2l_FLaBI3h6TWm6atffNvrYApLytWSbfWLn49UBc0RedzxPlOo8b_OfQ87sTlQQkd0LKODdEa7t02kCnrFfIeehD_XdkqYEtWc9lhIC2TNpFDNTVqVv5scP_smt0Rvf4dsExPnVfnNjJzD2gNwRM0aZuw2bexoJiWOk_mEr84EaZ5uLuY1VxxQT2S6ZZcNoRX785-DJ2Z5cDUY_GlN0HMVRw;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVdZjG1DoEEM0g=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=DE9439D6FAC3FE5A7C4E6114EA9081EF; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkGOWGEZhoXwg_GOjcGet_eT2FMZQXg-pArBcZBDpTJENggP_vsMrtjPHIzznom28rSDlTPBiUcdCRRF06mYKNCN7dHbJRtxyMfUI6a1HQkQGw_h5g7yapqxewD1Ltj8I0r_xGZSjdYMmnE3C-Gs-WX6Dff9_z7jzf4yHTZ7bpzuEZykDVVI4uPsUpY7NP65ln31X_sCOOmeWbF-gcTTpflzSjluD3y6XtpUtEhgt2EJBvVZoQGBzvMFP6BJCLYJMloIXMnQCq5LWGTjCyajqmFl4sigiJEiTj52nrEG2mVitBePZ9Gk5EJlr_BEaXCQ4LIcQouV7JQe5O1p-TqytjduuxAuOITG0D_FY4Jy6lkuy38A6Mt5pV2a4ZH252d8TkE_lqDXZ3QChXldrYu-9M78Arlys86aIhsObIX_-WUuonWDJkxtEM-jy5fpa9206W5sqflzEe92zvx1f-jdlifL4iHYgrcIMnBM7Jj7BzDQjFPz8jzhb0fK6XSFHwNq0WbLtXdVjSZdlF37ERA5UU5EdMqFcKPliolFvuY_ymc575lkV8qh8pG3Nux5WJdidIq07s9CcfGprr27lcosyszhPAPNAzbA1nV6mECbaeQ6Fq8HNY6ucAjHcQmISdKRRg;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVdbglyjoEEMLw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnvfapumrXYv3rsLIhkuWkDqXUDqx1RsdYwPl32p0qMbR3xjsnmbmm_LSwYu9d9nFpvcyGihodxE4JBKTha-MabtPRyiXvBUNRM5ypft8YKct1PYxzDhIMvg1mSGup7-oRqSU-R5jpCGbOZVRWmF63ZhFcIlA3VR2N38TCoFEe-QQ0qmZbXDy_huZPtUYBymc2232ZRshnoj5mid7UitpFT6_O6P-m9ja6gMsvrq_rv6tcrAQprV1JzGXsljqzDtCZhkIUg_n-CiEzW-Ft4931FI5elRI6Wb5BTfAeyd4pyFJQYtayT9etAdV_E1vffJrZgybjuRdI0-ON6lYTmwlq5vqhqz4gLdf7NQXPEsuS9UZqfWrUHf03T5hDlUcF_gO-QAj9VJqVa0y1y3rHtpZpxp5OFoT1F2OiS38tzszzknhkbE6ubLgIY6vOafqC3zqe3jE_L3Dsus99MAjUe-1WzHPfPNLfutHzyx7xWPWKAb-Rq-AnTZjdrZsL_smZpNnMEw8lcTk67aa5BhyD-pyWvroexQSCekc0MXmfm3YrFTFZFCkZ-ticzxfgtMd8mVlzvwQMz6eMwA0y282LmqVQcHNfYs9YoCcT7-o3PsgUEb_tGA0J4wVjTneIwpKmjJDqH7n6fIycV1y4KjYEVd_31gUOR7l8w6mqGs-tQfAuAUw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVdcinIDoEEMug=
     status:

--- a/tests/api/cassettes/test_get_telemetry_measure[return_temperature_boiler].yaml
+++ b/tests/api/cassettes/test_get_telemetry_measure[return_temperature_boiler].yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlvhMR8gyOFv2QF-qN1Q-DlhlZdJZ2du-QfsMFiyVKOK9SzQbgRJrKC0xRhq30z06tUhU0QQiEjBSmL5Q1hWQkATcFwXwXTtawXnKMGzbGBw67Q10E-6PToMMdz-2C5Opxg1VE5W04KdsKcidVhv2Wtb3p50Tr5ARfrNk9a4W0r1G3SBEzuqNd3cYej2lx1YrEmLgbhusuopXulG-OZtS_Q0sIN3MSzA5uHp46tJNeW75yt_Or3REMf3Uz-6VAxD5U=N;
-        expires=Sun, 12 Apr 2026 13:36:35 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.7doQpOKh0l6_ve3U9LQDF5G6IdJCXm6ak1eb_GMJXzI=N; expires=Sun,
-        12 Apr 2026 13:36:35 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVe7hE4DoEEMHw=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=d8c61ccb-e5a2-43f4-9458-80cbe379388c; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968951881420.MTE5ZmE5MmYtMTE4Yy00ODZmLWExNGUtYzA1ZjJmZmE3Mzk2NDIyMDM3MGYtOWFjNC00ZThkLTkyNWQtNzFlZWUyMzE2MWQz;
-        Expires=Sun, 12-Apr-2026 13:26:35 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968951881420.MTE5ZmE5MmYtMTE4Yy00ODZmLWExNGUtYzA1ZjJmZmE3Mzk2NDIyMDM3MGYtOWFjNC00ZThkLTkyNWQtNzFlZWUyMzE2MWQz;
-        Expires=Sun, 12-Apr-2026 13:26:35 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=4b3gqIAYGNopN-NM6nja2CkWUbCuAdxdqJ-Q9h6KvOI&amp;code_challenge_method=S256&amp;nonce=639115968951881420.MTE5ZmE5MmYtMTE4Yy00ODZmLWExNGUtYzA1ZjJmZmE3Mzk2NDIyMDM3MGYtOWFjNC00ZThkLTkyNWQtNzFlZWUyMzE2MWQz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnQvL3z5jBr9zIDFIfWZ9AW2k8g7FhvSzfZIFFDRWGuksciFl_g9YnNxvjQOZ_fXWydg0-3ZSi_yRrgPiCYBA8wgvrDg-4JomJCmnNwQJxJstcmcungGo0junmTwSXblhcXpsS7iayVrJpQamB3srKEN40kgiNEPD8zt8_g4sox_xO9V56RSsBq-P6aLO1jj_P1duXkTyHHNyVBkk8i7_vMRwTK_H2cv01sKj_3MFCEaQmICfbIBdvA8DGsrKfh_i056H-93FWLoJvvE6Ac8SydYQRd-OOBkbJJ7RDYGCAFhtUpeFnLfXI6_NzHbCMEDva5yWJQgSwwcXG8VGhu_kesQpJDL-BualJujMvPa3ScpnOIbh-L4WoNU89Le7p_af-eJwW4F96wH7mjRC0COAee5KLcj4fILTFjUaOZ-OYVyImWg7E90IdEqBD2_cpDwu3ptQNxu-JXACh0I1wBcm_ObXOUa0Iyx9P05lSKcsk9tFIJix8vpKGNdSF_6yVt4I5POr02-5wZcYrSzAIB0hCImbV3Rw3mwq9tsagIjEC9wlRaPaiVYVs9dCeen-LPLDsAiML-hAdfHaycbS9nnfUe7qCC10IPJlpTCgemOrCJCf_nKZxiGLtCrUx4BqoNk-qozOY_VWj47i9DLMHyrK9b\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"d8c61ccb-e5a2-43f4-9458-80cbe379388c\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-f022a71b92d7\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=4b3gqIAYGNopN-NM6nja2CkWUbCuAdxdqJ-Q9h6KvOI&amp;code_challenge_method=S256&amp;nonce=639115968951881420.MTE5ZmE5MmYtMTE4Yy00ODZmLWExNGUtYzA1ZjJmZmE3Mzk2NDIyMDM3MGYtOWFjNC00ZThkLTkyNWQtNzFlZWUyMzE2MWQz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnQvL3z5jBr9zIDFIfWZ9AW2k8g7FhvSzfZIFFDRWGuksciFl_g9YnNxvjQOZ_fXWydg0-3ZSi_yRrgPiCYBA8wgvrDg-4JomJCmnNwQJxJstcmcungGo0junmTwSXblhcXpsS7iayVrJpQamB3srKEN40kgiNEPD8zt8_g4sox_xO9V56RSsBq-P6aLO1jj_P1duXkTyHHNyVBkk8i7_vMRwTK_H2cv01sKj_3MFCEaQmICfbIBdvA8DGsrKfh_i056H-93FWLoJvvE6Ac8SydYQRd-OOBkbJJ7RDYGCAFhtUpeFnLfXI6_NzHbCMEDva5yWJQgSwwcXG8VGhu_kesQpJDL-BualJujMvPa3ScpnOIbh-L4WoNU89Le7p_af-eJwW4F96wH7mjRC0COAee5KLcj4fILTFjUaOZ-OYVyImWg7E90IdEqBD2_cpDwu3ptQNxu-JXACh0I1wBcm_ObXOUa0Iyx9P05lSKcsk9tFIJix8vpKGNdSF_6yVt4I5POr02-5wZcYrSzAIB0hCImbV3Rw3mwq9tsagIjEC9wlRaPaiVYVs9dCeen-LPLDsAiML-hAdfHaycbS9nnfUe7qCC10IPJlpTCgemOrCJCf_nKZxiGLtCrUx4BqoNk-qozOY_VWj47i9DLMHyrK9b\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"d8c61ccb-e5a2-43f4-9458-80cbe379388c\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-f022a71b92d7\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=704f8c08-6597-473d-a6b2-7a1407767f76; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/T88BTsLPuStoXLMzI9MMvjiMQ1g4zYsQVD+D3dkWTBlw89gNRUykT4ieqPJmzHUwH1KgcQ8kkWGKhyGoVPIZ9y1qAPdZfjmCIdS86BFVcbf0XfMQO93o6yKaJamCNQGJO2V0MmuCiFpqtAeTK9lE1hIyi3pPm0mIg+dkmbqnJu9HPU6ujNGndF24m29nCV0Lk5omnyIxhDeP+rBysoJPCqogkwXQC21el+i7X5WA5lPaBViZxVlSkDMt5XZcQ9KQLOsVk41Zt3xHYlMc2Apcy+9N+QpJRpf6eQwjUgTN1jMAdPSmYpbiAAAA.H4sIAAAAAAAAADurzJzeJ5l1vuKLywPBO69s/jKzWrQZTHlwS8rPzklALgwAC3TUwiAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:36 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.7doQpOKh0l6_ve3U9LQDF5G6IdJCXm6ak1eb_GMJXzI=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlvhMR8gyOFv2QF-qN1Q-DlhlZdJZ2du-QfsMFiyVKOK9SzQbgRJrKC0xRhq30z06tUhU0QQiEjBSmL5Q1hWQkATcFwXwXTtawXnKMGzbGBw67Q10E-6PToMMdz-2C5Opxg1VE5W04KdsKcidVhv2Wtb3p50Tr5ARfrNk9a4W0r1G3SBEzuqNd3cYej2lx1YrEmLgbhusuopXulG-OZtS_Q0sIN3MSzA5uHp46tJNeW75yt_Or3REMf3Uz-6VAxD5U=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtm3ZhzncN9wBQAoWOb7djr_qOH3aQPUgkjzziA3fZFluxTpTKNpOu2PpmfwkwQM6zTTnfQ-ekYu1ngm3y2Vr8vbzCv6KsAhyn6qqUs6C5d0QZ3wcOYTOIR_blXhVlTSzsjLTAm9S3eF3Ot_RMO4rAwiCIP0UL6IG6y4cGiaciGMujJN6j-qw363-s7XDjEqZcUNPNty0-npxvMMIBKaOwpkJy00SJJldTHnZ0zpLMgNaYltlv9FQTqO3N8FUtv6VpnE-xiwCOEYKjByABspr-CDYGsWVqGUWc_ffmExPkVkyuG7nT3FZzG3G-8LPpZWor0ozrbajU7IWh7QHurHTfB2qYJX_1x5G-7Jr63uXyxOgkl3F_S-XF9S8dlU5guQT5zwy4uhdX8Wyn19-mCGHXMTMzntHSEwgU6eRLhXalUi6UgRovamn9utrElHCmt6okRWN6pY59VQgj4EJO7fW6FzgsTOm8MjFWgssD1htJGwTNeZ3p3Nd91dBQj0laUREzk65mJu8HUFj_aReIzA9hyZfcEwCkxph-45tgTN_5nlRlfVdWq45fiEgOjcGd4uArAUmAifaM7k08U_-_teQcrv8DGFK52zja8y07Y8_AwTbcKfrHVGItwqrDI-HQn0UHMAtZltXI0CqYV65bct7YqYnRGsLMpJA3zzeJolkgj0uVyqOO79FwjQX8qg4BDrem2Hvs-WNYsr0nBVfC_8OVW4vD367UeBZX05V9X0q8eLn3yQS_YiCsJ21gfJeieBlBqt0G0g_jFXbdLma5IRLXSPvRUPuzrEiriXcbJClKOA5P6T5FnBcVgLNjrXf2CW8ROI2Tv3xejAT4j0t_k5pEyx1m3fzEHYBGbJOakmTNPZnCcDZSc4jQg0os8d1HMXPqFPK5i-AVtSAar7Z1A0TfibgnGwlAO0WOs6Q58wY-aJndAhynZe6BL2amzoOSD1ZKcHS5SlipCshj5ugmrOEAvkbmMjyr9xv0BI0BIdTfijksSMqXkB01M9NlUEW4Y1dgA1H6_50Dsh0o3ESDc05hKWDOLkE09Cmjp5tCF_UEgYSWtfgsAAvHQDgnQlkZ-nFU6Bhu7GMG_nET5FPaqRKr98gh3_s5aHF8PAwi8YBp6OMnj_ocfZnkSzpYWVzFnfHIRlphW5YvDBE-ntud-_EedukD-ofDbTwVylbfIICf4h3cuVf7cit9rX5HzliWTuMAe2VAtjRG-yJWt6d3YnTGc92zCpbVOfaj5VMMAtRB3KJ4el6QIXabh2USOk1A0-xFNgTVwrSqQ_M9xVO7ELxrRIakKuD2hwCQShYXjgc2Yqui5-2h5ZEtzaAff6L2Q9Zs2FiUMYu0XLrVskp7gJok3auJTQrdKMxRhPiM4YJJHWS0Rp5Cid7jFpHXLM9v-xMvaZ3xwHYxSPCp2jsu4zMTLQfEgOkYvx1tFxhkDQO6OtgPhbVtoG7Ho3SRyuKVXgsh5w7JBlBUdvD5txZtGpBZXLU0Yb3i9iH1-8Ov7__4Uy6xJBCd0kd1Zt3Pzd_gXz29pTBrDe2yKw68nY_O0UnyD3XC7Bi3IzS9qydzY5DhtAXuQumyTYqh69lUh9ObkGO-vhUIQ_hFrRWpSN-fz7Jb1d1Lhp5P0eSNopbb2dsjpopY4aBOVZVYdMaMLpsNtxFmgRrZrzfLz3cRq-12GRz663s8wow58o4_yKfuFjjWvVlLHDSNBKOn5jzOx4bpEACfViemfD7Ul7pVa1Zqk_-_mrAKonzjs5Gotiu85LMi8UglssImgsry8MlStsyktQBIauIldeuj7AxxPSErRhxCBUJWoxQAZDJ5CepHw9C8k0gCaN4lTkdldtncPWhWJ7q4B3NtBnJpktAeMwQhpHykqUuh8ohzzKJNRcJJcQ1YR2Wj88jOjyTPV22uRYsat9Do86_OovdmQiEQlF0hzYzLB_5kPEbSv5qM70dZVrmesO0bZEJvWGJZUsLW8xYWJ0Ql8JYDC27L2_dqi0BZdWKVJDrWCXuoyDCO-qQFljS9XpcpijsVrf-XEl8L3j5mx0e46opZMSAdshofQIC0_n9cUMRergxTiIXRjy7zjxH_8iWQqnVagAHZAlfepFvRjwySXvD3yWuc1-5w_U11z6dRqlaDHA-YOfzpZqsf8PifPAjn7aT0FK6AQyT-D3MfSaXTXk9EC9a9nogJBLnOLfYVt0_MioH1OoCc4j_svhI8khoVuxs-2GtwV-TqRFsDHG67h_uSad7jz7rpQof-1pQUQyLrEV2A5BE-ulE0sOetIWUWsb3ryYEoI0w_tn3OhZi7llM75gIHiBcbfugKQd32kDLP8ZqlvCJYyX5naEZn-XBE5fiEVfQLFI2XYEqy4kXZCeacyzPtYZpZ2qMTfIsesU9B0S0wEFZ2JqDCEvynz9ExRShTAeYshi8EJJveE1jI9ussznY-EwDk_o0nXxWWY5SgaPJqWsgvVYQvPhuETdOw;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVfEj9uDoEEM0A=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=18D26369D44E10F66FF0F62EDD513F16; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtk3sBHK7Q84GZk1e96PziXwX-Sne6OTQmqAWmqwTXcz4pi9PZJK7QBqEut2IdREt7EMNu6fEB7lVqpBz6SeBSaO9hsvGJexoVRUXOzQHJ3sok8lKKAGVyBD9SUA6mXtTy0AQmFwsHNqPj0CAyb1PaYgc4pU-8VrXwwq6yy5J_svRVTJ3dPsyHhg8fTVp7JCpmGbwRbD_1ex3KKrVk0UXy02pwgBEK_c77gGhgy3HDudP4Dx28Gxy4Ginu4LK8PfecPB4BvwJO3U5XVBq5iRNdg7XYTap-3cpCm5OY0WJKBDAxXb_RGh_ZziA2948YnEBtZ3aRKTvJePtsLBMiA77UqV7-1SdfU_RjDT-Q4GY6OO9VBewBCN11sGRyW8A4eMmrE70dL8invkTpPwXIJDW0I4Pxu6WTUhnHP5eAOyW5fYER1mVQbLujSxG5SbAaQ3KHD0VVDG18AU7uJ8Ms_GxNIFoFjTXMpHAQ632W3xPmHD8z25uASCWKiOS2eSdhyEPY932gaI1dCnAHOTPTHItEM6zzhG-BAd9cQyLt1s5GVyiiIftc2Gy_KrQA4yZ9RxOpL4fVWfwScQXchjLxyOuHtHmj_97opCmM9_zX_bNqe8dtUs23Jta98er0_iqnxKbbM;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVfHgiFjoEEMYQ=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtny78qRexs8-EDtb8vvxv0pK55fEBjpjA9AoUr1CFicAj8fcGdzuuDhIP8BM6f3l1cUZ4KE7oY5OT0XXvgcHQLF7DB-w0-uUruoREERaNzitkf2qF9_czzCfRA9sZVSLtoLx0L4TVR-b3CFU9uZX_CbunU5OXOIn4RqYLPWSiyh5XZx7OcQtcBmzmxzDFoN1VoYR1fMF32eMY3P7RbJTdUee6hcmNgmb_U-aZHPQfDdeKCFG6MM-EBuFKUjfZhMJt8qFgllE8XizP5ajKfoTXSrjvWxRBEG0jmLD8DPfGyMLSDDP-cylVVKIgNa71AAo73lR1wtiBELBbQRvd4yefOs7NtqlyTq7WfoXFINXnVAPjHWtNF1aCVsMzrEC5pfw1zd8b4owWCqKjMx9Lp1w9ABWQxmCcWxxvG48xXriZVcybWHUYgq_MuloHHK4ZVFEAmcdT4WlVaGQf5cmKdaa9ktdNwxz8DKkLan4IV3KKc2U7v7jkztB1te8DrkDgk4yXX94OeT0tBlnCIA1UaFdcv03TX84-XSJTR3nGRSRJvdEawg_UTmqf-zGQZYiUCF_rGqK8AN2VvrUoGL_4yFD1Cjr8KxSyfr7ULlH3byYXacQo7CxmK1rk04i4DreEXaG61HUsZ8gfYAiv6Y2z66zEKV61xbya0tKtDrs6anOdjn-g;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVfKho3DoEEMeA=
     status:

--- a/tests/api/cassettes/test_get_telemetry_measure[return_temperature_zone1].yaml
+++ b/tests/api/cassettes/test_get_telemetry_measure[return_temperature_zone1].yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnoTz0McFfgLLuH1MMVAjBJ4B-GrXEwryfZR2NcORlkPRmXOdmvbg0fyEXK82iaGqczAZsOi23z_dGfLnIL4uqHBti38vmzenHqBKUsZJWj2KEJukDwDzn6kwNd6TF54AgGpGQynoBYTrsyAU9jmnu6eSYYQbLa09Wh526vZ9fdYOpCfMpAk2Az93e7pDkzBnLxxo7KNrZxkVtfbbadCBmmLZnj2MidI6FQ1bLmfxNYtNy1kSEfIrFmVZnfLFr-E1U=N;
-        expires=Sun, 12 Apr 2026 13:36:29 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.sHk2NeyF8wYO6GI8ur8spchoVEsacDWC8b_3WIX1zE0=N; expires=Sun,
-        12 Apr 2026 13:36:29 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVeEjmLjoEEM0A=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=b9eb4aad-2c90-4964-b14e-941048806920; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115968896201838.NWNkMzc5OTYtNmZiYi00NjQ2LTlhODktMDJkMDY1Njc1OGUwNmY3ZDM5YmQtNDU2MC00ZTgwLTkxYWUtMTA2M2M0NzYwNDky;
-        Expires=Sun, 12-Apr-2026 13:26:29 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115968896201838.NWNkMzc5OTYtNmZiYi00NjQ2LTlhODktMDJkMDY1Njc1OGUwNmY3ZDM5YmQtNDU2MC00ZTgwLTkxYWUtMTA2M2M0NzYwNDky;
-        Expires=Sun, 12-Apr-2026 13:26:29 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=AoCxl63vevXVhW3NdWYmpHQB_-eLLwxFUcE4RvzS0kY&amp;code_challenge_method=S256&amp;nonce=639115968896201838.NWNkMzc5OTYtNmZiYi00NjQ2LTlhODktMDJkMDY1Njc1OGUwNmY3ZDM5YmQtNDU2MC00ZTgwLTkxYWUtMTA2M2M0NzYwNDky&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnyyn2EVHVGpyQXpYIK2mzPA8qexyQoAwmXHneZczgYuC50dBVQTjbyUYeFc1TARKr1LsPkMPqA_yHhZEeHpk7ZYhYdWZ0rVMv8hWUpQgUtNz38HLrc0FIpx-O1_tkzL1BzyhqUkMIDFwUjN8ACzAYRQMB801mMaG0Efe-rQ_dYUy6mKb2GB9tC_f479AwSH-ditNeprbosdLJM7jBkD9ee3pwFK4CGsUq-Dp01r-FC2-2tV5OSjYxD8kej-ckDthgu_UVcY3Sr517KKwcb3I9JesTaVxP7ImayPijTqKCzYJAevNOie9K9oqyTaTO5nL02UlW5bliChWbMifnuTxHDo-dMBYbK1mN7_spYgGnKQGFiRR4nLzwI-ashUT9NFYDgX-qYbO1LAzPcb5ZAO-jleA1Nslit60Np3L69Yy1_ULOYhnAUK0f5W3bVkj3b_mAfvxse3eav4E3WCxulG4gKPn9wD2clwJQAny1MLuWafrDOS0YVOyGSoeeOyDzVl-V9z9jWEtL4Io-amZOqzvncSp63fICcxyGQkaccPu69A8YZCPhFdzPYqgyXaRogvmrPjtaViXNRkpu2lE_FNZQnjm5wP936WlS6iILGWdTuhsSUvkbRtZvX0HY7XRLKV3I6sslgA8_QQuH91j0YN6el\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"b9eb4aad-2c90-4964-b14e-941048806920\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-0b6154c944d9\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=AoCxl63vevXVhW3NdWYmpHQB_-eLLwxFUcE4RvzS0kY&amp;code_challenge_method=S256&amp;nonce=639115968896201838.NWNkMzc5OTYtNmZiYi00NjQ2LTlhODktMDJkMDY1Njc1OGUwNmY3ZDM5YmQtNDU2MC00ZTgwLTkxYWUtMTA2M2M0NzYwNDky&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnyyn2EVHVGpyQXpYIK2mzPA8qexyQoAwmXHneZczgYuC50dBVQTjbyUYeFc1TARKr1LsPkMPqA_yHhZEeHpk7ZYhYdWZ0rVMv8hWUpQgUtNz38HLrc0FIpx-O1_tkzL1BzyhqUkMIDFwUjN8ACzAYRQMB801mMaG0Efe-rQ_dYUy6mKb2GB9tC_f479AwSH-ditNeprbosdLJM7jBkD9ee3pwFK4CGsUq-Dp01r-FC2-2tV5OSjYxD8kej-ckDthgu_UVcY3Sr517KKwcb3I9JesTaVxP7ImayPijTqKCzYJAevNOie9K9oqyTaTO5nL02UlW5bliChWbMifnuTxHDo-dMBYbK1mN7_spYgGnKQGFiRR4nLzwI-ashUT9NFYDgX-qYbO1LAzPcb5ZAO-jleA1Nslit60Np3L69Yy1_ULOYhnAUK0f5W3bVkj3b_mAfvxse3eav4E3WCxulG4gKPn9wD2clwJQAny1MLuWafrDOS0YVOyGSoeeOyDzVl-V9z9jWEtL4Io-amZOqzvncSp63fICcxyGQkaccPu69A8YZCPhFdzPYqgyXaRogvmrPjtaViXNRkpu2lE_FNZQnjm5wP936WlS6iILGWdTuhsSUvkbRtZvX0HY7XRLKV3I6sslgA8_QQuH91j0YN6el\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"b9eb4aad-2c90-4964-b14e-941048806920\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-0b6154c944d9\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=d3c5a542-88f2-409a-aefb-08fdfbaf0a45; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/b9zUva0Fj+RND5kuv8aiLIMV7/cNzqf0S4hEEbLxAEtK3qMAQgXjuuGpsEMcH7/ruWL1xF39z/njO4cOg0HFLa6tOQOxaWKnralMWds/1cVdqLxkPFS69RquyMrBXgUgkB/H1L0iTPbbENsA+ck+I/tq97gJeLpOhrgV1zkzU1HOYJATNJ1MfKVVsUpgcrlnN+/16GJF39OlJ7zQt3OPY53R5TJljzy1CzuFD4ra2HvQpI8nHhMxoQUza0enchWDcnVC8RNF28ekgKa2WSIkX77VLyMR5riij4ha7RyaXZZmdwTQMzHiAAAA.H4sIAAAAAAAAANv2ls9JSrG6w2nSZde9H888Z3Tjb90z0/i2hbFPYVHf4j4AO/lm8iAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:30 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.sHk2NeyF8wYO6GI8ur8spchoVEsacDWC8b_3WIX1zE0=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnoTz0McFfgLLuH1MMVAjBJ4B-GrXEwryfZR2NcORlkPRmXOdmvbg0fyEXK82iaGqczAZsOi23z_dGfLnIL4uqHBti38vmzenHqBKUsZJWj2KEJukDwDzn6kwNd6TF54AgGpGQynoBYTrsyAU9jmnu6eSYYQbLa09Wh526vZ9fdYOpCfMpAk2Az93e7pDkzBnLxxo7KNrZxkVtfbbadCBmmLZnj2MidI6FQ1bLmfxNYtNy1kSEfIrFmVZnfLFr-E1U=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtm7vEFuUcJCG2f6oHXh0cE5nF8qFgHMKZ5W9SNBCSPbGSn2GNt0qrAV_cKJUU0em8W8gHjsAkb7OaUzvcZyR6Ho659lJkn8HyOdxCBR9VnLqzD2jUNx948psswLFQYT1xww_dUhVUVh1lRwMmNk3b-hVzELP0hEwnesvPm0skwjeakn0KRtlNIYTinSfHOI70ZO51iz8Dv6wPYozl5WkAgmAcWFrbfYLusoTnet7biQ5kzyLhePNQ87RfChQ2X49ZMnq-Gz7-HY4zIXiga8WjQLZvifUjkCsEEEBgv5AELoU6jBybuXwBEOnR3vsW2eHYWClcfyaA4_u2Kf7saDPXSqpPjIBbV45dqncwefnQbU5AWhL50C8j60-0ssKOWSwOyF1MMSEJA5ZasOasq71h--33K51FaS-dr8W6dBvPIjy_1tzHyb4s6gGmj3o9_GTyxkNyUun2I3NRcnYlxyzb52Flkef47nAGS7Lzd9lpr1ne1rlnWiBkCgYlPKQfDnLVtqFgkses3gLlZtIFEyp462JTfr1x_kK2lhry1yI5LHnEoVvAPFQHitWOxdIcvPU42rpEV3_xUIPXwz03glDANq2W8Gs3yS1JC3tNsOXyyYY7X_6qXvGEJoavGIfu93653UT5IYWI2NzJMqhDo-XlmU4tn5-CE_zwItTIYZEmLVG6uRTZrVj9bXpa1jrx_w_UDmNG9lGbZhXXB9O4HuR-gx77AP-Sr69-lSIftFo-xwDdBREpzds-Cfn9Rx4D4PBmPm9kWuVKRHfHMGEUrR0_jq8A7DLuA3p4NPPMlCzp9OE7xhYQ5Mk7U5plbHS6rVlRK51M_-TII9kDilvdthLO_J6fFYGOf4M1WY1BaKmpNryvab631FO3x9KkR08cePxay3T-p-uRHzpsY-CM8efWw_rlqXFCl1GnkAMXS4NcXyv5Dq7aPmue6o89fls5G4VPzzA2LXjzMZB9mWBZpCPsxXdfpk1vPRfiax7Q_zHmZ4s8JqaT2aqZHHJzARUtrOIedLXt5DkDFZpy2uyNAy_T6wdrbEJGKEx3htdCmwMrmPJTGqsyDbbueD59zO8EKATwJDCOxTZ2bEBhGx2gKLhP51HJE41NPuwRpXfsv04hnfSbAk92fb6ZLVL5s207ddh3KTOz2v4jVm5H2wbajvIz2jT6xwAall51Oz5zHIX_xgRBAKDQDRV9v7DEuSKeL5hbBaCt0UAKgF3saksjrItE0slcx2qhxnpvSNXah0IaswbNQXKPWRlcz9iFgoEvDiw24yb6kojfLf644mxFqIq97wf2xSUkA4s92fngzI5YR9c3X_hGhcmVmw2Yh4t37piw0RsCSQf_GwdVjjsm_TD1hdh5E24UxAE5sssuB2lygwsVEZhuStYKHgg6y5hccTNA9H_lRHQkb8EHOq3pLEb6ZzO-1M7W3Vegyos0Mf8V0ALZ0atccSYLJT7lL8nEozuefCoshUkt5H3CRf--FTm-QUUf7pwr7rIxo-kwuWYbZq4zRYwQmnTqVyszXSR22CYIHJfC16SQM-rn9UsNbFczuFXeHPc789WyqEQXpXOyBP2mWTWcPSlkmbXGjQI3OYI3WtPh5YPDg1id7bcWyNMgu8t9wnk4DKr8Q5BYzH6PMHP_pJV0oyaQ8U0VP7yYwjpq-e31zxP91dTh-2kokHDxydjhllTEdLcBYUuhSpqHdk15LKwTgPNDeFUVonnzJY9Gi9LzYccli3yErMDMAYEZhtI2WoeJx_LQPRZNr4y07llyyhsYK3tZg9dqZfb-H-Oz_zR-NN3y6PvfFqKJRZKbZSktR3z9-8lWy-6Jtvb3RnA4i3pUFUdHB5nCKwSXMo0GNkSsXOe7qhnrz9HXtMb9BVs6W2BiUWTrtcqyUd1oDtTopSJe8B5919OPRWe6LdDxT01EobEHX2p-fzVsCUUEQt96uI1rSeYgHADJwPpUAkvWvEI0XNZmVNmqGKWGAUAj3nuwxko_X-UuHRl2WownonteOTzRCMwYg2TYzLhckKjdzERjrrrK96ca2mHrwEKsPr4anxGGF3ueYvHcY3iS4EiqHpSvyk-OMEcXOMtTshB2lBJ5L238BKYmvq5uY4Gu6ZuN6MjAiIbJ7Z9NAVtyH4eUyE29kKPjSRpCsr2FwObqOP__czZoI08r54amDSJByB227LAzc30OguBmq6lEjupcKlPdEvDBtLYaQ9Q3Ko4qWDIUEDPxBNvUJe0KXos4elB9A4T9jztsagiNZan0Q--wvKHhp5Fjkfl310f-q7AFnklplzCHI2J7eCxtVXfjZQt6CKzEx_y_oXzStfPKhiYyZHmOfeh53nsK4IhhCyRVF9NGb4gxhZRs5KlTSoc5zRa3doSWqNQss3xiVWrqg_h7zRJyd0V19aEUNV4rkMfkOMSkUwFjhlzBt_F83edgju_yL2bm0VBxGHPA6SxeWS4X_4dr8GMvMOc516LFg0FQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVeKiDbjoEEMRw=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=743E2FC620AC5EF13FCD12F5FC794872; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkkWk8rTzOfZP625hJjWZqjwPeXqIuYMrVTV7ybnsWPnQ-FipGU7Pize7ofH_6cujcVhR_Z6voEdU8GmNc1BJFBNvlGe2jlmUZyY_XWGJXNriCkMBsPDyU4tPV1llYExOXMXkNhd_5biGJp_siabPUHW5PZx_-RXyz3awlbnNgDBQpVOGCEjDMxmyEUfizrvgkGuoxBu41rIhjvVKY83NcGmk5QP0HheTumt66ygbCImX6NQ4DUuo3hSmHMocBQSMUftxib6QEroXFQ0PYqnyBe4ClKTUCArNwwZ0TALit2QszBCL4YZM9_Zn-FzB9nvkujrnw2SUZSuiHUOTHjwKKe0n55igRhcaGiR_9WLsiLI2f0Vs-YejG-6V8FLmv-TMGafhHzO83yd9uNYuNhetduqiGBJ29p_mjoa2jnY3MO-Cs6owc_pWpC-SCkO2N_49bsi9v3VIuF2QIMzwrbLKYrJEw4v97fuG94haZF9wg-yie8F-s9bTWh8-8occP6Gzte4JttluCj__gA1x_CtRXIf3bSxuTBvT6hANtakRsnBFWCeK-QKGrGONqNAcS4chHMonAVLcTYnOu7j__PIzWp9BsD1YGRO1Wz1Spg94lSEIZlKY5UPA9379WfzCQ7ZsE;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVeMi3jjoEEMBQ=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtk6jX3xS8juBSrKyUJK18A5mLOx89IDyDyEbiTWdAcUA0R7nBOgR-Y73nZcLRlDNecOVxxnUg1ZtVo_JsxlFPpyixu-HW1_CeNar_ctrXbVcgxZTw5EM8_us-rfiZ3oQNZtF_9ag312ilN7_d65IaLlGZxHBPPzAnyofvkb8ZAYDQOuRvWP9K10csOIHw3Qe5ZPAXI649LV9Zi1kSLzPWFMEQB3dq-IFl0nEx7hp1vQw8S4n5XD5Sofqa3xgNTUhvvzvwrLqPEagB5MDZN1ld3v_FL7XLP_cTlqOoym-2FA72KXnn7lziXO7rUgMRiXQaKXX4E-Hhlgp_Eptc9lL50pKCF9DSeRHEqNOOlQ5Y1b01SKHxdenECTr_DeTjQ4Lx1SlA5yt3_w77fu0ezjdgbI5ommXVjVfl5A6NgQLwjKCX2r11mq8jMygYs4yRbuwaMcMQDdXaHcdhj4xBL9mN3k_r-Ey32iGIL_DPHxmmqVkUhMtGUBJuEfp_s801hoTso1Cpnemr-FszWixAUWISX4Rmo2z8Bq5Zm7gAsoCeNE_oq9zfYsdzOSM2pqVtEcfSGkYx8W14sykKwOB-CURZyMyRA4z0eGYyw-dwo0wpSc4RE3DEzhFzoWy6djTwEKE7mc8lNPiplcbXt9iCmjG6vdDgJm06NkdO2i0122-5P2ow;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVeOhhZDoEEMOQ=
     status:

--- a/tests/api/cassettes/test_guest_buildings_only.yaml
+++ b/tests/api/cassettes/test_guest_buildings_only.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtknbDfCrP4NkUAWzdOgWQ8RnGaDw1J69uSK9D9ACicTnSVHV7bhrNCaTHf72Zm7E1bV9fmMKekvNj-4VN23GoI_JyVqSRJOZ4FeVEPrU4oNjdXcll_qITu2J4kV2_1fhEWDDRcUmoR2c8FpK8vlU07aYgvcDzkL7UZUBJ6xAnKrfbjNhOWbkDiY7WMeTgd9GrzHXR6xM56E9AE0mqb2uFSZ7v5c2GWLLIm87G-X3QdCvaJeOxRe4LHA-TSaJtL0xNI=N;
-        expires=Sun, 12 Apr 2026 13:37:52 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.Gj17XF0kND6tg_Jt7trT2vMOlYPJanMVa-zlAlSO504=N; expires=Sun,
-        12 Apr 2026 13:37:52 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVrFi0gDoEEPEQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=7c0dec9d-82e0-4006-a3ea-cc85ec1351a1; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115969729777751.MWY2MDMxNjQtMTY4Ny00YWU0LTkxOTgtZWYwMzVkZGJiOGQ3NGI3MjMzZmUtNDdlMy00NTVhLWFjYzQtOTI2YmQ4ODUyMjlm;
-        Expires=Sun, 12-Apr-2026 13:27:53 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115969729777751.MWY2MDMxNjQtMTY4Ny00YWU0LTkxOTgtZWYwMzVkZGJiOGQ3NGI3MjMzZmUtNDdlMy00NTVhLWFjYzQtOTI2YmQ4ODUyMjlm;
-        Expires=Sun, 12-Apr-2026 13:27:53 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=oVkqUdOTbQa9UCOabx735wr95C2U06Aq8X3-blxFRhQ&amp;code_challenge_method=S256&amp;nonce=639115969729777751.MWY2MDMxNjQtMTY4Ny00YWU0LTkxOTgtZWYwMzVkZGJiOGQ3NGI3MjMzZmUtNDdlMy00NTVhLWFjYzQtOTI2YmQ4ODUyMjlm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlwC8kwNpWqNlq79GNAgqFSRVLvBbrSzyaqgjvueDRIZ-s1vqUwnW2zLlxvEIq6Trt5sYnc5J14YNHMSYruXRJSPnF-ligdBDTAW_bRrVenIlKw3yREptetrzZLC5io-a8x1A-jvzo4Wi7lCnbsgyIRJK8bPvERsWSfyYKD0NsnThSkj7uziXqfuIuHo7_Pq7UWgpT4_lDP8hupW1tS5pqVrTal5Cr1vPQ39gZp41xT4dREXvdnzWEtSWp3EcqxQQZGmV4_Uv_tjKaHT5LY8e2dBEV3xXU2-Bk8z76ua15HllfA5Q2gbzJSn2gpsuFs7w-u8RyEryLpHtKowQwbk6N5ATHmqG6iYmu4Cfer1PCDnyaGyUoYZ20TsyKDIKdWaSjmqxaolnI1tjZ5H9KR9f_P5ZE9H83ZVAMhaZfTtPF1y0b5xVcJFMa0oB-BEdHJeDuN521OqvEZ92XDHRiQtg_cNCZdsXDfI8ddQ42AFbKErpILKlbp4DAri5qz4gF_wZNAqYAc9nY9L5HNFvGMZecqx5SgfIcTXgJzOjDzy2SYiSvdy5nM4weZlOqHS4zANxjNA0WngT7YfU4VjRNhKtzlLQOzRQn1rhLZa4G-3bnZWpG40jVlreJ9Bv5z2Qn8h0KnXXXstUnyhi6YmdDOfv5p\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"7c0dec9d-82e0-4006-a3ea-cc85ec1351a1\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-9160949e7c86\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=oVkqUdOTbQa9UCOabx735wr95C2U06Aq8X3-blxFRhQ&amp;code_challenge_method=S256&amp;nonce=639115969729777751.MWY2MDMxNjQtMTY4Ny00YWU0LTkxOTgtZWYwMzVkZGJiOGQ3NGI3MjMzZmUtNDdlMy00NTVhLWFjYzQtOTI2YmQ4ODUyMjlm&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlwC8kwNpWqNlq79GNAgqFSRVLvBbrSzyaqgjvueDRIZ-s1vqUwnW2zLlxvEIq6Trt5sYnc5J14YNHMSYruXRJSPnF-ligdBDTAW_bRrVenIlKw3yREptetrzZLC5io-a8x1A-jvzo4Wi7lCnbsgyIRJK8bPvERsWSfyYKD0NsnThSkj7uziXqfuIuHo7_Pq7UWgpT4_lDP8hupW1tS5pqVrTal5Cr1vPQ39gZp41xT4dREXvdnzWEtSWp3EcqxQQZGmV4_Uv_tjKaHT5LY8e2dBEV3xXU2-Bk8z76ua15HllfA5Q2gbzJSn2gpsuFs7w-u8RyEryLpHtKowQwbk6N5ATHmqG6iYmu4Cfer1PCDnyaGyUoYZ20TsyKDIKdWaSjmqxaolnI1tjZ5H9KR9f_P5ZE9H83ZVAMhaZfTtPF1y0b5xVcJFMa0oB-BEdHJeDuN521OqvEZ92XDHRiQtg_cNCZdsXDfI8ddQ42AFbKErpILKlbp4DAri5qz4gF_wZNAqYAc9nY9L5HNFvGMZecqx5SgfIcTXgJzOjDzy2SYiSvdy5nM4weZlOqHS4zANxjNA0WngT7YfU4VjRNhKtzlLQOzRQn1rhLZa4G-3bnZWpG40jVlreJ9Bv5z2Qn8h0KnXXXstUnyhi6YmdDOfv5p\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"7c0dec9d-82e0-4006-a3ea-cc85ec1351a1\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-9160949e7c86\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=ef436244-bfb8-4aff-91cb-43b73cb0066f; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/iyi82+WGabmuRr0aRWDS5TTFVh3qAPk2d9upKQ2gRGFu7R5UbgkxTyCGAL+iDrTLBzjOOXBKQ5oeDTiQzcqkmQ6Enc4ayMlmXHHtlIid7o++uYB1VWNzhxmK0rQvpKfrFozDKXTpvIdCtbPsj+4eJsqFFx2LUOnusHklnolt8zIaYIU9PUzWH/DibNeGqE18ejN1Ly1eTSq1EmAL5zOCRamsisy1ZUqNiJEMt2yQgFnbj8QCYS/85EBbDxy1YHQU5gaLr+DqBBTWWEzMjIaosxWi2NypsS9Ualg6ZA5sgugWvWGud+HiAAAA.H4sIAAAAAAAAADPU6JZ16rG8Yy65JOec4zfh47zpf9oYDxyd2nE4xPzzh38AEK98aiAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:22:53 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.Gj17XF0kND6tg_Jt7trT2vMOlYPJanMVa-zlAlSO504=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtknbDfCrP4NkUAWzdOgWQ8RnGaDw1J69uSK9D9ACicTnSVHV7bhrNCaTHf72Zm7E1bV9fmMKekvNj-4VN23GoI_JyVqSRJOZ4FeVEPrU4oNjdXcll_qITu2J4kV2_1fhEWDDRcUmoR2c8FpK8vlU07aYgvcDzkL7UZUBJ6xAnKrfbjNhOWbkDiY7WMeTgd9GrzHXR6xM56E9AE0mqb2uFSZ7v5c2GWLLIm87G-X3QdCvaJeOxRe4LHA-TSaJtL0xNI=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtlWkncs3RYiY_ZUPpOy9UELYNofgB8pLjjXubqIA841RG8MyHvrx4WzGxqvDfbbRTNUAcYLiZ55yZOrcuiPVE2n7UQvF0-QYmYGiBlaNiXbLr07gVkoHCY1ToTOEtytcEgYsHKLV6-AtZqLTUqMKwTpJicNCmZ9Nfpsc0b_HztD006_SooXI48QCiaBfyvRPXLSe75MZCPMS0aSGmSyulOf6lINR95RBarYgcLNMYik_jbsUQr80vjDUQAIlPcpjsSO67w8aLRNe2IdmQAkJU66ncf2PXQhkEMCNj6n4XQs811Yy1ZjgJ-RHNcHZgJXGWBcCzdAHiANOa48LHnm_gUP43e5zQcjHEy2vX13Q6popnqSOuYKWXbu8K5-5Le7XBL5A9AyQMaFnX6LOV9uj3idbFYMFhgsfS2PB3iUPWv0uUPv3l90pzu5qfefYwZDmWR6CANGqi-iMbKnGhZCeh03Y1MVtMwOu8IALA1heMbXNiNkG4iPr3J-evTkkCBwzv200A4PwGwGY8Aymh5Gd7fHVBw9f3dqbEKYb5EHozuHkUcQ7bbK5BoFYTVX0XF0P5F1ZeMgqr65_LV89YsnWzuS6GlDNSzQv97vUMVt53ZipluXtJXfqh4hZJ1mBuXCtv39aSBZ2exF8oUHXjKGGRZROgm7WpQKgBQSQJ-Vtjl2k_Q31d6r1ZQ9oYUFunV8IA3rz-Zlgkt94Q9lYQ-DbolBUibeBp2dp1v1rbF2AH38Vfwilx13a_B_7fWv3tHJBEzrYOHsoJDJxBu6ri5WgU0ff39XPL_KmSWaRUM0S7XzIDQy6ag-4OBDCaqPDGcvycGr2AOIXALd5pk-Y_A39aLVYdt06Clu_9IZB3GQrhI_Sf2KTBupL9ZONY0yAT5XYjzcVaKucTO72YOcuReYI68NlCCVbPoLR_-MJC2jtN1Dp4_tAu6DWvCbhxVgY_8WIpzNpKBsS2z4o0Y0J2spZDVCUKlBYR9ofgrpAOc7j3Q1aenf8SyVR3Q-hwJ2KnlLZEuud5DG3L0GyPb8XAQlZKD-Gwq3MU0_58SqNE77kQ62VraIyrfV6mO_-J4qICUo5atPpLEfhV2kuOhMzoCb8x0BrLxaMrg92DkOu2DAPd_ZWvGenPf65Y6QnpwfwSPUEpudYRjpVG6K-zEXXaJnRmdTrJw4u5FnV_WMjZgMwVKULKFLR-STd-i0WwYB-b0-u0dx_kzRvzsTwDbV91HHtrQcM78q1CAqa7QTkGkIpEob0qbumKN-K7sNKfc6qdUJfwGP6wOWJqPxsy8fJSxauxwDwY4Xn25EKK6WQCR5HbH7DMtP9dolFXfT7a5xvR-lCpDB2zvIBnbIsCibFlcxphbvLNoIna_z8Z8dJKy7xCIOE9xoPQGxWhBe2b-BH8hdDX8cPtEgpzLrzvajwAuUa0tBenz2UHMe6mqRecFh9exHhkVign6ScWua3AZOJqMIym8Qc0OX6X4es7CZVKnsik1NzZlvWjBAtGHu-QjsO_pVp4RCLShP-VhiIecewd-BWQ9zUPJD7wPs6G1C9G-Syp-k-bKY2BgqSooWB65HhDGZHpWltYCKMtVtOLL35zr4HylvWb1RwPG5xh6xEBa_0AKiYE5_mx7T3DmqROZSayxVdFWEe2QYhEHQuQGx1uvwlbSq_c4woM60xn4g_y0oQAbfGNtdGLzmNMxQYAixVyAbShqaCxMvHA8KO1M0c8lGmJYC41nOCfiVHX2xrZ1mH_H0Yt9J__-M0XX7dW1klU8yucAZK0lciDFZ9r9AkdZT7CG62GeunZkv5Bby0NmRzUDlSd1RL2mFYdt42vdZj_ZgcOleD1vz2mqE4v77gsX4ySHj9GT3Kgbhv14xvo98nk7ILHeQFevxGiSLn3OGdBQ9TBMi9HTKSikbkFww7B9Bbks6f9DuMfVnJ1m_kcdh-k7TjKAWz_eiI0qiH-i0Egf4DCKu2IQO9hfHCW53vWafJRNlqAVYtKFtPSj66fbDmFlKO1hwlDytP9PrNmLY6B-mWG2s9RXCmDFpcLXO2ahsZd3z0h13KGjP31BSxk2izsVvE13IPBdedEBx7RGQCRY57YdAkhnndaP-EIbfCWu_C5MG-KlH6Q4rQuUjs0Txg37xCkOCN7GmRwZ11yeEG2PJ5zgHB8vdgkyFhNNLVul-46p2MwmK8ysf5BhFAIJtzETv8Cq5UZRDMo1SZ2uzxYfm2Z-MF-VCznd0SkAhNt9vERUnx8oXxEW-jTycPkwNLBTIE_aEkGveKf8nerxUbodS-FWpuolzzEBNyo1lCzMmV8Dxq40PAtIRQjbjoR4Oz_UALMrZFJRizhlL-shnkaRtabdiAnQNr54CdTxAs8dj4nCfnqiIyN5ABeZr03CVCEyqCmhuxVHGF0avcUQEc01fF-vFUk792EW9JykDzrYGaBnr_5Vb9IYX_hvz8VBJ05fKAAymDzho12k6ip5eJEWqiQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVrNiYtDoEEPVw=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=AAF4CA196C0BDB62AA85A0953B469CE4; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnajQOlCBzGNDr3Ar1s9QF3RO3bcmeWEwwA_OvhDeGBOEXp-HxvSAoC1a6WKe8Gnkdnvg-dbl7uy7W1ySCrdplFtmKbWkVU5L3OBEi4aJdWG-XL_3gaOMfuMw8mrh7Yai6fMwki-xeAb4tpWO98yY1VMW1PkJoK9gWtmDbakSyjqwu6Eld5l6ebOY_zOEpGQvUgPNe-TnX9ICHBEg9VUa1X44CcfyiE7XvcvT93aZXzH41vtzazeQHTD55f90NB5shHFaD4XY1bDtyNV_pFFtsmioZCkflMemN44bRTblX7lvKvC8QQ1A2v-rHXtvdmWTt2lxj0_FwDjvRy3qNvrvqj2Y6jDxmkhuOVuErEchekVo6cKLinUCXpvKaC6JZo0B7t_amz1gePXgqm_oULrYG9LOAVbbkQ4mYLxIjeUW4LGRcvVVrMnD6Prqx_yVNxUOcMX4f7I2Qs7RPbJ27Lf26p02JmvfyDL2ofNPbPlfdNEAJo68AbLrP8jyZGdWnCOsuVRo_yacgoPXmL8IuZ8I04zl5yjQmq_QPYPhpDRYLlM7wBT9v384nWc-ZFy-s2ejspDFgPO5sL6PAyuWZ8qTHqbrDuYwWOcmJcj_SvJpIaaIBc_iS3f0iRuNIwgOVC5Tg;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVrQgXbjoEEPJg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlYdXwln3-HgaowkfJFoSKj7lnwCFOHaiHsco-tB8aC0yP6jp0CPNO9T_nz6KCKv63i_cDPmCxENYgBez4qxsZZYmgW2DIR9uOp3USB7GFEnMQUpfnYUrSi4b3ewJlWRWebY_jsuvaHkDSLO8AVcrrDXNmC6qiRyBAo0BJwHD_MMOWVXhNZksU28R792gCiYtUWwcvxggj80fJXDJ86rY8d8e-rD0uuarWyqFtpcNJDsrwPO3SUsEj_vhSA5QAp70dJthNC-UTLy8WyfRtgQqUvihkvcGRa8AE1DluntBvUR7akX_5iXozlY1_1iQpHUkxWveR5PfG59X3fwcn7Eac6JP87d0HnY-36g1cu3bQiL5r2qh8JFov5qLGMUxw7ZhHvO6WAbpNhP5VhvhbTet8aPiwkPShn7RczWiGa167TgWCoZcLFKJQmGBQi4h-DivlgvGNExyKoawgWfuHW4u4jApjXRmTJoYUkG6oYgUYVdG663vHB35dgP-6Gb6LTBIfhT6WiFtGP6JzLNefqIfhrxhh-stRTzmFDwGo2xX1ZeqenbhO7gh3pd0aUzG6XOzaqBNXC2fGeJrwCSl1PKsK9aQCpwUEEIAK9x11iI4d3T5lVl6VN4-eeMwOfdMG06LL1r_qF13qI1JQ9K6-RxnFcrqKDYL6u1kb7wJ6vboXLDA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVrSiagjoEEPVw=
     status:

--- a/tests/api/cassettes/test_multiple_controls_together.yaml
+++ b/tests/api/cassettes/test_multiple_controls_together.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtk1nUNfMnTIwDbX5wzUrXTdNVwsbSZdVXyTtN3t3xOXxEpZqf6ArudhWj6iEgNtdbe4cjTP1_QZhk0QfhiGqDf4-EXVQ0tPYGx7icGEVxA096gB0Rhh0hsrF-daG-9ZXRsM9hKeK-S-5_jPw3KPkBlUg3ejzM1HwhYobHxJRRoSWZTj78r63ipVcebgQoodyiiRhUMWOad-0O7gVZUzi_CfDqrFZl3dvBp7XIy0AHVBuzAEISQlsVx52mvYeWAhRGY=N;
-        expires=Sun, 12 Apr 2026 13:22:41 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.7_IXysyY3oh9zLiiIcr7eR8rsmQXdKUEXOwGIxrlRfE=N; expires=Sun,
-        12 Apr 2026 13:22:41 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTcth8RDoEEPVg=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=f58caf5d-7d5e-4cfe-b088-cec434ccccb0; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960617633488.N2E2Y2ZmNDMtYTkwMC00NDVmLWJlZGEtYmJkZTYyMDllYWMxMzQ5OGJiYzEtNzZhOS00OWU0LTk5MzktYzNjNjZiNDNhY2Q5;
-        Expires=Sun, 12-Apr-2026 13:12:41 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960617633488.N2E2Y2ZmNDMtYTkwMC00NDVmLWJlZGEtYmJkZTYyMDllYWMxMzQ5OGJiYzEtNzZhOS00OWU0LTk5MzktYzNjNjZiNDNhY2Q5;
-        Expires=Sun, 12-Apr-2026 13:12:41 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=LyLk0tUEiqhKpYEX2hV-_LgFrw77QODlmZPXi1sjN6s&amp;code_challenge_method=S256&amp;nonce=639115960617633488.N2E2Y2ZmNDMtYTkwMC00NDVmLWJlZGEtYmJkZTYyMDllYWMxMzQ5OGJiYzEtNzZhOS00OWU0LTk5MzktYzNjNjZiNDNhY2Q5&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlQ695dk_zTF24yWXf9Rr3b8rbU5531zHSNHabeD319wb17a9xbhtAoNr_MY-eBYMWI5YQU0r3OIO1sHWEizTTZS32i1-6Oa8GMGr2qYqCsmhVxWJlzSa_R2OEVxXuCr1wSG0JVLilVxmKrXUz36t32Xc-okFvwoEX_2M17HBomy5YqcYWjzjwRK6bZxTjB5SVBgKb5e9EVhM72nyONZ5djI7cOElrwrDK1ovp9xhKI7gfpCpH5DRxnn1rKIRgD4pJAtyG8VV3CvTI2x_jyL_l4Gs1uyFvn1J_GDp8_WgYjlfBRtNZoCwaXLhAlQOEGN9z_Vn2dOolEEQUgZHXAg7d8JQ_VNUamfOAV2MrGqgbsPHSk7RmwwDaLiqloMW_td287pEIWbCcsgpmlq0sWUqW1Ir4tNx7RE3EjfhDsmumF4E_ykNW29MsaPi_1-TjhvJ_JC97KGwt8aqUnhGDML2GkXBnCyYzbgQ-sVwxIvUC9ZBLDvXBvx8ZzDj-2QZhJ59p4jNvbY4Dmx0DiGdEG3Jl3nde3h5QjJC8c0sqVxPYuNXZuz-7p9tE8VQcPOwTbRlPFs0SrAUjaA2Vthqh7NBSHVzkMFE5FPczwW3otEK6iieT4BsEvbHW99FffU_sVGwQnF1q6RDR9NEcMQTsnByl8\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"f58caf5d-7d5e-4cfe-b088-cec434ccccb0\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-3ed0fe35ba57\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=LyLk0tUEiqhKpYEX2hV-_LgFrw77QODlmZPXi1sjN6s&amp;code_challenge_method=S256&amp;nonce=639115960617633488.N2E2Y2ZmNDMtYTkwMC00NDVmLWJlZGEtYmJkZTYyMDllYWMxMzQ5OGJiYzEtNzZhOS00OWU0LTk5MzktYzNjNjZiNDNhY2Q5&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlQ695dk_zTF24yWXf9Rr3b8rbU5531zHSNHabeD319wb17a9xbhtAoNr_MY-eBYMWI5YQU0r3OIO1sHWEizTTZS32i1-6Oa8GMGr2qYqCsmhVxWJlzSa_R2OEVxXuCr1wSG0JVLilVxmKrXUz36t32Xc-okFvwoEX_2M17HBomy5YqcYWjzjwRK6bZxTjB5SVBgKb5e9EVhM72nyONZ5djI7cOElrwrDK1ovp9xhKI7gfpCpH5DRxnn1rKIRgD4pJAtyG8VV3CvTI2x_jyL_l4Gs1uyFvn1J_GDp8_WgYjlfBRtNZoCwaXLhAlQOEGN9z_Vn2dOolEEQUgZHXAg7d8JQ_VNUamfOAV2MrGqgbsPHSk7RmwwDaLiqloMW_td287pEIWbCcsgpmlq0sWUqW1Ir4tNx7RE3EjfhDsmumF4E_ykNW29MsaPi_1-TjhvJ_JC97KGwt8aqUnhGDML2GkXBnCyYzbgQ-sVwxIvUC9ZBLDvXBvx8ZzDj-2QZhJ59p4jNvbY4Dmx0DiGdEG3Jl3nde3h5QjJC8c0sqVxPYuNXZuz-7p9tE8VQcPOwTbRlPFs0SrAUjaA2Vthqh7NBSHVzkMFE5FPczwW3otEK6iieT4BsEvbHW99FffU_sVGwQnF1q6RDR9NEcMQTsnByl8\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"f58caf5d-7d5e-4cfe-b088-cec434ccccb0\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-3ed0fe35ba57\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=31e3d4e9-386a-44b2-8f3f-482a020d4698; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/Ve1yhf62mmaxdPb5VCH1/dOKTScBU0Y4Rxki0CcGJeI8gzo3JF5xE5jCnlerVFf8xaXu9g1RxTz/DCTwN2Pqc24wxausfSAh/cfUjL6TxhdMMca7wS3V+mgOOlgwBvF7l5caoviK+Y2PBICg75ys0mvH71Mp0L/wJm+6xOi2z2VUB7whkqGzSc3EKoKU7fHa8AZesoexf+zB+/S+ua52Xeh6yQfiltfy48DmnYHpLuY7m4k6eMzWFhZsnI1HAPamAalNpCSS+bPmfe4K/4dUuDDezbw3bemCmWHJs2c3qyrfJbhbmFjiAAAA.H4sIAAAAAAAAADPz3lxSMjOTZWd6CP9hw5kuN4vbEvTmzdZhrZnuxXnwhA0A3DcGxSAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:43 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.7_IXysyY3oh9zLiiIcr7eR8rsmQXdKUEXOwGIxrlRfE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtk1nUNfMnTIwDbX5wzUrXTdNVwsbSZdVXyTtN3t3xOXxEpZqf6ArudhWj6iEgNtdbe4cjTP1_QZhk0QfhiGqDf4-EXVQ0tPYGx7icGEVxA096gB0Rhh0hsrF-daG-9ZXRsM9hKeK-S-5_jPw3KPkBlUg3ejzM1HwhYobHxJRRoSWZTj78r63ipVcebgQoodyiiRhUMWOad-0O7gVZUzi_CfDqrFZl3dvBp7XIy0AHVBuzAEISQlsVx52mvYeWAhRGY=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtlMNp8hPwe-gSVKIWzQv2jyaczFWNMI2HGHt1H3mKCbH_xp6uOfzG49yg_GqVSnRa20P7ZsfrWRiu74gi3um4jyTvayYFrgPvePmZF77wEaN0BVGqwUFTrias7pwc5VkG4wiplDLeHjbNSvtvC3m7D5vF0AccVEUN-KEZureg1K6imxJO5hfEjl_EBrSOkGBh-wiZR-3QcHZCJ1O5BCvrp-6E69PMDfGR43NBkNIc-A2KJ9EhvSnMPdQhufb0ZidQ71OaZ3n4UltAam13nhwC7SmzdtXPU7ifb2iZjRimLixzZ_gBlgKgSlIAuJpMqleK-CwngH8Sxu0Clwx9hYbzyXiFuUU0GDYEezREUI-G1xcIMPdXbOJ9H3o8Lh8fKzTbJBv0APRHpDSUd05Evg6UEPE3e7SIsXVWR6ZZyKtoex5HNnOmBTtqgjZhEy_ovsG3UnvW7rzxxtImCFAiSxUOpEtf-3jZ_sAgXcFkx402NjFAUUYRlQW4f5S8tCLXnZgPUwdIyNfRcdOIZZ-E2oS0IQ_Hsyhuzl8ibUnUDHlUJrjVmKbkv-CooRdepBNKb1-BDde4IWZtvdWQCSiShHvZbj58B924Ej-xVVD9ELRoz8g7yygvc1wravZ2Pxrp_H_zwipjcLmWQDu4PR18JM5_tDGr62tdNm9Aq8ISRV2zzeBvZiNuLRe-VdR_FmNvMXc0zJmCoASU8j3aoPY5KYXR79SndmRMoG57vv0ErHMbQ_Q4pxarDLqwqDdSP9IS_x5cmAxFH5Po441Q3eetaM8CtOBogReoeHbm546P4jdTs9lVLbJe65RLvH0MWzK3_LIQrflU_hjrS7ZeiTGdMybL4TWxoW_LutGYexxsRCh57_1Rty7UWOjzsoEZdWnUtgvsqUjTK-FQUarGGy8NkzcYzpjI0bEG9B8QQGmI6ko57b4KU2OltAnNRdEO5yGXOPwMriH6aKMbMqhtAuOPQW7q5SSPb575LAx6gbVKh6wWZqMYQBY3KCuI1rFiNQZryU0MkuqchiNMBf3pWYGw4fyxbnhJjIyzaR0kq3vyU6mCoTSDBpXKf8qhilKH-q1sxzIHlasApf_nHRj9WMmne_Y1wk7wS6910xnYTJhITWR3EnnYU-7HaKLPBXsoQp80I3SOn9ylbC2UKN3X6gBZJkSmOuXV6CYDiqW9GHfHHwfYn9UgKmkbakKAa9FJG7oWHOmY_6VGbe0oV2Lh190a9A_GKRlv6_yKL3djqO0f_66ibmYOqR8RDEpUbwA0myQTxK1OlaIwFBz2GFwTKAPkCUU-J70J8dGsykBBu2nsC7x74lCEEmBll_G5eZXMN8dXBWs6id2-E5eEW8Ynr72GvxBJr3Tivid6UJh-RknzGKxdrZ4FRzF6v-5rXbMbI_tMKna9nvSP3PU_atCQVIMtM5PpkBRgEK8PJWrxUc58rXDv1GQ1sp3DnwrSzyW0oIF37sUc-ha9CEr3gL8e_ojbldyqb7dGvawySKdBMyJc6FGlQNIlY247gyfnH2LSjISBC2B2dukhYcwhTLFFvLS0bVPHjx90IZMuWZlUyfVBdKkB6iw2u_SbrIAwrCbBWtBOS1neZ96wWgZtlebp4EKW2y0kXjWsQM30JQHtyTmfqbGrLJNSHAp12iG0dHpRFeGgj99ANRb1IdT4fTO9fYL1CjZC7ZVjEeBj6kySj0K0Vl8JGyYfxU9-gCxM0d7LUT1-iBH7t0jQK12sXu-BpBwhJqs1KgAsdVM1Opx2MtbrNX49Zr5KxmiC1iihCEKa7ctHMqwOkG1ppocbecN9xNxH4yt_6Hr6l7hsmfM8wEXTl_LbEfLWXvVfPtTr1tWBl8QJQjgXQWwN7AGBKpE-gnsHcnWgfMLYLU-0H0b68Gt7zyZho-JV4JL84-jnbsRF6vZjsEffNauixMaXd62miWCsVtAaBXsJiZmA-ot0Qqd6suJG6dc9gd9muFwqSkcttx5C_TTpXCCScPPsH3R3OheOmPVpoRnk0xBPM69KkfObw725ko7bG8_Ua1r9q8PX0SYWsClfKYDzFlUKQKXVVEvOaghPjh31yVdBOGdn9O_m0KV_iuGCiQlXKJguz-6y3B1IlqZmFmwPlSIdX7E522LJEndPQY-4xk1x9OCjwm7qNLYO3s8HkIxvs20dYikN0zw02SYABtaeemelQyv9HtHYLL9SqRgfIx5MiJqkyWZ2VmvzPFUL8NFMZ9mrqheC8LNAT01lgocODZSoeZftT9PH7fz-47OI_UGWSO3cKA90sKmX9Rk5ukOme9GWALeur2IplJ8oiDKs3cOoJ0LXs0DixrMYdr24iCqBDyhCnb32Ti9Ni0ZO2166ys0s61r5gbNzFz-lP3YUhS5JV7RQ9BYgqYFHFn6dqKUZIixCJQWoPchFX-3sG4e3eYCIzTNLhTocBJuyZ1e-jkfE6zqAxE6rqJVmkj1l_2_49rCkj40vgr604jvA;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTc6jvMDoEEPKA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=FF5893FD44AF34F4FB24370100215234; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkrRVoScjh0qmA01mRj9zdQ4SL5hDYxoOkA3rzOz5TMs8y2XvVaO4xO0_GRXVWL26yfQqsLpuqoog866EMoa4jjqx-kCmEaFh5cchqxQ1fUFGvwwnKhI3AF30YT2f-L3AyyC3cwJaS2mvT_0w66VOjI9AKLCmHxG7Wy7TYZIBYFr1v2h6R0UXqbCmTOb77PmXRtgX6UqYPU-h0RwY250Uujyw4UrTjujLsvBTNyVIQ70RBZCuKa8JKF_gu-KVBDubqYGFl3A2IwCR_e6e0n2y6Svue09IKvzyFRY6uZkGneVSHxk5O10mdNNoC2_HcsZCruN3a5LJbuqJbwsJEbzTS-rR-Itfz-habjD-MKtHbUNEwCP_oA8wOrvH4Lwnp58-Otnw_6-u4qPj8OzPJIhtKhB8CDXOi3IRuKCbEdZemyBlriqQmPk4uljhN39ZDgRNZ9HCZbk-l2P9d1ZkHD8sqTgFopD7jHn5-BOw5I02ogDRq52ETTt_naXU-aXgfm1xjyQWiN9l43NwGSENdPYpP3QweTETmMiwrO0d9BSVh8AkNrZnDMp3YTnVcXGjIA6BTTRoAuJmwv7-zBHiH57uaZmy5MUCNrhWDUVeatGTG3AJAnp7iOjESGph4MmpYNCHY;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTc8gHkDoEEPpg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtk8o_If-btsjbwNOQ0VpxAZ5RSLl-6qGZ_2s1IGx3kuoajTqtXFRfximfp8ZFiZbM2vjD3qHYH_pcotgMF7JKnu2hPevx5DVeHcEuzBWfYP1a3Evnnlx0LFSB39wa-yNYjwT2tnRdzv3iVvbUVDMI1t9ShA7fZ3vfHUYRKtln-Yb9OtvGo8x_y74Ozib5QFK6ll74Av60RwoYFaOWodUIeGBPYobfARSFQdpWR7fJd8capGjBcmI9HLjB9JWTVfzEWn1WlhNPXnoZYdzXr-mz3vIjA13FKCMun5V_sXEli9gizsPUxjSlr-pmtOOKFQe3B6DTUmvbWX80-2p_kziAKSTjXii7Yp0-Dhue1lkzm6QF0di7JUiYnWPymMh2wtB0MsjM8kNMbi1J_kXV6GuiC0gnECgKXsmrrMGGrfVzWPzJLl8O_5eQyI06_V2Kbokx29sSnFqPM5NRMToc9buqZ2r9625aDeVaepe0HhLP4FQrOt-fTr7SLll3mWor00gjcQX6gX31OzmwYGDxiJWx-vMNOqcSARTV4Ut5wRZnWASXZxg4DqR0j8enN5Dlf-91fd_VeCE06FCCyOOGwkBAckzXbSZRZQ5nwV3OVYQNo9FxlwtRv7tan6dJZkmMo9plUM-FF956s-zF23LkDPxGdIH-4jRybzmk7oWLw-GMlF_Q;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTc-jxMDoEEPMQ=
     status:

--- a/tests/api/cassettes/test_multiple_devices_consistency.yaml
+++ b/tests/api/cassettes/test_multiple_devices_consistency.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtl5Hd1rAcGq0AaVtBQvJC2NDnXGM8ZO9jv2CC0FYQu06DOIWWR6DrX4VuLn6GyG3Q5JG7Fg7Zyezo1omVSEHy3OZmRZswwhlWj9fqHmz3B8NMu4PpgsPlh-6OrYOq1emJt-_C7fmAW5JsbPw0cXd-Iulm4L6hGTEWNrQXQhGc3l3H7DXRc5CGMLdGQzC0aODGAn6A1bi-0ZkjLMMHdcF_4IY-6Q9u1ovVqzEUqd9dbk4I5YxOUFkIpK-Jzu5Pvqq5c=N;
-        expires=Sun, 12 Apr 2026 13:16:45 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.oGpqUQz1Bg0hVe52AkjMcqFCcmYv-71VRMA5j8hdl40=N; expires=Sun,
-        12 Apr 2026 13:16:45 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSlCjLtjoEEJLQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=27c0edd7-7349-4bb9-9d53-18fbb88abd70; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115957054509678.ODlkNzI5NzAtMDFkMi00OWZhLThmMmUtMDU0YTAzZDY4Yjk0MDJiZDJkMzItZDViYS00ZmM3LWIxNTgtZDc5MTAyMGE2MjYy;
-        Expires=Sun, 12-Apr-2026 13:06:45 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115957054509678.ODlkNzI5NzAtMDFkMi00OWZhLThmMmUtMDU0YTAzZDY4Yjk0MDJiZDJkMzItZDViYS00ZmM3LWIxNTgtZDc5MTAyMGE2MjYy;
-        Expires=Sun, 12-Apr-2026 13:06:45 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=rVpJmJCBPOpcKhT05PYEkxnB6q_vsqNupUtDBHn25OI&amp;code_challenge_method=S256&amp;nonce=639115957054509678.ODlkNzI5NzAtMDFkMi00OWZhLThmMmUtMDU0YTAzZDY4Yjk0MDJiZDJkMzItZDViYS00ZmM3LWIxNTgtZDc5MTAyMGE2MjYy&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlkPzLdnUW2RsxSP7RIm9Y9JzphFziJZnGz2aCGtp1xcpBXOU6q8bfdQ5MXQMpnzeP1yeBvgRTKkMbxIPHqMHmqAN34vpVM4mc3GpGQTJhZGiOvtY6H6IilBfx59WDoL9FuK47W37DhGedhpKiduAXnTXtpiZk3Kp_ZTsXFkR40sdOfeq4qPR8KHN2VSd5QXPIwsVWqQUDJ9gokKfsY_sDHquUjjOgj_5i87hZTdgTdcgfSFhDoa6Zv4XcJV3-0Dr4aTI7baTNSGYlcBVTeDckXk_-IOn8SJi5IoHc1CXqCXDPcel8UN0BmqYcOr85CJhQL6meGo4__o9t48YffCevigvIsMrUzoGkJbGIZwTrLM4YjW_MdJ6knGooZ6hctN6pYyPJJ6QBSZ-GhGtlx4vPGoaiajN4zOqtuHgRL3Z77mcHCOHmR14g_VP_L8nyC2yrOwgDxw1aXX795TWii6BA8Bzg84O92r1AnGbdDrcOB5zZeN9KmeckAnxPggRysBwSMMO12hBD_JdZZ4_uXecuFS9SM8c9KDnJ-pXRMKv9zuk6u5XzDcQiOAVl2KS7pRJ4tarf8oVFwh5HUHrIoxxxJfakR3fLny7yfDLATjrhWQSYKDrKIjplB-9IOO9fFoNX27CEwDsAV50XtpOAri1kp\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"27c0edd7-7349-4bb9-9d53-18fbb88abd70\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-10c1fea84cff\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=rVpJmJCBPOpcKhT05PYEkxnB6q_vsqNupUtDBHn25OI&amp;code_challenge_method=S256&amp;nonce=639115957054509678.ODlkNzI5NzAtMDFkMi00OWZhLThmMmUtMDU0YTAzZDY4Yjk0MDJiZDJkMzItZDViYS00ZmM3LWIxNTgtZDc5MTAyMGE2MjYy&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlkPzLdnUW2RsxSP7RIm9Y9JzphFziJZnGz2aCGtp1xcpBXOU6q8bfdQ5MXQMpnzeP1yeBvgRTKkMbxIPHqMHmqAN34vpVM4mc3GpGQTJhZGiOvtY6H6IilBfx59WDoL9FuK47W37DhGedhpKiduAXnTXtpiZk3Kp_ZTsXFkR40sdOfeq4qPR8KHN2VSd5QXPIwsVWqQUDJ9gokKfsY_sDHquUjjOgj_5i87hZTdgTdcgfSFhDoa6Zv4XcJV3-0Dr4aTI7baTNSGYlcBVTeDckXk_-IOn8SJi5IoHc1CXqCXDPcel8UN0BmqYcOr85CJhQL6meGo4__o9t48YffCevigvIsMrUzoGkJbGIZwTrLM4YjW_MdJ6knGooZ6hctN6pYyPJJ6QBSZ-GhGtlx4vPGoaiajN4zOqtuHgRL3Z77mcHCOHmR14g_VP_L8nyC2yrOwgDxw1aXX795TWii6BA8Bzg84O92r1AnGbdDrcOB5zZeN9KmeckAnxPggRysBwSMMO12hBD_JdZZ4_uXecuFS9SM8c9KDnJ-pXRMKv9zuk6u5XzDcQiOAVl2KS7pRJ4tarf8oVFwh5HUHrIoxxxJfakR3fLny7yfDLATjrhWQSYKDrKIjplB-9IOO9fFoNX27CEwDsAV50XtpOAri1kp\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"27c0edd7-7349-4bb9-9d53-18fbb88abd70\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-10c1fea84cff\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=73fe3bf6-f25c-46f5-ac94-bc6d028d22b9; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/0839Glkz/B8h+ZHyvVnNtOUN3r/NkM0NpIL0f5HyNwZVQO+gwyowFusCrRS48s1mhHZ6cAtXTZ3MP2q3JoaLYzju8HUvq2lbBD4KzUK+8/2FZ2UhzEG0p5GR1bRSmf0YHFUgjndbSSSgK8asaRGF0+fB9ZHCwBIhFWc/X1cyWT6ntUiWQnGii+lh7G9lS0KIMjrHyeWqi/9JjttUkdHzjSpOmDuPxOYEO2dzvjO4qcusgf3OAEnKyNh6wm2hibFHPzTQpgHiaaAPQ5v7vH+cRoEUTDiBkQUjdJMj6jBw4u0hk2mSZtziAAAA.H4sIAAAAAAAAAAEgAN//CyiO/ZzRe7oSemX9nGnYaBgJt6EfjJDSxAdvpfTsIwEkvaXKIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:01:46 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.oGpqUQz1Bg0hVe52AkjMcqFCcmYv-71VRMA5j8hdl40=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtl5Hd1rAcGq0AaVtBQvJC2NDnXGM8ZO9jv2CC0FYQu06DOIWWR6DrX4VuLn6GyG3Q5JG7Fg7Zyezo1omVSEHy3OZmRZswwhlWj9fqHmz3B8NMu4PpgsPlh-6OrYOq1emJt-_C7fmAW5JsbPw0cXd-Iulm4L6hGTEWNrQXQhGc3l3H7DXRc5CGMLdGQzC0aODGAn6A1bi-0ZkjLMMHdcF_4IY-6Q9u1ovVqzEUqd9dbk4I5YxOUFkIpK-Jzu5Pvqq5c=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkMcbGV3ndd8qjNWZGY8jpa_ecC34_5kon1r6kDiPYlq79lIv51SMQbL8nYSs24xXhlv2ctNoHel_qmHTX-UXZC_h83EnW5bUJXhyJGXe0EbmS3DRDzq8pZs700fKflPtujiFIuHzUT-JX86r3xlYBsZNNUOX8XCr8-bBdWh5IRxdP9nIsHL_aKY44BEm9NEc15U0wBgsn5RxzUtr9C4MoaYgzZA1Gp561sc9rGrZrMJkWgMDmk6MVkw2U60-Y_qTLhmff_e6ep-icrxNzM4FnYk5PikTa3ajE_yEecIyH5ivYCUROHPzr8AUm9WsFxHBa4F27W6KVFyAyCy6pMKeINoklsl_mCGgWyCwZryd8bUCNL7SVJW81H0Gr9tnFwneofA6V-VwslEhp4x6q0HiXKZVhc2px2fCpRrpJrFrnFbAMtrafOF5Zh6pTe3jdwrlki2rEeIvCgKIZjAG5fsGQlfNH_lL8raa3iMkt2DAieB71WdS4cJrFjM6QKn5JA8-xzNjrMSKzq2q9JbZOohKYi65nj8J4gmif5c2gzqChXnBXDFR5y-nHuVIkkIaUxN2kDhYUvItH3TxqXwa0D025UhZ0JqxxNh6cQfDSozxVhX51kQpUJd7pt-XAzCS8XWUD8LXqGEWooV00HDSyWRmInQGuMtZNlDf-SxG90KKKk0FaIMwH0SK17QS6aZFMjoj_Ypz0_MnIFSxa0gUCzQBk9dKy5mzdwrfWE8tNKhkK0yL3uuLZGn3OdccEkLGwsqTXuWwWpcLZGWbzG8uMegRicSPmmBIZMB7axvfYd4cdkpjNCijS7KtaO4mFP7upAuXxj8uTbyOE3upVHCAiPyacvSLy0cv5m8hEOEkddONEmMWCqY60YUMHiUHvczmA8hsSq2I-AtNGdqqAw06Q-jaSb8VF0x4WIMYbN79B1d9aEw7lTlZpGijE6d1QZn5KQ8FNFzgw3T_1lHdTtLZWwFEq9hCnnddbI4hZ6h1nyZPZ1BlLNj7fCnH7ZI08zAxTg2zMoWTGMXOFRcQ_eC4xzqB3dmQy6JycJnbWrlRMlaOddn94D6N5T_YLMOA9EBj4Be4423NlutjZ4CDle054WPl8wKN-7BAKDunKTxEKh8QydeojWg48PwGWBDRi-IpLxNRk2JgxnUXqMj-0ayDUY7w3uzYvdGGGd-sOy8UHkZq_GQtCpR4IBcpJ0RykAROTuvWouEQehBvscFsUej2ZMcgQ_i40EFPfSunze1e5-5_SdjF6Emx9PYX7o3_0sRXtUGlVh2fYr058JQfW-mmIqnzbnlqs6rR_vkEdj9TRmLvCo_1x_G0e22s8H5t-YdPMugWXdkC_fFCf863CQyXItsJlbVhOWXQmC2o8LST664dV7pnb9d_aHu9JPhNX2QzrXtyXev9FmveqY16HV6xQUY9BXCHZbeeivTdKnO5f94SA97gBtBaW9q46RagCnHJCPyqESUBxHbjYV_7EVCQVV7AZ4WfZRxJV5HOzUYSHWA1Uu8GDnlCDGiDSGAVXUIwPbkW2VaK-H-sopB3Z2oDbhiv7hPsv-LcxFx3pUbDMUXIPpicT9-ijW3t_MZLo46aZfNTB9PGYfXqP4Qqj8R1JRSP6taI6b-vmLHbHdjwHX5f-fqjTX-LryrAp8Bf_-vVu1DRqH_4F4Acwx-2v2rU4gnWwjXwYoCyR0dmcJbM5wGUhaqyDGoliIgC7zL3NHtJOzvjVaBu6pK9lhz42geW4Inp4oFvYbn0qmmSWdSYm_tdriLv8ugHb_z5fW2osiioAjxJLkO-W4-R_jXYwLHnAMIT-NCC5MgL2f3BWJMMcAbU42MzOAaJcKEzGAqSFi7tvE70K_VSgI6hDRWPxj0VFvq9UpbaDjpwpgykby71fzfD9Lec4zCh6CYxHuFNjhQklqot8BwzVyMGwuDx7jisSEZb9e-4ieN9OnZcRM0bo2WI4wvjvWjYBWhKiMDoxMOoC2tbAHLNEzPqulimYzT1FFdH6uWw-wmQDMlMSrk1DFE0rprcq4Jumw7trLpG2lFUAtDBU_pRwqj-_eotytSfpNTMnRoHn-22sLBLchgvGMj5uK6xggGcb2REZMES1tWvlgUz6xHoyEJKytFnN-3yh5yJqEXYcc3yYwleTnrgwvoCLqGtu_Nk67dQrXjKb0R70ku_mLnbqOyMiOoYm-KRshGXIr-q4TlHF9a2qokUk5A-ab2C90-70SI7VXbsDCfNcOooC3HgyX-_ne2f8mr5uD2Vy5-AsfUMgOnb_oeYCOEan70Uhi0DMdhd7cKgAKy5q-jNTnxjDbH1uN11RromM92gb3sNyApbxhkxlnjH3haDhKrRdcX-oUyAaUt_gneTzb5PHjI_ghs5rn0hwTurhePaj7fCcFJUv0eNB5CK5z0RB6dWHaRGUN_t8awVl502G7lrRc3P7dS7GiBu2O76XxaQaFMLRR6ldI_shoHttGxj5CzQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSlJjp1joEEJTA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=E718A9AFE60FC790387895CCEF897BCD; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtn7IH45rMNEKSatap_o9aIAGDP0QkpKAAK4VfoQjyK7hC8g7e1TqPZGjAWcVlKehlFXAipS4c12ycFaaI6L7O0Q9sAfv6g97uuClQJjaME8GrEATsk2c8cJ_IXudHjtfQCBG2O1PZpyuCkablYn5mEzgdLHCtJtISgB3YHA3YgkI-K0zLxOWFVUXoGGABfymeBCQwZ6WDjAW5CdOjDCSklmVQeUSExQyPsLwF4YyksFFcLVz_RPOgQg01wQOpmBc5FJ61J2FCa54aVCHOfEye6Ry54vsWJ_0izPmSmXOE_hm9FcBT-WfT6htR32ZjxqvjtaTX1WFTwhaYxvqnhyFBdPI29ImYLZ917C3C5-fT648FLEtXd2E25UeN5tvvAzdaVC8xFno-GvgH0qIS4kHKHLwnevYkCGgwDddmb8SapTzBi_Dh44HPm5bPTelodR2HD6ZqYFq_jYet_7Ntxe9VWigvU11ZLgg47Ke6JgZr7f9Fyb_ajCuEeQu6zs8v2VtxgPl24Quf9YS5qSWRN8fk-sDOU81uDfTsqkUfwXu60OsQ0d-_lufZqflSdWNYET5u8AgG653wfKAvGgCDkLkDE0JBNvsNSyJakKAQFaXb1qdaTUHfkEUmC6HvCv9VYuRNI;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSlLgkTDoEEJ7w=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtm1-kQBJ052fV3uchSTs30MTht7sIMnZpH_IzCU-89PUfmKdGB55A1Ze7MFcvDPOjrnqIar3lllr1jvpTKcU27J4frANh-eLnYS4SUbMLCXP760ZuFrUC5NAOvezMNj_CFcf_cOMNQeMslVAE9LZt1URXPMYwUw3IWCKiYompLPdQ8_JIItW6x3yYG-v1I_03biuawwU88Di6x1MODPv1VsCkJAuClcCvmwk9eXjGQc4quh6e8XzH5HnnF4Am0YOAuMOLR-lxjVMRHY4bO3qxLvWLSqt5BxQ4a_T6ABu0yw7hDyJVJf_QGZ6MDqPZUSZQzuTKzHDCHdQgz3wnyKFvPkAUTh9510KFtsSYx-sOy8FhiA_3qyEXpjG8qPtM0gGwN2a1dVut0GzfIpukx33n6YcpAIl1QEZtZqVf7r3Va28btqvWi1EUbFrZ4ezSHWSyIQERTWZQHR63phAd_zysY_YT87eAG5nzBOnMi6vkFlBsVcN8cyYKh9rRJqgegWmFZML-5-yTnGBC8dDv4w5JqPEp6aY5FmDcYOMZFWuZeufbjF5Cxygft3ojItvmVecDHMkOcGUjFDdZCqoEjEq_ftYQ19v8XfdQMrI4H7fR5PrXDLnws6PeRcBgIrlaa_QTF5brF3VYbuE4bzEnyKRdhrpbdekXl-mV9TR-JWknUsRg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btSlNgd9DoEEJCg=
     status:

--- a/tests/api/cassettes/test_parse_telemetry_values.yaml
+++ b/tests/api/cassettes/test_parse_telemetry_values.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnz1NttNunjFSiB47bW6yqgCADhZJDblwpAolIgwCe0RV5QRpZyBg_VDuOhOK6bqPtBZOwTemOl_Hb3job2S11BCgwZ0htwLB5tlUpH0msjVyFtKMsUkKlxvvz2pAfESNQh5mDzJcrN1fO78-nNz2iX1YvIfowd9MS7E0Qq9gLIfOikY7zZG0um1HUxRwkXrSdjxvx_EoAHYREJCFOklKKLkdK7DtOAHfBG2xtBjy-6nPPBsBNQWlUN6wYdGTsuxgo=N;
-        expires=Sun, 12 Apr 2026 13:36:43 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.Oqd43mKRaZxtqSiRpOo9znO1AIk17-424GhZzaHlkQI=N; expires=Sun,
-        12 Apr 2026 13:36:43 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVgKjy-joEEMsA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=e0e5b129-31a3-4bcf-b6ee-fdba41b148f3; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115969030501369.NzJhMjM5OTUtYzVmNS00NDg2LThkNjktOWFlNzllYWEyY2RmZjM5NzhjYzctNGQxYS00Yzk5LWFjODYtNDAyMGVjY2Y2MTU2;
-        Expires=Sun, 12-Apr-2026 13:26:43 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115969030501369.NzJhMjM5OTUtYzVmNS00NDg2LThkNjktOWFlNzllYWEyY2RmZjM5NzhjYzctNGQxYS00Yzk5LWFjODYtNDAyMGVjY2Y2MTU2;
-        Expires=Sun, 12-Apr-2026 13:26:43 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=qBTdEHyIwJ2WMt3n-G5bnh2wq7qbt2eyAQ7O5Mu0SvQ&amp;code_challenge_method=S256&amp;nonce=639115969030501369.NzJhMjM5OTUtYzVmNS00NDg2LThkNjktOWFlNzllYWEyY2RmZjM5NzhjYzctNGQxYS00Yzk5LWFjODYtNDAyMGVjY2Y2MTU2&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlVSk25l8kNuzXsmeSutNhVVuCJpNFexS_4rZZc8YwY6Vk7plAWTogrItq8cBK1ar3iJ6qlpm6u8DHlz5eIzN4Ejse_YSH2K58PvG8ikB1JgHwjJZNHWme_w9q003rcSeY9lNgT2YaDSPedlXH9FuL4nHN9pAOEQr0Zhdm0KgWf1hjXImBTz5UD9zccZkfsheCJdbYggPULlGRYyWFsUam96iR31vY4086477aWYmGQdHJaMzIX8zVKk28CAcIVuuXf-gJnB-IGJ2DDEpjBVuqXJi1XfyFdCw0oh6ntQXAqKqi-Je5DVdTsaK-KO6uINGavrzX4kH68z8XyQ_xYo6Dgoec8rEo6Qd8HlmNaQgIy1Kl7B5PgkKdlG4hnRFItVdNd5wSz-S_JKIgX_3tUjooXpfZe86o4DwNxrVrM339pNGa29T6oTD6vUlWBjLi2STmzy1MmFRj4FT9HPRzRo5pKHAJ5rMueyDjfLwugApDjO-8WVn9T_IMcF1gBz7mUQ4KtovCtVUqPgntkzgf05oDxolvCwc7at4uMFlurGY4l0nAfPjxv77cRJ81cBmmwtOoWQ5u50Knw02s7D1TIxQ4RSGJ-85vzhoyBQlZs6PJDFO2Oxxkc2p-hj-M818MHZNBFlEu5s89Im8bBU2Ey1Srr\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"e0e5b129-31a3-4bcf-b6ee-fdba41b148f3\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-236bcda14b06\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=qBTdEHyIwJ2WMt3n-G5bnh2wq7qbt2eyAQ7O5Mu0SvQ&amp;code_challenge_method=S256&amp;nonce=639115969030501369.NzJhMjM5OTUtYzVmNS00NDg2LThkNjktOWFlNzllYWEyY2RmZjM5NzhjYzctNGQxYS00Yzk5LWFjODYtNDAyMGVjY2Y2MTU2&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlVSk25l8kNuzXsmeSutNhVVuCJpNFexS_4rZZc8YwY6Vk7plAWTogrItq8cBK1ar3iJ6qlpm6u8DHlz5eIzN4Ejse_YSH2K58PvG8ikB1JgHwjJZNHWme_w9q003rcSeY9lNgT2YaDSPedlXH9FuL4nHN9pAOEQr0Zhdm0KgWf1hjXImBTz5UD9zccZkfsheCJdbYggPULlGRYyWFsUam96iR31vY4086477aWYmGQdHJaMzIX8zVKk28CAcIVuuXf-gJnB-IGJ2DDEpjBVuqXJi1XfyFdCw0oh6ntQXAqKqi-Je5DVdTsaK-KO6uINGavrzX4kH68z8XyQ_xYo6Dgoec8rEo6Qd8HlmNaQgIy1Kl7B5PgkKdlG4hnRFItVdNd5wSz-S_JKIgX_3tUjooXpfZe86o4DwNxrVrM339pNGa29T6oTD6vUlWBjLi2STmzy1MmFRj4FT9HPRzRo5pKHAJ5rMueyDjfLwugApDjO-8WVn9T_IMcF1gBz7mUQ4KtovCtVUqPgntkzgf05oDxolvCwc7at4uMFlurGY4l0nAfPjxv77cRJ81cBmmwtOoWQ5u50Knw02s7D1TIxQ4RSGJ-85vzhoyBQlZs6PJDFO2Oxxkc2p-hj-M818MHZNBFlEu5s89Im8bBU2Ey1Srr\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"e0e5b129-31a3-4bcf-b6ee-fdba41b148f3\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-236bcda14b06\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=4b710ad7-6e2f-462d-ad49-881c37b7a515; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/hBQeNA74aQFsdttinvhbEU7wVkG1e/UyyVvdAEoigw+AjOuwjNobX2mGUtKLCTvq6ahL2WFv/VNqrUuR+Ihn/SuVDFTI/GSVNtdk3okzfGEhTcoXNSCSou5iLUeV0dEhCfVZ3Burq8Wbx6Sq56Bf6WVy0xGqJcmcPDxMDO83/2rEqC2J0cYx6omMdFMce/C48MU5ir0IsK/8rOKF9GYqbIAiD2UnXVNotHnCsPOjKbk4voGgcvcRnhxfRScQQQtL+e+BO0LdQ4i+RovJqXXLLaGAQArNC2FLTYPNUtpZ+GflF20+5+3iAAAA.H4sIAAAAAAAAAHsrZ/nkZo/deye73+I7H0c6vTnyO4Dl1w2Fo77dh5KY5EUA4y5qQCAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:21:43 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.Oqd43mKRaZxtqSiRpOo9znO1AIk17-424GhZzaHlkQI=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnz1NttNunjFSiB47bW6yqgCADhZJDblwpAolIgwCe0RV5QRpZyBg_VDuOhOK6bqPtBZOwTemOl_Hb3job2S11BCgwZ0htwLB5tlUpH0msjVyFtKMsUkKlxvvz2pAfESNQh5mDzJcrN1fO78-nNz2iX1YvIfowd9MS7E0Qq9gLIfOikY7zZG0um1HUxRwkXrSdjxvx_EoAHYREJCFOklKKLkdK7DtOAHfBG2xtBjy-6nPPBsBNQWlUN6wYdGTsuxgo=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkQ2sF-DYuZSJlWx5W-Fy7CuHaJvO2Yklzzyg5JROxR2EbdD9XERx9lsFlwVo7SELDLj7FGnrcD6sqZLX3SXcemvoWPWHJeGM0F3cFefbm22-6fpP1Y-K0vlzmp4uUiTuKpZgckC7lkrtbM5w_WBnwhDGByzQPfMM0OELfKV86jAHd6wulM1LKjY7eGtYOOqNrlr1Qkg2ufV0vD-AS98ghf13zorM5PDRcfHPnAbsO7ipsE0FyG3h0CTrz01ScdVJldkt4FnODg3A2YrSH9gKQo51xk3t2z62RfoUp2bKCEmbYAiSPaFTB6cm09a1q8hBaHdUjRqil1zkR0hM9Li3G02rRxpytrZa4bEbxSyimTBxJ_MNBAABAV9VtADgcdzcfvhxWD4w8BlQ__Si4n_9EywiCv3T-IF8DY21BNYIpm8TC83ibrxNhcsHTi2Ar8V6NBFDgqWxaaknQie93RD3pKj-ZiHetoD6s0_6tJWP4m6XCV3pQrC3pRImRzxv9wwDg8tj6GmrA3RCiE-5ciYZtxRoLGV79_Qp40Z_vptewTg95xuJIscLKdW0MyZOSXT5IgsRifWhT2Wj7809KHwx9dB6hKff2Yh27N7hj0yHwVdIIYFdJ-ZmdldHV-7kmiTs9bTl47V44nwdy-VyrshtBVJZLgu1mYF3oUt26MVPn-9qcEWadUaJ3aYsiIUSJl2Y3V67ZhlvTyWavotNCBp-mGLO2VPdKqR45VKVQGA3-4bIxAvwT8jPcz3J9f04PFNBkGkBy50kOswBkGfPtyzXg270V6P2uCPIPTQt5CbQayn8BO3cn0G8ct7zGi61m-5tjhPhxJXMmGr2Mz4T-EYercwgXrjXQgsJKZLt1mS3UOUS43gidbQ1s6lm-TePwirybVY0eee-Gtu5Gduo0yVvm3161Y8VASpo-7eKQgtfuMA-0Ex4CB4-gg307BIwzOUqjaGcra32ngZqRei8g9bfYGdUi6j5nQRRK7D3L5qQqXgV7jK2Di7ky-saUT_pSbdle9tkjFNbB8Z6jGkLknK-Wozyb5Y0lwxg-uVa1-SF303Ig4N3b9R_wImEhHs_ZdMOIHp2DFZmIKQNkg3hngH5dkygszuk5M1OXgD8O174dE0p9oA6o2AIb4F6LOgjqKkj9TPX65t9SPBaGB0e7GSgNBWV1xYAPZKRqsSi5altd9CwoBiAxUv4DnhFGZ7Q7bvE8OxCsfDgr-3tqAchfz5jyLb3aCq2sThrjkZYRDOdA922NIlW3UDvJa-Aqud9hk5T23glbagwHMlgm1R0fLrp7OSsQKyWmQx7LF-AmXGj0dSZROXb0z_-VXGaR3EkHIq7jOApP-AjP-Mvmg84q3GQ1Fv0Zpbuevpkh_87vwfeV0oOqSiNwd8PYvZvV8QuWFjQ0kSlaetxPRFs-W3_PsTDBKTnf8HVe0nvMXnGlVsIlPJpjR1lw039HURG9bOLCoboBjCLxFMSQPWOxaFZrpp1BxguM7HKRaDhNzEQK4FcF7uCz24qAf4YTg2gFITn1DAzIae_YAyzDd0gNzOJ-3K0Zt8HLCdaxQmZCCl4c2lTXelEXIM8XLmCyIk_2Gj8D1LCYbNfU1Td_V6V7lo2UF3fSls6sGQcUjWA4dIudp509DLM-c5MvREhZyGpVqYgU04zvHloyZODiDGsCpJI1nc0PJdYyuV4g8QCE7dedrG2iffVIye4tR03sk4QqwfR60yNUUrO5TqJRpwzY0CMSfvVnGSW8efIcVRUneSEHMrumACiXy9sBtoLhTLzFXipzpjnrr2EoJiF3sG-xf-zQHfZhARufqZhKNXeGJT1qhKRoTUn866REFkjVvCEye3T3Agb_jcTl2eLaF2-xuOkN9fFAigukEoBwtpV1auFNd8ENcUx5QNftEdyQtwSXd0CUN78-CA723wp7DNfheDboOTLqq38pqdvTlakqBO5IB0JSMd5ubIpi5rgprJeqoVA9HAq6_9won5KaJbuJZ7xR5ebpwYos0uH54HHG6tWGcKBZY6_UHMbt5HdL_Oc7qjHRKvGv3LR-JK6l_gNWqHI4YUj-5XkU_ZuwWbGuwASJV3nA6-yoXhig-vMdtdAzthlppwvxYaruZO_tpRXvMnYoizr8-EwwZgCUtBcTECG8wZYIzsU7lJ9lLQqtwRdOtQ4KSqkHH8yspaRty1Cfy2Egu6ez1D2nL6q9tqmrHmbfriXPl8UKNJahJAD--3Gb6zALuOT2n_FPgQaRPadagsfUzm672549FfVC1kno8FJOJ6U68G1ZC23eJKn3HJ18ydquVnUEvigMrIIOPkHrGVfhPf6lPhZqVEl4ASSOmFCtRCy54tvOasFicPbrfJurXL4sqrX0MEfDh_J-GccQW08bjnIgTjOLoUdZh9pwtYXjP-C20BcBaMwAfM5wIaJtmNEbLjKvPY_BA64c_UdzFbQ4npG_Su1avScEW3LdHlgKkGA0IVQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVgQhJqjoEEMWA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=59D90CDAFA55E6C78826707305A4DF1E; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnd63L2e48CqUGM6FbcqeEIDOy2JJfaT8ubQMXpfoluw4IL-72cQGLj4S8dcukTyz1Mk9hjshfYn2F3nOwpEP9pE5Nc_p8IYYv6SEqMaoIHoWvTY_0nCVxD99rV3E5BmVu8qFA4-CJtAD_fARQD_gJPCQGkp1S5vKuiIvukrJG4agLZS1I-I6rerRH1f7c5hAp9sSoY-G418jQhGjAEPGV4ijVetOaP-M2yEhO1D8Rq_LcU920KSHQvr6txiDLNezw5MUzVUoJNuLOFfmTi9dXHKDiprk5yfVlnDTFnol2unzJXa1nBO2aeyFuBK1EJ6YudenfEaIu0PzODLkKsAakBzx4AtcET2iqZAgOOGh7JKC2uH1xZoaxsUszRPq6Xt8aB0I30KC14lsFupy215kfGsuHz5kpuy9n-fEIJqQOwt1QGaD5y3xopxWheDMgGI4mYLGlFqqAuSSzJrRYNZQsUETshPPapDCUqm6AVvzbFSay2Wb9IqwkLP03Dvef3fwcDRP535Zzp-A2rMv9Ic6-6PSX8iL6gaX9N2SVAXd8wFZbjO3yPOUWV6PnVVYbIPb4Yy03ANYwr7FpXDjpCA_BN2ac9-IdK0JQoZUET4iZKJWWQLOzaf9lNrtOMzof_Ww8;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVgSjDlDoEEMCg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnqoc5KkzjqeZgGI6BGdtU_7REsqdS63OmAqPo1aATaLD-vi5zDeYR2p25ySSP6yzig-OmfJmlnpHCRNim8xI6dtOOWCn-FGIH0_YBEle563x3L1rEQ8IF1QgOQ_cI4AIAy9FLGI6szUmzsbyztBOwPt-hs7GuMoTqqGmnEbR3z4X6z2FhqhSUbfMnFb_8xOEtfUgHgJcjuk1PHZZUHgcR1_9DhqCHo-N4jOlAJpD65pWF6TutXBKEHlnEPqxl2dc-wzDaN-RgXpkL4XtqjKbaXPndRqWlfKucv3zZn8qZRlXf6Tcu7vsgl1ZAPe4Nv2V9CFSnfkFEIKt0-iYH4xhcoIahb-x4_6c7FDJndQYgMhwOUWSzQ5VSBU3JaJlA9SZNfq646qIospdnDZDeuAyUTCFgpTlmvaiYfQvJUuN2k8rYDp6PV4v6LW911DCHdd33IRLvp7MmbjTeh0IGneZytWjzXL7eCwH1jYjFsNpUuaXi4ihfVWNjovGCN1ZXAXx6RRQ5uaXVxadJ1YH9pv5CiDX6_h13C90dnpzyt9SDBOd3qZJQiC_Y-Z6i9Rs7aRzPUx1vmM71ljr0Lp5G_yQw1OW6SXn7QZGzyfeAVH1YaB3wIohh40e9XsYoxf4i1govQ1JHhZPLYRBlK5R0QOwVPskIP1lWIM8s1zuSDsXCdxA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btVgTjNtjoEEMTw=
     status:

--- a/tests/api/cassettes/test_set_fan_speed_auto.yaml
+++ b/tests/api/cassettes/test_set_fan_speed_auto.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkbJ-ujpdEYYKP1dC_yVaMSVLOXYUsrmwGKnTfBflOgVhvzo8LxTz4nkpuitvGE4eBBTsXjcsobfFtISNIRLpXfani1g4H59y-k9_MQeKHxxBfEc9eFyY70zcjOtZ-Ijse3RmsF0thiTBHcThEn2hTK5JOBeo2338DA6kWZYf_NewB06B5w_ZiL73-DlPlk7_Yw-XuPK-2hddTEdpODbsKi7jj74WDMNPtvlV4guaJwo8cSvI8oXwuc9WIdvxPUsa0=N;
-        expires=Sun, 12 Apr 2026 13:22:33 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.4MVgC57kXxieZliiL0O7cSDjk9PCsefuuX6MyCf_nkM=N; expires=Sun,
-        12 Apr 2026 13:22:33 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTbfjRijoEEPQA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=c2de897f-f2f1-4eec-aca6-705064687e9d; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960539241919.YzE3NDFmMzMtYjU2MS00NDhmLTkyZWUtOGRjOGMzNjRlOWQ4ODI3ZGUxYWEtZTI0MS00YjNiLTkxNGEtZjA0MTJmNDdlNzkz;
-        Expires=Sun, 12-Apr-2026 13:12:34 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960539241919.YzE3NDFmMzMtYjU2MS00NDhmLTkyZWUtOGRjOGMzNjRlOWQ4ODI3ZGUxYWEtZTI0MS00YjNiLTkxNGEtZjA0MTJmNDdlNzkz;
-        Expires=Sun, 12-Apr-2026 13:12:34 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=Q6EAyI9WTjiLxnZm4kQWhwoG0oZJOhyklMjEd81Wgmc&amp;code_challenge_method=S256&amp;nonce=639115960539241919.YzE3NDFmMzMtYjU2MS00NDhmLTkyZWUtOGRjOGMzNjRlOWQ4ODI3ZGUxYWEtZTI0MS00YjNiLTkxNGEtZjA0MTJmNDdlNzkz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmWgDNbQMjwZPwD2r-N46BB-BI9k2BpM3GqK2RUhI7hYh0EiYZ7wvIbusb2ymyzR0Q8jNiIhc1r5EIolPBjEpPCXEu38W8Cn7XdGpEHGZhi6AxomWLK9Qu5phwG-GHbFgkQ1Fbiwol9mR-NQJ9DpNRhDflG5fuJ-TdJCgLqZY_d0YAFnVHhXCOtQBRUZ2_su9g2U4NTrTaVcTzIZRyXxZhYyvPqVDffUI8DZDTXDy-AlkMD1hO48TB6ZSajV-8Y9MxL-EDtmjLHJBdkSEggoC4pTTh3TwkUc4WawObgk7yps2V8EYQO2CHiUzMLD4TV6Sevm0yI3xuuVExTWo6BPERHZ_sAMen-bfJubbYVMLZX6_cStLWWUWX7gn8K6jhY9e7h1WOdpre3Qzvwh_dogHcRvqe4J4a1u1JR6JhPYZ2NjJkDgpdr-pkBzFcixybtCX-aLwvd4-COacrIEwVUV5ZDmZsmKCSE2hOe1Jv3JtiZag5fXiDNi_CIcb13F0wfIulRqGq2fL_dkprmcg5npYrMcD0U8DaaBFpCT-11JQbLGylOV5oNCn-G797dbp_S206-OMn8VScjfRmna0ln151dbwxGedlytau9OBN4DD5LGZr48w_ib1chdk8-mdPzo_zrouNL5GqzwewzKJuxouG4\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"c2de897f-f2f1-4eec-aca6-705064687e9d\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-3e09ac792c48\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=Q6EAyI9WTjiLxnZm4kQWhwoG0oZJOhyklMjEd81Wgmc&amp;code_challenge_method=S256&amp;nonce=639115960539241919.YzE3NDFmMzMtYjU2MS00NDhmLTkyZWUtOGRjOGMzNjRlOWQ4ODI3ZGUxYWEtZTI0MS00YjNiLTkxNGEtZjA0MTJmNDdlNzkz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmWgDNbQMjwZPwD2r-N46BB-BI9k2BpM3GqK2RUhI7hYh0EiYZ7wvIbusb2ymyzR0Q8jNiIhc1r5EIolPBjEpPCXEu38W8Cn7XdGpEHGZhi6AxomWLK9Qu5phwG-GHbFgkQ1Fbiwol9mR-NQJ9DpNRhDflG5fuJ-TdJCgLqZY_d0YAFnVHhXCOtQBRUZ2_su9g2U4NTrTaVcTzIZRyXxZhYyvPqVDffUI8DZDTXDy-AlkMD1hO48TB6ZSajV-8Y9MxL-EDtmjLHJBdkSEggoC4pTTh3TwkUc4WawObgk7yps2V8EYQO2CHiUzMLD4TV6Sevm0yI3xuuVExTWo6BPERHZ_sAMen-bfJubbYVMLZX6_cStLWWUWX7gn8K6jhY9e7h1WOdpre3Qzvwh_dogHcRvqe4J4a1u1JR6JhPYZ2NjJkDgpdr-pkBzFcixybtCX-aLwvd4-COacrIEwVUV5ZDmZsmKCSE2hOe1Jv3JtiZag5fXiDNi_CIcb13F0wfIulRqGq2fL_dkprmcg5npYrMcD0U8DaaBFpCT-11JQbLGylOV5oNCn-G797dbp_S206-OMn8VScjfRmna0ln151dbwxGedlytau9OBN4DD5LGZr48w_ib1chdk8-mdPzo_zrouNL5GqzwewzKJuxouG4\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"c2de897f-f2f1-4eec-aca6-705064687e9d\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-3e09ac792c48\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=f65eb86f-0663-474b-8f4f-53325e93ab61; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/IyxH2PKEiovLlsEBjU2HQySofm+YBcMe/cdrCqZmWHORcEAH3EaLMbVGmwwG9H6VNq9iZG3q/QJSW1e8QdpQkRJoetUfarEhYtHV96eLcenvCwbjYBdAPBW3SCjojmhvut32fn7dUvG4rx3LRz4qqZoeecCFhLFgOWFoiCa3liDO8UEypFfQWnwHjIYP0LCLseGfGMeWGnXBlc45IY3NHgwr0KfWHcBaSFQfqEiqUMVphQQA6FvWBszgQQN5JQY6hhDiMQPHnQTuurPF0ATdTSVVxIx+K8PYD4c3UF+Jdq1IPWYxQiDiAAAA.H4sIAAAAAAAAAAEgAN//VMA0ab39o2yvdYUrqeQRlGcit6dttw/ZdKx4vIURo6MICzBWIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:34 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.4MVgC57kXxieZliiL0O7cSDjk9PCsefuuX6MyCf_nkM=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkbJ-ujpdEYYKP1dC_yVaMSVLOXYUsrmwGKnTfBflOgVhvzo8LxTz4nkpuitvGE4eBBTsXjcsobfFtISNIRLpXfani1g4H59y-k9_MQeKHxxBfEc9eFyY70zcjOtZ-Ijse3RmsF0thiTBHcThEn2hTK5JOBeo2338DA6kWZYf_NewB06B5w_ZiL73-DlPlk7_Yw-XuPK-2hddTEdpODbsKi7jj74WDMNPtvlV4guaJwo8cSvI8oXwuc9WIdvxPUsa0=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtnTV19AVLs6wR7aUFlxFwg3fu4QpdCN9gSd0v-0yWoh8lPVRKqP5BXXM_maNJWJEhTucIuDZg60dPFeOym75eC5dQTaCn_8-SUTafC4JqwNlz7YFE3ukyLU-aY4jpI4_cmIWr8hepHmYPmtLI4_lbOoSbYjFCVinFvynX0p-_k_WdylTQzmZQl89gXBTzX62Iua5iTdNJG9DIkZ9RdwMxGxMAhBQuMHhK9NbJDbrArwLj_ujswNbQdP0G8_Zmi9VHvY3XSo8SLmNyNbehhOVVzWKUnPPhpIC5oT_cTporOHdMwnuCF8XH2mMRUsr-KzhIJxq5wkUKQ92VToB-xgp-WksuN-wiUruRpTwSzXLZh0R0P6hsoxjN5ODhaM3GAsz3qD3XlafWFC5s7oalDapBYM7rRMVdXIYm_sV16K_W38H4hkAq30JYjSVnwseC1r7PCRoxeWpVnzmTclfVubq2Kdpwp6n6rnujjQc_7XhnlyUTOMotK75OXiA_OC0JWcfzPCHAnt8f-V-YCKymF9RaAdL5PXZRSCIndfJDaUHkuTg67xGtgeNSO1aBFuC4pfHwnf193oUkpC4y8eco1umUhKFwyMxkmcT22H1vvaedfwp0ZzC-bqDv7TpM3L3v4cJk6I94m0v-vuNpKt6hsRecfH3hWo7H3x_QytLcpyAAm7WMst7rxFpoO6CGuYapRT2MpHdzf72_aJo5pMDw6gshy0sZXRrMoPQ5ZG10NmP6-9tbkOpM8t6fw5or2teXfSjkhjU4ZwAz4L4dLcadwoHvC89RZXAMinT7yNR8-35LcKBHWf3uTMJ99fzz8GR6pJDNCDyiEZwOHHiP3ZqcWa09tD4IzmRMECixQufw1jPFJdfx6XdtP4_LDO7oad1Yg0xSsHp7FX4IMm5oYC_wTqsm9teCqST8cv7UebIe8Q8LkooT4TZ0voVN1gmVweuenf58R9GkcpDwzEiGb38u3Sqw4lsKhTBcbKw3y6mXD11KUYcmBR_smZkZro3Er5MWrzEr8j172TjfPw1WuXWXOJQ4LFgzn5d0psAMHIxZr_0CePCyppu93lOf3ZiSXidDwKIK3TNRwADvqyaUSgvtmBwRlA5Tyl5Ff7boXqWQsGfm_gU2Fs0aAkC1Lm4Su0-RSTshOt5ezWbzmXIyNOIi49XSd-ZAvC5eRzRzuEc71UA8b43aJBKDujje_j4pmjXDgUWgl0sBXkMEBNL-XXXVCxnfnGCFWmkfeOX_0IT6ujklsH8KzkxiUttuUj0NVB_v6YJHS9nditWikSvuUHGmAtY1rleCHFC_AQvW2XsPdoX3SKYVjAWgRaghDLdVEHhh0s_XUIDcXwoIgmCvkbqKTvpXRaAbc6tKoww1CjKR2wF6ElrlAjZ3WSmHUFE3GEPDggX8jimEuQd6lnPocKr-_qEFUGuUn8u-S95tzoxH2Tl5kM0xWLF6Gh4WWvoIUIUDDRb-Cex7hJm-U0DIwSIYrp5Xh2_hBA2pWbtqrdHKD0b2uAKsAPr6m-d_U8s8VeJJuHz2B1HJAvs8BcKW1hR0a0nOF187vC456ZdJk2IsaVm6S6QjhLx5Mm6U5OD-bJe_YZJ_zL7wbcZMZHOfsg1nd_n0Jo4U9QU96Fz8nmzG3Bo1mMugETcRCKKFYLFksq54pIDWTkIThWL1T9lYkmYlDhI-sytjkLWzuMAOXauG7CM__cVM-xZ83Si40e_-CvI9lnpj2oncQm55re_VJIck7-PGHEC5LPqoAQdIW4kiiBkqE2St6Nb9n_Xg9njO9BgOdRNr_n18K-m4szydOg9dXMlraWgcAsjY1XAmlKHqO0agmmTYV3Eg7xhVHbK9YsgRSXexn14yGVj5a0JxrZscPwXFE_xTG0cpWXrORRg_77967GIZKUJT_8SCWWHsRkRWMKSFMJdssCDnV3WHjZ_iybNqmSX3Er5fyA62SmhjrKKZWd7DGy7hQG6YoIuMHUKnz_Z0MAu-jRSsFhACOg6WAnjHwRgFaaTuKpnu-uRNPhDeLxreFNa6F5pbkkjPcyd_JcyPc1zzA4AbIZMm-TS-Qb9V19BEiz9eIo6dhXC1Im_fJd0X_7jwNHq-qNfgafaaw6p3vhTNI4dK5dx16EwsnppXvOypIlU-3-7B0qghRn3X1z2L8L6MaU4riuUO-M2c_sybhRNgf_46VJE-32y_7BFSIRO9rWX6fPYJCXQoDaoksb0IdPlxMZhSfnIOmTRp4sPs0Arjwq7-5_-zLOTr7clwcCs_UT_o6iEu_jTIF22kDgYFU47LZaFAZWXrbuec7IcV1N7UOzLaLMsW9-QyrqbsSF70fzIX9x9Wo5Izrp8hlTRJ_xQ_Pz1aA0dcJlxxjOu_7aOzM_QFzhiOieX9UF1IWPfDOOC2aHrqarNkbRg2R60XhcXW8oszSk7BqJBhNNEII45UliY53Gv19LfyikYt1K5z0lNWTGjN_eFLnoLWTmmw;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTbohNLDoEEPnQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=87332E3EF4484E745B3B9024C27E158D; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnNvSriK9GbYIt1lM6p6xcOxlacpj3Sgdi4aSNq1N3zCL3fZF5mxplO1r2oZuOrkS00zxKHuAtnTjjx6mj6aR3tkIey7WYbiyzH0WTgU9n029ytzgopDmJmVf4Cm-OlZZZc4oMU1EWvMswpbRTSoFUUXUlPaagq22nUJEdcP9KHAXxoo20A1LUdH7uLz8KRC3Hy4EfNztJfnP_Zxy__cCHTQ1KVbo5S0Ldb1Q0gWDdNpPADPXu5wDIm-LlgGU5IlegstOWQiXLR5mCp4DRh1X1dOi288vojSx6MTltS-BOUSNDvnohfs673Fp2se0T_aZ4E-Ihh6k3LEwH3aerDYHGpOQS8Rhr8MZoXttUXv6qIybAYT5pA1P9YMrZ80SgAvWf0b_-mxoSsI2tq1nRR9Sa-U9Z7jXxA2iym9G6QgxitL18S9cLcp4m-dPFp40ul8ddOnYEljblO2Cy3cvhooF9HU1HF8BqRppaRK7m1yORh6R8T09OGsTdXrqJi345kNY9k074eY9AXv19HsHvPKr7Izi6sONjzzWgk1Brif5igFTy2gFMvwu1PW5AgJK2kfB_fFzv2EwHYK0qpS97OkeHieMGijv9yqxuRWZKLp7UggAuav-8_RAYkVNqrC4taqq0;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTbqh5nDoEEP6A=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmXDwdISfcvWBad3by5a3y8JnNVvyXZM160DCWT6Mavg5-W25zI9BXrFI-1c4mKjWeNKUaeOHErtihxljo8HP824iFkizgCuW3SJnhrN_dBLiakQXAc80IWp4AB3q3_zay_IFvdNcBMfhXyRmbppuLe3nYnp8__Jl6WIZRtukRQHlljy3wLRiEA47IhLfz-wRsKS3R2GpMTrf8GpNjrqJ45z0032fbc9reBhHHJ0Y4j_m5mmwCzeJG6oC6tA-wB5Z9LlfuAsKkN6axUdPhwb3z0LGaJLJeN5vFqXAOeaUTK2e0a1rINtKBnaDbJXHykCpFhNBNVgYXwXUOZN5pEoxQkdZvlQDYBvyIqWjXrpajYyataTb8-a96LODBkLErSbI7YizZ-_G6cyB8m2sZwlBK5lgVwLhnvMyh8HU96kRYM6CDzORkKkVXPfC9Euv5gVjpaOiZvZR1MUTPRLmtkYdfNF-aQigW5-pnLSgteGrXPgaScxAtfsS5Me1DJT8p8pJ0YR9S9JLx4TL06m4MmUgyoGfdMFwQBu_Z39fqRyfbK9NdyjYZtW0eKFmhCjeFyNQ0GU_AjWZ6WFvcuSmOpX3qEUeuwY56a-5g8IFogbCT7SHdYRqSkOPjXeTUVRTQveVwLceGptjP9ib_dxKIf79N-AHvvwNUey6jt-tZUPitnvA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTbrhXCDoEEP1A=
     status:

--- a/tests/api/cassettes/test_set_fan_speed_three.yaml
+++ b/tests/api/cassettes/test_set_fan_speed_three.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlpLaHV7MP-waJyvfS1TmXRAnsVYO6nQcu_62-XsS9vipOzas_rXso6e-alVCvouN7Yl0yCvQrSbYtLEkdMGoCmnsnNyY0r_mzJ7sILF7K4gdeXdQ3usd77x2Y6olTSQT7SYOAOSTC_RGA_bIz0BBvQOFac2LL-7NS7IZlBanKPES0SXeXHaYL9DwCCRX51MIvqxyf37VlKDD2cK-M5DKBhshMeO75pdS6sIY92hEWPqWXJ-V9AhAI4A-Pmm_nZE6s=N;
-        expires=Sun, 12 Apr 2026 13:22:36 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.7ybvcJ2-sPCbgNziBukSse98nX1Lx37046JLfisVlBM=N; expires=Sun,
-        12 Apr 2026 13:22:36 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTb0i0ZjoEEPBA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=3467dff1-1f28-4984-a802-0c81c80cd0cc; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960560413836.ZGUzZjI1YjctZjI2OC00MDY5LWExMDgtMWQ0YTYyNTIyODc3N2I3MWQ0M2ItZmNmZS00ZjNmLTgyZDgtNTEyNzc4ZDNjNzU4;
-        Expires=Sun, 12-Apr-2026 13:12:36 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960560413836.ZGUzZjI1YjctZjI2OC00MDY5LWExMDgtMWQ0YTYyNTIyODc3N2I3MWQ0M2ItZmNmZS00ZjNmLTgyZDgtNTEyNzc4ZDNjNzU4;
-        Expires=Sun, 12-Apr-2026 13:12:36 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=Jv_Xggx24DM05DsH811BAi7kywsAVwJxhWYhMIgwiR4&amp;code_challenge_method=S256&amp;nonce=639115960560413836.ZGUzZjI1YjctZjI2OC00MDY5LWExMDgtMWQ0YTYyNTIyODc3N2I3MWQ0M2ItZmNmZS00ZjNmLTgyZDgtNTEyNzc4ZDNjNzU4&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlTIqdF8TVBE4-3_VfTkU52MShzcetcEf30MEzNg4Qwp93kO1oe0fxvY4GfiuzWGAaxp8Vu3ZWkkSrTFLBlgLJU0sJmF2VcLZkvLU7JBhERRiQx18fnJRgIPKoPqvNrJBgQDJ-pwudFDbVYQdTO2K4jT9z2ewneLagjnZdR6AcGCZj21e9OLrx_5Dmh-bF_Yor0SedcdaSBunhajNs1p17lIRVfPooaNVPsLoDq_cCqGJtH9mGGk6Qcqt5x2ONs-ZAITyBKaVSCbcF9odDfXoZXxnJo42dKYA-qLvfOgb9p2aAe5BOPU5-fm5tOk7pr6lhs2Q8f3D9yhW6zGRvnET3TTQSf1yT5S2RgT_-8IKGEO81IU3rBC2mYd2kgGbwmd0FxgtASXRzgszVwVMKWju8f6wvSd3fhcYEtGnnYe6cTbJzm48ncOAoHzilEBkrgZhzapXBEP7mYNJuAaIvQ9P6l4gX5iFStH04lk7oEM8887lHuEguY_b6S2CmeHE5Jng6iVeT17URnhQMrJYoduN3vmV4TTo7reUjJmrUbL1CIf7UrXysY0cS_q_BWSIk-xKGHipjHB60iIBNF690eUybDvz3bzM68h-UwEhwXK8eaSasO9a7gVsCXniFoNMWlI4Amfs-lH0w9kI3BhmAibbC9\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"3467dff1-1f28-4984-a802-0c81c80cd0cc\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-4b70a3ca778f\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=Jv_Xggx24DM05DsH811BAi7kywsAVwJxhWYhMIgwiR4&amp;code_challenge_method=S256&amp;nonce=639115960560413836.ZGUzZjI1YjctZjI2OC00MDY5LWExMDgtMWQ0YTYyNTIyODc3N2I3MWQ0M2ItZmNmZS00ZjNmLTgyZDgtNTEyNzc4ZDNjNzU4&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlTIqdF8TVBE4-3_VfTkU52MShzcetcEf30MEzNg4Qwp93kO1oe0fxvY4GfiuzWGAaxp8Vu3ZWkkSrTFLBlgLJU0sJmF2VcLZkvLU7JBhERRiQx18fnJRgIPKoPqvNrJBgQDJ-pwudFDbVYQdTO2K4jT9z2ewneLagjnZdR6AcGCZj21e9OLrx_5Dmh-bF_Yor0SedcdaSBunhajNs1p17lIRVfPooaNVPsLoDq_cCqGJtH9mGGk6Qcqt5x2ONs-ZAITyBKaVSCbcF9odDfXoZXxnJo42dKYA-qLvfOgb9p2aAe5BOPU5-fm5tOk7pr6lhs2Q8f3D9yhW6zGRvnET3TTQSf1yT5S2RgT_-8IKGEO81IU3rBC2mYd2kgGbwmd0FxgtASXRzgszVwVMKWju8f6wvSd3fhcYEtGnnYe6cTbJzm48ncOAoHzilEBkrgZhzapXBEP7mYNJuAaIvQ9P6l4gX5iFStH04lk7oEM8887lHuEguY_b6S2CmeHE5Jng6iVeT17URnhQMrJYoduN3vmV4TTo7reUjJmrUbL1CIf7UrXysY0cS_q_BWSIk-xKGHipjHB60iIBNF690eUybDvz3bzM68h-UwEhwXK8eaSasO9a7gVsCXniFoNMWlI4Amfs-lH0w9kI3BhmAibbC9\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"3467dff1-1f28-4984-a802-0c81c80cd0cc\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-4b70a3ca778f\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=c16a523c-82dd-44bf-8999-fb3d02849f09; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/INYR+72ejcPUiThS+39+UI3kTOae0lH0gZ9/XsWfY6VhiYBg+NUpHwONAbGx7tTpRygRztDn9GIVfcx+LFcHpok7/zD8GDSO2CZfTjiAnMEo082HbM/ffk/WtaxggM96jXnbGr9pyPAVazlJcAnplDC9xCgUGgCD3wDFiyLdgqrq2KGHcoKr33NkW9oasg2+mWAIbgnyeNVksJuXDt6Tzxj0jbs3SKdqPyzTkYVSXHxO3koLs+DW3Ctc/0o+2/sIQ/f0Aegz0A9O2Y5wjhGxyn7MDg+e0LvYxzLoviVzESuIhktyWnLiAAAA.H4sIAAAAAAAAAPNen8Jt/s56m1yFTmS7ZuHv01xW1x9muNZtC9jH1OzjIA4AXuEOMyAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:36 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.7ybvcJ2-sPCbgNziBukSse98nX1Lx37046JLfisVlBM=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlpLaHV7MP-waJyvfS1TmXRAnsVYO6nQcu_62-XsS9vipOzas_rXso6e-alVCvouN7Yl0yCvQrSbYtLEkdMGoCmnsnNyY0r_mzJ7sILF7K4gdeXdQ3usd77x2Y6olTSQT7SYOAOSTC_RGA_bIz0BBvQOFac2LL-7NS7IZlBanKPES0SXeXHaYL9DwCCRX51MIvqxyf37VlKDD2cK-M5DKBhshMeO75pdS6sIY92hEWPqWXJ-V9AhAI4A-Pmm_nZE6s=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkC88E1-PGZm0n3uHYwVr02rBTae5yLNRf-14SiyN8I2LWYx--5c4Sn_bzrBMVEyKlNsyg76TzF_jjCJJzbgR9J0odsRsOfycMWSvezmfXHUXQFdOLD6C3aP2Q28FkWia4lApGQNi17t07_F8SmkzrXdMTt-WLtceAqCO5j87wjMw5-KmxLVLDkz2X1awMjM7AedBeoJn3K2nEIcqAchpOZZ9NIwjCK20mgMPuXImCSoqAkNJE2jrh93Wj2EPcZJ3UMEiCgdUCBRVMVgNkahWWC_FuoIm6OS3XwwhstJEUX0vD8SkZzQ0YR43RRFWz9iUea-XC5oHOFE3XJzWdDmTBqh7Ml9DkTLL6K-XOoNYmU_XSjWXiqGqpMxmEPpkdfD0XDEjwz5PHqh4FmFd7Ez0enkRzKMo6f4L74aPx1RObboCRUUJZmZ-tZddd1OYPk_FeqLWdx_vL5mG238jNQKj-zUFSkdmK-lYzDxsTH8h7ILyi59GnumSKyye-1BksaZF7JZZRpc79qJN-qIjJL84tkclFw8SVqRvMefUx9NQyza7uVxV-WQVUt71tCbFtGorVVe7JPat0iRrc54WprJUkMbtVMlwiFxNGKUzRqoy5kgblsvHlbGTEhM5zSN4WtYTabf99c6n3OzyRPTsfANZlsDk6CuGSZMNtDcCoUwhnl4hqEZCQCzTPeYpV5rWcIp2da_iR7ejSgLfr1MAvDhSzWItf8ijCE1xGAM5gxyyoXJdSuili569ReOUVEP_h2IWanNRxsaxn6d5aY2lRa1Y36TobqAx-USo1R1adilT_SNDB2ICRVv7_VCxrm6v5GZy8sodPBwDeYd-WUFzOuez6hm8PPPd11ZhBy3To2ECZRSaE1JSHvUcbx9LemQgaJ08Je9bz-QXConeCwDVwfSH4PKt42udAWcpX0eC3t21YsqfkiwjRLw-mUoVjvNtTYa8jZK2pyLsJpRE8rAl5LNtK3pjwEYIYcBZYj-SlTpkJX1d1WS-mt5perBWxnY7zM5XiA3CxkkG7xHVi-FtJ6JZe8KBlW24JTE3I-H-r1AtvNXWgDEBGdb0aEUSWz-v8MbhgZXogRq0xGUW6-yultzD3-ZiW5L6ogXDzCXYIGDLz5yAw1VKxr9wLShdxLL8AUIcnxLE3abMf3bjrzTRj9da7q1R1QwpzxlAJwaGEYQEeVlTlVKJ06D-7OC2MPMDzI-IZz0HxOIPmOn0SjxzzF9cCS3diJS2zbrME6drCd9M3yPxirPbKBCpzAwAvU8K8qzxhXWSJOAv95MCsYwxI7XtNJSpdDibaOy82nbaCOaWQZi8djyxWQ_l87iHyWC7OQipN-M56cjWO50F6hF43Zf7a9-EvOn6jcDVanrfYDB0NEQAs479M51L8e45uoHQSR5H9hHxK9K-d6M9fIEPlL7QIQpYtAZmdz0X2h-jnEjTvjpwg8Ur6UVY8HWqWfzE0-7NNpJIWau5rkKKA_r5NKEtCnduQq04hoFUpdMjuk5Sv-oSbPnL0Yg1x09E81ctuc34Dwm7YdMHMB3Xc9uoBSKggPl0wA7W_MYsfyOkdcQc0zdpu51sCCsBO00gchf84e16fO6qEqB_IFJZj-ZrZmu3Lf-FUNj4vof_pWFWaWttlCU2QFxr8w5rZXZ92oAj0GQrqmQ4lE0o9OjwPdqdGESu1QSeMQhE55oGgrVj5CSW0SMrZ1zjRriAaSW4Y2iSGGoTpcMpGNRQaZIilVTFC8dfm7TkLOVpGTpx_2zkfWS2BjP31MRtvw6TdDVRit0-pGVtXzcl0hEtDOen6d7DY042wmgtdSuVfyODjSmAU5IkekJxdmWROofgTTFnCjJWJUupM3wa8t-15FG4k1PMJG1XK0pRTh8Ey4HR0E2owQYGh30BPp3sD0JNNk6aeIpxVQ2vZuHCLvdmGM98yqNG-yGUXGVfv3VhCZpBaGMDC4WnkiusoaBdA2jYEfIUmGtMPUCbXLEt2g4szKo3GIBzySJxIc1e9hPeA-9wdFIYeRHf5ll__yEoyrpbAk6Iu6X3hFGyDgelUlhkHCDiZYfJJFjLkdlkFR7twxezp6oa2QAdP0W2temCUsVdxalLH7jrra5DPTfUm_G9GEBN7YC15LUF8gFzc0IipeeLgbT3SURhi8kwYmj_uoO_s5tNp08xGqGQLox4qBxFbBmd9-PzORR2XCgietIcrZEsFmSfZGZTfmOMthQl3GXQgfPaxVusGVyWBPNwOyZqMDRWOWSfb9-UXLiztAYeUYp6EAUGR_7oOl3rVhSpMrMUUaiEtzf-tWfBTDklqg3sIA9rPlrXbShEDsLDDy3TOYSItQXFm0UIoww5ZQKT0ZH7yyczLCDWv7__30pE-_KofBN8Fm_7ehgxdoWgMIu0a47U5as6G0CkqacCFlWmKhhL8CbxlRWTfkGHsqOsDtc-sYPNlLghiDl5Ag8pd9WtXbR3_G1UM0z5t7kA;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTb7hbNDoEEP1Q=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=32A3DFF4ED42951E794C3D751B5303EC; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnlgpfBzskPqSdIqciuu-YhPq8i-3LRRGTQ1Z3h1RLSUWv_rus4OSc7wGMlBEmoflexSkZ_kU-Ez4WNqhmnnnzmZbhx2y7pqZJUXUHKHFUQVGb0hZ8-dcHNOz-l87AxI5ihuSRAmza80BZsIJjyHaQiG5AzJonBtqfaNXo6Bdo7NIeIdCLd06Ckdyf2ZrGeiDNRClO31MsEmLVa-oQlmgsCDtkcR5EEs1gTcJstQLx9MWlVZQgSSZhzE-Ct7nH34ZKRH1iVA9q3NYNBI8NXVqTzlKZg2RvwxuWh7eZjEeu_xrTYxBSVELxXi1kZW2fhz6eWIa6VXFiGFTu0amg7m3ogaCRGjeOzd1jGtgFln1Qm4g3TlqN9tfdqMHeTTnDPIiKYYySWHDLiZ-7pWL6SLmyhmntZ1V9vjd7jt_KOwkObxlobqub3NnjstYFvrexnR3ppqT4CF-x8-TCSnOk7vQUjGvA-bFBUCrot_ixERaWMJiHVdZdHMVBqkMaLsNeH-pBEArOaAvEsrf6i_EGWIDVVqbWTvQU4MT-IVFmMWwBKjhhxN_5UFix-1BZizGj0BRF0P9JUcMaNly17hsargE8lO-uk1pTALJ6DlXSPNOtAEFQRdE4dtU75n8QZtIQI8js;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTb9jCADoEEPsw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmuoBt01ss_HrUjsXgB-NcK8p2JQvnqNqT0qttZW6Zm3fdPzKa_ME9lZQcKeC3SelULDE2JcqIL-HQCx2LiKc-a5BB3J__2saMlN-8xYIrGZT-M1juJgslxk5ku3nt_54NC_I08_Io5ZB4Hx5EZ5wdPNctpH5KrwzNLym7NNnFXWq9Ly5Xt10zt8gEecsZriZ5VLrBWg-HpmAkmNk-T2eVA9Fs-kJKBkt_Vbw2--32d9_TbDh2bB6nnGNdYm_SUNMOQMqEf0Q3x4gm5XF5LMT2rrqEVDsQk_UpP7wb9YBy88Wc_Otn_UkaBFk78iosehUl2r7zbE6Yd5p8sZ4LT7qJdZcvWqRvt8r3pw9NnH3buA6wWxC94ptEt5Zj04EuizM_q-XE3XpIVwexOklwD2Yl0MXlCuHLVFLbA2ziIIm-aKUFcG9ZooWCNybheOgeLj_PCBrMHel4y_iXVU-B17jSlJAENM8WFM1nfarc0eejncnB9sV4vjUcetv7GzM0Rpo2GCVosU8-Go2MVUj3ybsHoxDBUT8YFve3j4iOY52pnDlNJe_Hokni8nWaP2qGTTtAxM9Tirbdf-L5t_G1knfvi74B50S-RsM9ggT-1RM9EGOub-udpWLvKhe6dEGg7UILQZCW-2jSSuZDemJNwjukINp4bXBqpGW_umF6TbH6KbA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTb_gyRjoEEQlA=
     status:

--- a/tests/api/cassettes/test_set_mode_automatic.yaml
+++ b/tests/api/cassettes/test_set_mode_automatic.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlZaTrHhOBjz9AB2VYhEOX3X17z-ztYKFa9OZiUilB0c_AMba1-tjeUp-WcYp50qpLRk1J1CG-NXNRYvJBuLcG-isYrO5Nwo7LL_CMQoYL2AbZW-F_eHzGwiCAwvrhkkxjvgFlcXE9tSn9fzpbS5r5wPQTGXSoRrfjB06zodVSfKV1RY_JtS-0DZNCgMju2ztknGGhYvL5raXDuu4CvzFkjIgkPIhPF98SjvllmTcZ9ew4kNFcSWzSZWOfBN2D9LPs=N;
-        expires=Sun, 12 Apr 2026 13:22:31 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.Ha8wjaSYFyK4mYT8S-6_37GIYsBemXuwMOtCd83usvg=N; expires=Sun,
-        12 Apr 2026 13:22:31 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTbGjoCjoEEPRw=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=e3a96eb3-85fc-4572-82c8-127bc2d1c8f2; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960514807396.NzRjOWIwOTUtZDgzZS00ZTBjLTk2YjItOTQ2Mjk4YTlmZTNjYzY1NzhhZTMtOTllZS00NDU4LWJmMzEtNWViNjljYmIxZWEz;
-        Expires=Sun, 12-Apr-2026 13:12:31 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960514807396.NzRjOWIwOTUtZDgzZS00ZTBjLTk2YjItOTQ2Mjk4YTlmZTNjYzY1NzhhZTMtOTllZS00NDU4LWJmMzEtNWViNjljYmIxZWEz;
-        Expires=Sun, 12-Apr-2026 13:12:31 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=9bo6884jy4AongdzCmYu4CHeGaA4u6iX_wloHmc3t7Y&amp;code_challenge_method=S256&amp;nonce=639115960514807396.NzRjOWIwOTUtZDgzZS00ZTBjLTk2YjItOTQ2Mjk4YTlmZTNjYzY1NzhhZTMtOTllZS00NDU4LWJmMzEtNWViNjljYmIxZWEz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmAmkUVc7UaNVQOyu70yddYtH0lw7xjfp6ycmX55qumc4osnsNKwX27JZVC1JgIVH5gD0-b0uWz-HSV5bmspURSaB52hHdMIAAOXN_1EXUZIQTFAgYflJr658QdNAliogf-u6BOPhtw1v-9eeCfpMZYdKjzOw7CbhW1jlunzMuwCwaRTmXaX0LKdsq1BsBYOlu8_bVu8anPSAF-T1jZv_Jj_rXMUEIFyBY8DzDzyEdCN2sajC2y4M8IjPKKYWE96K5dIkN7D0N2UebyhFyGmBVe0BonyVPA1sOJ_fXMvWKbb9chz9O7FWVplkY7DCMIAO4XZ5rXjtJW54SyE0mbOnohkGzTpY7J1VL3JEzrOvGeEJnawIZwyzbddutyJkLRwbpc0t6f1Sz4EVfnQK-t-2YcT_0GXW_8KwgTra9RCdDFOgqhrqm3JtzJceIdO7v7yGQtQNt8hmiu_C1aFSTw0Re9TALqUvbaPM4jT3PV6L2O-GzDBZNBHtnPtnrI1wcM_64P5RtefhdHK1CrSEaUovfCsxtyx4iHn6hVCwiDG5Hf_EB40o3xLd9wY_4zv2weyZ4x8-tU33YeiHJMYHoLFIXnfPKjLg2WWtA5DZyjw1ydkaG6tCoM-EQ89GjAdDFO1rtOtiv-jf5rKD-hV35_82O1\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"e3a96eb3-85fc-4572-82c8-127bc2d1c8f2\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-2fb9806516d6\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=9bo6884jy4AongdzCmYu4CHeGaA4u6iX_wloHmc3t7Y&amp;code_challenge_method=S256&amp;nonce=639115960514807396.NzRjOWIwOTUtZDgzZS00ZTBjLTk2YjItOTQ2Mjk4YTlmZTNjYzY1NzhhZTMtOTllZS00NDU4LWJmMzEtNWViNjljYmIxZWEz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmAmkUVc7UaNVQOyu70yddYtH0lw7xjfp6ycmX55qumc4osnsNKwX27JZVC1JgIVH5gD0-b0uWz-HSV5bmspURSaB52hHdMIAAOXN_1EXUZIQTFAgYflJr658QdNAliogf-u6BOPhtw1v-9eeCfpMZYdKjzOw7CbhW1jlunzMuwCwaRTmXaX0LKdsq1BsBYOlu8_bVu8anPSAF-T1jZv_Jj_rXMUEIFyBY8DzDzyEdCN2sajC2y4M8IjPKKYWE96K5dIkN7D0N2UebyhFyGmBVe0BonyVPA1sOJ_fXMvWKbb9chz9O7FWVplkY7DCMIAO4XZ5rXjtJW54SyE0mbOnohkGzTpY7J1VL3JEzrOvGeEJnawIZwyzbddutyJkLRwbpc0t6f1Sz4EVfnQK-t-2YcT_0GXW_8KwgTra9RCdDFOgqhrqm3JtzJceIdO7v7yGQtQNt8hmiu_C1aFSTw0Re9TALqUvbaPM4jT3PV6L2O-GzDBZNBHtnPtnrI1wcM_64P5RtefhdHK1CrSEaUovfCsxtyx4iHn6hVCwiDG5Hf_EB40o3xLd9wY_4zv2weyZ4x8-tU33YeiHJMYHoLFIXnfPKjLg2WWtA5DZyjw1ydkaG6tCoM-EQ89GjAdDFO1rtOtiv-jf5rKD-hV35_82O1\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"e3a96eb3-85fc-4572-82c8-127bc2d1c8f2\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-2fb9806516d6\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=432eb6c5-f822-4023-9370-e3b3d8fb1e85; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/lak6ccteWBtVZJVFYY5WbNiMT2xAv26vYM8r3o3wjgUN6pODWJBzKPpSuNL+APpA6tKBuSyKTnSCILGqtfxLf/oGuNz4NwBvb5gJtAAlkQdgWZomJe/Y3AAbpor0D+TW80tF1V58fpriy5RRuV7nnlXFIPVl4A07HSSeGBpHd6RePPwnB/AVdLG6wxHjj0k7uPF7CBOEd625nZ2hGU7gKkbMLezRxvBiLGuy+rCLWO/5YtFkk5yCQFzVLYFQhXW0Q9Kk+hnGap4kTgncU78TP30zzbi+2Ysz4uBEN16/cK0hdRpkLqriAAAA.H4sIAAAAAAAAAAEgAN//0vwCFfRjoPIp5hb5uULriRhqjKs2m2IwsHtgBmmt9Pr6Mh9FIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:32 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.Ha8wjaSYFyK4mYT8S-6_37GIYsBemXuwMOtCd83usvg=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlZaTrHhOBjz9AB2VYhEOX3X17z-ztYKFa9OZiUilB0c_AMba1-tjeUp-WcYp50qpLRk1J1CG-NXNRYvJBuLcG-isYrO5Nwo7LL_CMQoYL2AbZW-F_eHzGwiCAwvrhkkxjvgFlcXE9tSn9fzpbS5r5wPQTGXSoRrfjB06zodVSfKV1RY_JtS-0DZNCgMju2ztknGGhYvL5raXDuu4CvzFkjIgkPIhPF98SjvllmTcZ9ew4kNFcSWzSZWOfBN2D9LPs=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmu1PMD91Trh-2s9rl3IZJ8u9lu68nImw08b8IfToezoKkZCUEiFEx6LLjgI5uxjtlfWTJFU5KWMytl6wlm0vSpkBcHLr31dpkA9UbDG3y3BWAzbL3Cg7b6yNqKsM44kSdwKZFCnoqx1JEdDl2fqaH90i1Ofvm0duriDBX8WEJxpDhA3RkfBbMWngRjqZe4D0jsKC3ZWhNHCtEtq4MW7K2Z9QcsY9CIB5Rz_LrX_Egvj4ie0YQB65FKx0nj6TMt3BaKIN1mQXpwxLF-7ZI2mcX-scrByFa3EIZyyHLhYD4hby9KEC1lqb9EleMkzrSmADIZYS1g7kaBKX9T9rxrqaqXS9T-ov3QzAM5xILfu7RsPXkHmZf93UdYcEQOiTF4fuw-L3gzlnyR_X6_Ep3GUARalFVJQqQirjnYqoUGVaMIauWwYe1d-0Vjm5i1HmEna541hVwnyoCKjrUurzkcMVrTfeHExZwa9eacYjAYsVh3JzZuBeCXkEIEnL7ebC0W6ObsacUagsm77RJwcXvro_TNEubeBpcTyS8TYra-iLr0tf9RK841lfZNdn9faWJ8f6Aruz-EoDHJnCxCTXe61tXwhViNXZsEQ0O5UnSRUCAYLCfabO6xt8JwDN99Hz6e1yFv6ZV9QyMwtSOz72unYPswbbFjYI4f0gy-rmC2b3qpbzhfSbC2lmh7Vr3JMsEfYkIEmCMKGuQC3YUNG4MgetnD-8Lk2UNz_2x0QfJ49BF_gkGBlCchcS1fEOiFpVC9ZouMyOYxdX680ZxjVGvYkYzb1a0YEk3ExaO0H3LyEyVIyuHr0EhtAsAvqnm1M-JodbBQp3geG_6rdCdNORdH4wjJleZTsfHfdr3w_LWvZH7AtNRnvEPJUEuEVquMG_ApehxpWnrmtjq6xn6c3ljQDaKPOzydUyiwB1sPa4XDx8V9ogOgzmSLSMmlWHPosPwjXRY9p4LYmldMif2H1b4GTQjFZdBidwOrh5LE39IRGDIqxlHQNA4WOI-pCftoh2j5s7U6IxocfNyfpWjA3MwUPmymlheexQPwaAVf325J0ZxK4e31VHkny5_a7JS32bNE00CSyPXgdB5lihzmMjOvyvZXvrMWahuXbVedG24KY_QU6FJuYTkK84i6P31sJIh8VudBAtiN3bpbnsUabYTsUHyV_6S7IfB_VBmR9ugkW8vYDv2DC-ajUmn2JOTdUISIzYxLQle4uRQSNnVTYM5fu2klFycfEkiDne5NbLyYMScdWfod3It4GrWTvjYQKrxrlSZiyjPtV-StmVvIpoHEciM79UvKY8wnYlVPNbALbq8Vr7yBBD75Z1G3Dnyau9oCxouff58L8gtILBm8w8Eg8K_CYI7cgifnjoLizGX0ctGUyRpnjqZOPQH8JwjK7EyYj6dWrtjJSwnG0xUTjnWibhs_qppdBJKubofoH5ymE02lRmACTcSvU-cjuyGE57gFcAPh2iLooOoAgcbsFvcGMnsU9QXoUV9SOjrvLROSyUB2Hv6lzuDwIWPMkqYGLhp3ptGXZSgbs-NgFVqnFYEPKnk7ORFxComtwkehnK99VxvKeAHBlwlO_tqBezfTuAZl-3VTjT-GMC4xdf9FvP4Fsb2hxbF4GU_x1A7YxHwbbznWnfgemRUc7kkvxQ0NqZ9Nv9Im81Mk24MW_nAx0X4t5kjDHuRm5_6ErL6VZjrg5g6WDUvDxBR2djvHCh-48P732G6k-u4fedRvp4HX095QjPkw8KJ6cKrlG2cC-5IgBGdOhmpJTqV_DUNCmTAKgiAjMcL1gnSCMgdt-D8JQqMwnLCqxYzSGOtLpLuFR4bdAH5wt9UocWzIyVMIwpiXuRpBHOcj6V4wqeccHaUGrpoH5pZl6osg1ysgtDeHGkvXkGiWOEw-F4JxerBtH8g0QUOCN0PCxX-Q9rczJA8LAtMyRhwp_bsMqgjaSV0SJpBZM4s1OHWIWaSHRAh7cyiijURgEIrKFuQh8_GBA_xBkw1Lyb8sJ9ovpRPZetnoT7viQzfOySSc8J8AtJl_IXFkcoRnnb78KEpisBcei7xpfLklcTdAx1QhS-I61HJ-bnLBkUCgSs6yRZbVMI0xZX4CdkfSR_df8gfxWvrb0-x5VgYgrMbEKeZD6QJv-Tyd6FS7mV-R9Nhl3RQtMTLKqEznDQ3eXKJ-JyHX5vBfneAXsFOkO9Qk2H3AZvLVkq2rn2_W0uTHtBYoUO3QFhHQ19NrqQc-Q59xukY06noj0r-92jMZ_Fr_XGS6nRUdlFBMecnkI-xToQ5YhXIyjyHelveai6Gh1ZO-Wq4uK1pcLTIJPGqs17_P9p9XeSOa5FsqrNXpNQMdjRNPflBwTMlYY6ZKw4eGeS40TZhr8lKEACbzLjmsF2slMa8C1hJE1OhKqNBG_HOHIWn0gZj4qkOK-rmH-ME9m5rMN1_HKFPkHmej7Pg7TguE5sbX6Lhsjdu4fGWa6_P1_w;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTbNiqTjoEEPgA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=5714981C1EFAD2F11C1D3D12465CA4F1; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkdnXdYhK5s6VxsmqEf_9lR1uAf2HBCcdHBaIKqSnLCxqb9SvQlXjOKadQXSlhH6gvpi_pNrWVYmXG4_VnG-BH1IIo4HKCQvxxhd1rc58-3tID-hh9CCJfu0b2q79YSxJRAl7_1SoD7ToeG_sap4cvsRgGsYC87dWuRPhKUtIkz1IBkQswJoLz8mBf3anOOufv8dkoRBkcXC5cEy5zug_uHCOuvvRF-KhP911Yl-jpjUu0FR8MgjO4QXLJwi949o3TT1K6I0Cfe2kbQ2TuCDMI5yltiev-QJNoDmdDhY9c9O-glTwUTUpfXqJLvq6vCZ8aNPY-dScX_mjKW_jDfyFY9y_25UPmKrNHJeJ7_i2bvItf_An5e1wIkmrywFOUuekiSrl297M1cOu1iquFV2YeCUU38pQe7yCJO3eRdI1FJUTobZeQse09hpWLhwuocEI4YZdUsFau3gntnFU8IWgdKXS5za5siKbWdqNYiZXdjibJMzdYq9tNtsshoumHSkFJoe1ahnSf7W2Vn6bEFm0G8fLONOiqS_D-Erdxeqjp6qZ5mhJy9CFuuyNxiThV_MKSR2U4c_CTuPyO7ReM3fPMQs298eoVcZVUealR-R-Z3BPAKtYBw_3ZDpH7zYXjk_AU;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTbRiF_DoEEPOw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmeR6k56x2keSABCvAYUE-iNOsShHaXrXpAYtmnGqFnycR8WfBuS_T8xXMPVsx9bP2F-qyipxdtdOV4F-vhZe87GL4Ku0yLoPfd3W5R2QZSi_Q_TZT4olKgqbQrJ37rYX-pCnwn4J-dl_D0huW22ya6AtJDABxNGEfUS2Vt5VJLoLIIc6nWlTzqk41jivxxJ8ZgSNAenRTX_UTGlb7MhbL5D10q-JuOURCjSHVSTglA5WqQ2_xW5BPmONiir0zLGU8C5l3USqImix4JJ0FfUQO35S65n3S4KlScQf9q25A7sQ2v0whbIQgE0g3D2K6JUFPqaxth4MhR94EFxpsjKAfIkjnie0QZmecvuidcYTka-QNJgvjYB3kGLZhhLx8V8mZTf_5kPbqcjH7HT2TaZuLAthqklB3_UOHFG-hBXPz4wR8TQQ0qvH3LHUvpj_JgehsBVxOntcktPc-Ynye2e-gHVNKPBVnaiLf9fJ-C2LFxPusEfIuhD3fR4HOPIqO-bccHShro3HPECBrh35MljF-pcH-69RYL_4rs0AMTsQwEgeNOlMzCf6VpaunxqtuhYV2Lr36NZWbCrsK-HouFrnGMpKr0f0S0Kp3JzWP7_x_SStNYEkbbF029Eh7S8E0FcwLLYNQ3bY7xq8BR4w5Sv8arEsl66WDiVQkffuYryqN0gw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTbShXHjoEEPNw=
     status:

--- a/tests/api/cassettes/test_set_mode_cool.yaml
+++ b/tests/api/cassettes/test_set_mode_cool.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtk1Cl_k6qTIp6PMGGjaaZmdQlNsq8-X8n5gxGQhomlr26nkFgEY9sE-ma6qijxR2emYFcFzyfKTd2Wf0K8cihTr6iRNJZ_DzN-XeQZxYtpdUzu1O9EsBr_ZULEFhZJMT_TrjEN501LvdgmThvOxArlXO4qnpv88145wkLsEWNcBwd-rzJlHIKpDsrY4421e-Lo_Wk9F_BPmhNCvKFlvfYjIAzE3zuEjvr08p02xy044QxE4MsLCQMdDf35CdlNuylY=N;
-        expires=Sun, 12 Apr 2026 13:22:28 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.-HmyGXaxGhyHV9FpYb3ykWBaZVQi7sHZqw_DvF46QQE=N; expires=Sun,
-        12 Apr 2026 13:22:28 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTaqh5ejoEEPOw=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=94466b2a-169b-49c0-85d1-15c1241c067d; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960486775209.ZmE3OGQ4M2UtMDFjMy00ZjRiLTk3N2ItZDQyNjlmZWNhOTYxMjI4ZTI4YjQtNjEwMS00MDE2LWI5N2UtY2Q0NTI4NDE2NDI1;
-        Expires=Sun, 12-Apr-2026 13:12:29 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960486775209.ZmE3OGQ4M2UtMDFjMy00ZjRiLTk3N2ItZDQyNjlmZWNhOTYxMjI4ZTI4YjQtNjEwMS00MDE2LWI5N2UtY2Q0NTI4NDE2NDI1;
-        Expires=Sun, 12-Apr-2026 13:12:29 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=smTaFOwVnXzIDYGUxuXQ5Zj6Vd1uYJG5Lw0vPO9-bJw&amp;code_challenge_method=S256&amp;nonce=639115960486775209.ZmE3OGQ4M2UtMDFjMy00ZjRiLTk3N2ItZDQyNjlmZWNhOTYxMjI4ZTI4YjQtNjEwMS00MDE2LWI5N2UtY2Q0NTI4NDE2NDI1&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmlLDZriD2Gnr0W2PkREQNkml8cOti2-zmYMFU-oB53LD_MhL-Bmew78m_mUv3cuPtR1OZLgOTQAq2TZ8JXdv5Xp6tAlvL6R3v6jaU5Oit72jlWMgAQEA5TX5r5aYomTNN2WZPFFaOLw2X1Fn7zzer73XjoWtgDQ9o84npiAZJPl4IvA7_BkTA1xONyCOADHdV8jBl8hJuPz6rCeBkHkggYHMMV41bUD7HdqmC4R_PEu95OJTmosn5ncVfH3fWT-Zp0k0gX9Y8dW3bJvGY15YUi7rzvy8ZoThhpGo6E-aHIjoAm1Ll_JoYAEquKhhKta-YEa-g9-tJGhMU4aweC7zFAjH7bWuWrzUwE7oVwTSiGUtJJ4e83JZQFPWbFkeJxv5OVJGiYNBobvzIdNaDUo2c4ML7pFTirNcJr-wTSoH-nFSuRN0Afqi8VKem2-AKFFuv3OzL2y4aNIuuBP3dV6zkBxxup2_pX6zrAy8Cj3jaUgWSFjZ02RN9Ie-EabuNOlQxSj_vPz9JnAh37gH2KFaXogDY9T-m2oJvO4ovBExuqFKN1KyWTv7G7LpG-hpyKDP-k4ZvtXkC5wPg6a-Uv9FJH-MKHOgF-8pX-hJ_HwPDPLz6re-hn0IK17Y7g0ykQWVFaLf2uRUgjsJYkHUM6CHH2\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"94466b2a-169b-49c0-85d1-15c1241c067d\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-c6c54af2b01e\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=smTaFOwVnXzIDYGUxuXQ5Zj6Vd1uYJG5Lw0vPO9-bJw&amp;code_challenge_method=S256&amp;nonce=639115960486775209.ZmE3OGQ4M2UtMDFjMy00ZjRiLTk3N2ItZDQyNjlmZWNhOTYxMjI4ZTI4YjQtNjEwMS00MDE2LWI5N2UtY2Q0NTI4NDE2NDI1&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmlLDZriD2Gnr0W2PkREQNkml8cOti2-zmYMFU-oB53LD_MhL-Bmew78m_mUv3cuPtR1OZLgOTQAq2TZ8JXdv5Xp6tAlvL6R3v6jaU5Oit72jlWMgAQEA5TX5r5aYomTNN2WZPFFaOLw2X1Fn7zzer73XjoWtgDQ9o84npiAZJPl4IvA7_BkTA1xONyCOADHdV8jBl8hJuPz6rCeBkHkggYHMMV41bUD7HdqmC4R_PEu95OJTmosn5ncVfH3fWT-Zp0k0gX9Y8dW3bJvGY15YUi7rzvy8ZoThhpGo6E-aHIjoAm1Ll_JoYAEquKhhKta-YEa-g9-tJGhMU4aweC7zFAjH7bWuWrzUwE7oVwTSiGUtJJ4e83JZQFPWbFkeJxv5OVJGiYNBobvzIdNaDUo2c4ML7pFTirNcJr-wTSoH-nFSuRN0Afqi8VKem2-AKFFuv3OzL2y4aNIuuBP3dV6zkBxxup2_pX6zrAy8Cj3jaUgWSFjZ02RN9Ie-EabuNOlQxSj_vPz9JnAh37gH2KFaXogDY9T-m2oJvO4ovBExuqFKN1KyWTv7G7LpG-hpyKDP-k4ZvtXkC5wPg6a-Uv9FJH-MKHOgF-8pX-hJ_HwPDPLz6re-hn0IK17Y7g0ykQWVFaLf2uRUgjsJYkHUM6CHH2\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"94466b2a-169b-49c0-85d1-15c1241c067d\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-c6c54af2b01e\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=a79a7c07-5792-4478-9219-bb8086fcf811; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/S9MeKnlkY3+gV/AYBXk7gc5fIMXEmu47l13EWGP9hoGiCBMksuYHj/YIdGR0nh9KA34lvqqxMzkswXakNr1abJXfzi7C/HnuPGjQfpdm9vLThrFzBCLJM6GZ98nsUjBl3J2tNoxQeas/AK1JVudTd+3Uw3tnWr6ktb+4UqYcnwfQil4WpYZDZwveIzgkni5Vo41PaF9j9nx1a5MYVYbDQksZpLAZVQAz7DMez9MH36lprJKE7Y2zFtbMKr/R0E8zAMOwJhDCtwlnx1mkT5uKZYciViIiiRuP551K4UWBo08IGaYlIn/iAAAA.H4sIAAAAAAAAAFtwPiY7wOX6J80GCzGzbmt/a3ftZ/XqL2R9jv/fNPftmkgA6OmPmyAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:29 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.-HmyGXaxGhyHV9FpYb3ykWBaZVQi7sHZqw_DvF46QQE=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtk1Cl_k6qTIp6PMGGjaaZmdQlNsq8-X8n5gxGQhomlr26nkFgEY9sE-ma6qijxR2emYFcFzyfKTd2Wf0K8cihTr6iRNJZ_DzN-XeQZxYtpdUzu1O9EsBr_ZULEFhZJMT_TrjEN501LvdgmThvOxArlXO4qnpv88145wkLsEWNcBwd-rzJlHIKpDsrY4421e-Lo_Wk9F_BPmhNCvKFlvfYjIAzE3zuEjvr08p02xy044QxE4MsLCQMdDf35CdlNuylY=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmJbXfEhfdx6y08fdypE2_apyNrkYbSoAP1LToSYhEkDo808nTZ6vsZOvyXYYA4j-em7o2sSe7Qf9BgJ4yjemw1za1Gr7Uj8EqeTzhkP5w5pdhfI4GbbOzACJlTkBRKFFWsWbS9ZQttTA93-TvWyF8UbMfF560LAyHByfIcgLsduqCZOhf_Vbi4bmRK6_X-6W6KHzkOqVsPxAWikhwmW0beAJbuE4MT6o5kN8lUXU3RFZz0-p8YLF1dV3_Yircw2-RDKQneaNL2cZxj2UJmawDoa1-JQOMhyoDF9zUv9_3t45_k_NHfhDrawS7ESVCrYSoqY8A-5A9lepdHJbNd5Qm0f6SBNwziLHeSTuV1kLcbPHukebT-750f5hR6bEKCOcBX2hCFLsVzShY206tOxs86vQjzaNw9gkLzwqGR_oIFaO6g47r8C4Uj4XgKKcMLWu4jAhWma5-U2lHLwhKyzioED3hg8dSTGJF6s_NQoLrHAqyJDeV4XUGm7pxiA-KmUt7zyJvQPXB3MblaOY6_FtxhHZKfJiCcVlmyCBpiWsp5lLCgb2Io_Hi6gmsr19ILpSCDRkCvxBuBVS0yIH2kSfNmq3HueG2VAP0qLXBhhAMJYTTnmj7V_sPPYRrrKm5lREd1rYlmeE9nnsJjre_ugMDNRiRrUylRXTIztbFVdTACP_eqn5j5A5URVOtjlA52KKOeBgFNFZjdtn_WaBSEz8bGqn-2KRpLOCWDFEUShPdlYIvjR5WSzIbGiLoe3x-vSo1Z9hZzMpnquCLkr_c7jXN0F_CUsC176znocbEk6vzo0Gq2QhK5Ub4BWXsYA7ogOwkQPDFBTGzTRQAlaGebtoeTamHf1taBPIwlHJGbG55ZuIXIWvfmZKJhSKrVBO-9H15ZdLFWT5CLlREV710BZa1AcjfCwuqJfXpdl7WwHXgpHSqLf_eY7IRSyBgsxxEs--naZP9Wtdlv2rDfXuPKX8xetxZEEPwbcF6EpVMyeS3NuRgQejNHJova1aWz1G0LlCl9K8CNS3QZkQ5shC-Itm7c9yBQmePeA8yraLz7wWsS_SlBJjz4Dm3ByilVtHuhdF5U8qdly_CR-4fs_wW9BCi402mPA-fPN6QheumYbs60rrkqY9815O2O-qhdcJ3osV7OcnevAhfMyoxmx07FR-XQk1ymeIoVTqL_Ff1-wXICKVuesthVFlJAtlNRhnrHSEv2Ao_qhAkM6wKANDbFm1JgsJEpopfwsYJ_61aUDrhnrYWkz3VMFwUs0qgxef5aHyhaUjUZmMaecIMPzWJ8PWXx5GuQlJmSC-ZcAomvgyvjd8iy8a0525F1GXqD4-bmkI-d2y7_k411oH49M_zicYGFecB82CtJ7l57cX88wcuZHeMG5euG0Rg6keSJ7Z8_iPoC-7QJQ0Z6BtRgZ3ovjAo3OLu-2nAIq_rRGFk74EGw7lVVnPvA-VgomiwqoS6D2CmuDriNRfjvo8zeV3AIJvbedJ4O6yTYe8_Cdq_mInRH6jRqMXY8VYmIuWaHeOYmJwvW-uN1dNWsAeBeH5T_pXypmm06xleu3girc7Ok8e4Ab9gpylAi7kw7MXbGPHM7NtteEUQ6SOpRWbFsB-ynvsFGOzZOVGCchWs5iq9KI9tz8jCV3xKpsEbPElNUQLYvtXz9HoXf8NNPzMSFNz_oNy4lycLEMAjMmAi5yKAi0bKLwYbnEwOcHjXVOMgkI6bGdWl1FYfyHbgPSHcZOTuakXx9pX51LLAUxYZc41p97zN9CJ__eoOzop0V7NENpP6ZwyB4QZyQm_NomoODfoKoqk8pWA1qoU7_tooEI0rqu1kn2vvYY3ooUpP5cSOxF2gVedOKxZ5aQW3mYYUvxeFXDLj4Jh3M38b5UbQc7IhvqFpKPufH3npS1z_QUPjtlEDNLdXjlRmrkhALA9MhEQnjdTQTXPgOW1pnFTSBgB5CNzzi3i9wC9Hvhk9prJldaH_8pGB5rheQj1Me6SXJKBInrRzp8trJPrAipROIuPZRE3gR_3b-AoAEx9zp5tk5PayxdAFLEqk5G9cFMG9VFEOhth0ZjMqUHPgFV8Ufm8aCj06NIc4_eso0MnWRIcIVhOdw-xNUgxI5PW8AvWF2zvyYu2VjdsHYodPWWjD49Aek0FC9qFGMuEP9FfQGfMAjhUfBwLs-rbI89TNuus4XUl2HExqldgQrnsqInXS4mrjofyV_O_zJ8uqPsKLu7xCZQEKh1jB9N9xJez_kTcq71DL1oDXoz6EVk5X6n-T9WCBOQfvptHqfPNxd6W1B_Ob6_t9fRh5BGvU1f3RR52lxHmYBaBE3iFZHrGDummahBFUCYS8xgGMvYJpI8wR4NCikkgFL5O9L0Y19P_Jxvq-1Y9YwmxDErOvzKKawqyHOIuX4nuCqnTfdK4Z5JL02O_xl9DDe_nyOIsSHaFvaqGTv-Cy-FX7w7mkpL_Gg5ZW4pFoshN5Itg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTa3hWYDoEEPog=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=9306386DACA99F51C6C272625FF3E675; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlxSrG7SaRHEqm0autaV26aLvJuaAn3x7HziGu182RKiietEJ0uEoCJp1f_vnSwXUig_TIMdNb87VoJSdSPCW7TawUoCntVrMl6Va7Iqpm-tKgB__kAZIBA3kiED8Gmye-7V0HNwknuUm_InUHIwIM0xKMWikPGNS8aHsgUHt5OJUcsidM4KaVXT4WbojAPHCH0I7xlKL7SvS56xrMHO9IQkIVg5-QT_4Z2v3OUfJ2LKj0ctVzb9igk1zJ1jNEmVm0Lnm_iFvuFfbOFEuzZLzt4OUnxbyJFV8kGRUWBrBEOVnamvxbudhwJ2XeE0MOrUBPWk448m0jP70ycA80691j4J8z27Sf6zmC7v6uYE12H9-zuYdk1Xbm6TCCtg-di2JXJfgBNgx0omYg2UNBF1k529dVdDWWQ7NBct0WAV50Tw5oitxvf_4DvNl6bx-6785sH7VWlTx6Yw7KoE79Pk-w-F7Kkt_ygnyLHYkvjmeG4RkzIGC0Yx-wDfLgcpGBkKr1Rw3mVCj0383xO10G6ZLvSGaQ6iHtpu1mXVj115ULsNviwVtNrvGPQQZKmzsoqDZsfR47pTcxIQwYjIGfimLOXGKT-uyTYcQW_0cpgiPHLFuBByQNbUCYNsUMPQ4BPhj0;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTa5hXQjoEEPog=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnGxCWUPrX3NJZ2_FVMkF8LQWQ22GbQgT9x59kY4YXmNJr32FXrXAHI1BA4uoKVTiHKqObpmbiytEeZMv9r0hkOeTQwC6UtuHsD4lsDjissOuAV3FeNQrQswbIn0UH-ngBDByJ4FEDE4SLzqSnuV1DyqzlG0Fk0wtks-c4G2yUkzC8tuYKETGoOMZSCZM6RiaEVnwn6oYw8X67GwoeK-6mghiWme4q3vEVEl-XRAN9IARAyAmd358-Q_A0eP8AZzkomWQ8F3-5Tnurj1yhkNbkDuR7OR6xTWWtPezb-11fzUi08tCr0rPiswI1pYXqd8bM7Bb7wW8--nU-JAw1BZCnJiZoleMXZ9PTZhs6HrfdzeedXz8uSJEln9QIjz5umiRzpF6yg1lAucNVMHFrYR5yKxqADV460tck_ZdatfHcFr9RTePT9M8W32H3mV5HMQiMhtiAw_AEE48FGyF8utZKoamhZSo0umE_H-cxgPrwPnQL4HPtkOUOYi6whe3mYiFwnURR8mDcbOvg_tmNGzStpKM9z0wg2HIHutxFZ4hmoVbFwOQSnM7xvw65Obo_njYi2ubR_gMmHuoL1YV5WEvW_SUlkc0O-toYOHAgS-l5xrpckPSom5avHnprZj7zAeZBfp8AJ7EXxjideCk7tWuaaSPQCf6DzAm0zpvQMXYdk1Q;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTa6ifKDoEEPjA=
     status:

--- a/tests/api/cassettes/test_set_mode_heat.yaml
+++ b/tests/api/cassettes/test_set_mode_heat.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlHvqOxkwJiirYPc3tZvvqzJkl1U_ufdDu3FaBWNyNdcd64lG3o4kFO8GjpRnYBlierRBmrFyCOJPkmTdjtbGfTehSC8Crm7mxzDoQbewRmeOIAoBs4IxYhhzYp-0tBOVz9izjGzKHTFCwhU26nUYnqdipkWA2UMDMjod5ZsL6G-LRUXkYU7SyObcmfRcdXxacbhC8f8Kcrf9wsLyohGIjI7hNWP7268kfuu0iLC8qEyp3bUoXblfBU4QhKBSX3lZ4=N;
-        expires=Sun, 12 Apr 2026 13:22:25 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.4SnSl5M3jtvhIpy2V4boqjeykqdMlYGEFuTjiZyB8gg=N; expires=Sun,
-        12 Apr 2026 13:22:25 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTaNiPijoEEPjA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=343f806d-6b98-4eec-9cc3-01fa9722c425; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960457730521.NjNiOWU1NzQtMzQ2YS00OTQ3LWE0YmItNTc1M2U4M2ZmYjU3NWI4ODhmNTAtNDFlYS00NGE5LTgxMDItZTYwYTQ3ZDQ2MWIw;
-        Expires=Sun, 12-Apr-2026 13:12:26 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960457730521.NjNiOWU1NzQtMzQ2YS00OTQ3LWE0YmItNTc1M2U4M2ZmYjU3NWI4ODhmNTAtNDFlYS00NGE5LTgxMDItZTYwYTQ3ZDQ2MWIw;
-        Expires=Sun, 12-Apr-2026 13:12:26 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=L2UFhaunCVS9gh69nMWpnr0wzsXG0VDfbI7UVARPXLw&amp;code_challenge_method=S256&amp;nonce=639115960457730521.NjNiOWU1NzQtMzQ2YS00OTQ3LWE0YmItNTc1M2U4M2ZmYjU3NWI4ODhmNTAtNDFlYS00NGE5LTgxMDItZTYwYTQ3ZDQ2MWIw&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtknVCxDNdjbQa8Mg9E4St9p2wsiBk4ysHT_bHhaA2iSIzWmDWOEEn3UogwKJBIYH4j52mp5WpQmnLDbvwZxpwKRCIY6J7BA2kyiKnTYkZ6Yx8VnLx4tV04S3UsRXLCE63jish7R5gzIKWJo6fFJPUnAyhgMxMJpEObwf4UVrligd2y62UuePOFOYAHZaatMuzdjCA_YokLhSZXaWM6FmMlHS6lezA_231vQ4i9_FVxaO69p8-LTqdk7wpUnkXx47T6oX7PZkiFBZPje5rUjGgt0lh-1xfwqZWGf0n_iHiVhWA6q4nx_tjv0SiaXfzIPBzf4ifqDrJzAWlO90Vl5sog6Sf6GlmvxFuydLe9mnO-brkc6Q6tcnOZzEmKTpuVpU2KwRsHJusYIXa6x3wWRMZeP13xE26U0RzCxvHv216CC3QwYehZVFKd758HBVCo_qdKAmk26Djgudy70-v075x6xEeGqF_oxP8PyPMXtlgvEb2IHX4cwjb_jPOqpbBb5NogT4wuZfPgcQVsC5GKWTXggihhs94atVCrqi9FFJXn8qmzlW28bZKEV0C7Jj5xQgCJroegX_hfNCdMESoP5ckRiSd2LcCemfz-veMEMhLPB3GBlXVEak_k6X6_USpv_UNax_iSs0y_h6tGoCWHuwerN\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"343f806d-6b98-4eec-9cc3-01fa9722c425\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-4ad96e4c94fb\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=L2UFhaunCVS9gh69nMWpnr0wzsXG0VDfbI7UVARPXLw&amp;code_challenge_method=S256&amp;nonce=639115960457730521.NjNiOWU1NzQtMzQ2YS00OTQ3LWE0YmItNTc1M2U4M2ZmYjU3NWI4ODhmNTAtNDFlYS00NGE5LTgxMDItZTYwYTQ3ZDQ2MWIw&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtknVCxDNdjbQa8Mg9E4St9p2wsiBk4ysHT_bHhaA2iSIzWmDWOEEn3UogwKJBIYH4j52mp5WpQmnLDbvwZxpwKRCIY6J7BA2kyiKnTYkZ6Yx8VnLx4tV04S3UsRXLCE63jish7R5gzIKWJo6fFJPUnAyhgMxMJpEObwf4UVrligd2y62UuePOFOYAHZaatMuzdjCA_YokLhSZXaWM6FmMlHS6lezA_231vQ4i9_FVxaO69p8-LTqdk7wpUnkXx47T6oX7PZkiFBZPje5rUjGgt0lh-1xfwqZWGf0n_iHiVhWA6q4nx_tjv0SiaXfzIPBzf4ifqDrJzAWlO90Vl5sog6Sf6GlmvxFuydLe9mnO-brkc6Q6tcnOZzEmKTpuVpU2KwRsHJusYIXa6x3wWRMZeP13xE26U0RzCxvHv216CC3QwYehZVFKd758HBVCo_qdKAmk26Djgudy70-v075x6xEeGqF_oxP8PyPMXtlgvEb2IHX4cwjb_jPOqpbBb5NogT4wuZfPgcQVsC5GKWTXggihhs94atVCrqi9FFJXn8qmzlW28bZKEV0C7Jj5xQgCJroegX_hfNCdMESoP5ckRiSd2LcCemfz-veMEMhLPB3GBlXVEak_k6X6_USpv_UNax_iSs0y_h6tGoCWHuwerN\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"343f806d-6b98-4eec-9cc3-01fa9722c425\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-4ad96e4c94fb\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=38318e41-7502-41f1-bc13-fd54b50cc226; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/iFXcAiIUiUAvYp0KwC8GW/kjnBoEmCh7NL6dBEnZlqQUYmY6bOK47DkYPa9IFA8Y4MaA0ka4vrARQBiHFUeB3Aaygxb/GxinQHeWc5zwW+Gg/Vl4xdw3fjGYa5nwjiBXsybPqTtN1JRar22x3Gik0G8orb76SKfJg5F4FidUBcLY0HFNPeSxWX7N+B6hjBcfvFiDGTPlD06GEYamKtYFz74Wz5wtE4yjcnj8EByL51EK8OrFA25zJasRq7m9J67aMC0b5kI2qXZCGgI6xfah8LvJVTA+Pa34svB6eKELNCNNvuEUHQfiAAAA.H4sIAAAAAAAAAHNsORrG4mgstKpiUlfGmRdtHRuSPm+4EHBySdt1n7NpPZYA2kCRTSAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:26 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.4SnSl5M3jtvhIpy2V4boqjeykqdMlYGEFuTjiZyB8gg=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlHvqOxkwJiirYPc3tZvvqzJkl1U_ufdDu3FaBWNyNdcd64lG3o4kFO8GjpRnYBlierRBmrFyCOJPkmTdjtbGfTehSC8Crm7mxzDoQbewRmeOIAoBs4IxYhhzYp-0tBOVz9izjGzKHTFCwhU26nUYnqdipkWA2UMDMjod5ZsL6G-LRUXkYU7SyObcmfRcdXxacbhC8f8Kcrf9wsLyohGIjI7hNWP7268kfuu0iLC8qEyp3bUoXblfBU4QhKBSX3lZ4=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkw7JKAaeR0V4_PnkeP20GHNPKa1DTco_5gKC1uFHJ5Cu7eTol6z-loswTd8UJhfC8-orNCkYlPtqlubwt-dE_ROBYziCa7HpCoXAIhp8ObsKgj4NUcNIuWlUSLWIIZbEh_9B695RFxSyeGU_yHCcwU3qI42V2PtvE3o9F53fzD2Y-FldRu1Pi9da82lJsgPZotv8vIDe1VquQ6VDAL8p5AdGvVnJHNETHrt_zGdSfUZfcA3e_MeKFaRxktYbI3rWdWdqR3iWsXfHLGxCEf9I7gSmwpS6RZ6YuWAiXnCtsqUfqhVOKbeh9HrUy00yVt5nNpf7WkpMTkRxfALQZ1eTdZ0AaG8Aj1kDekgIwi3uioPW6I1eOUzQY8Z5nORwxypWDwBguVOI21swne_yDuN7W0YwkN8VPTrFuAii-que48IKZ57VSmIrRP9-8gbBtnW02tNdP3b2fn5q8yfu2zf_sScYKwW3afIZ6Asknxt5IId497S6F90r9BKnKd50xWJ90fa2m-AY1jLmeYfGfnsRh6eEookbP7J1mR_vBXZT2O2TzzGejzFREB-aPmkx0g8hXuRMqqP_JRm2Gcj1XvtBVq4xeSDGrYrhJeReZTYfTnLUtVorf1Z1ixEkD8Bd-iR0zRypOtxfVYKoLlqlNtK0g8eMD2hhwcRYNLMuAuIdcpmPwP1OndOtlDWnRWCieKYuImPtRaeBPpdiSM4w75_olbbwZFpPJEKUKiifLTBZloVazZSfgj0yBAmvRdLS8QzQNKQyNkGSgSWb5BkXItkVh5lKfK4_bLqldHIDS76v37cJK51vwTKQr2maFyXMUBUpvgrt67At4zsl6ZfZw1Iq04jF7PhpLhFdlTcK7DJgdLEXbqmJAaXQt-aj0fk3ip2As7X8mXiW2h0M40sJosE4gb_EL9XhQQaYV7YCKECQ8V_nMkRMy4XI2o5B6wLlpXyatZINgc-p5fgqyfcs1BjJsHvZKCGTlLgcb_Cnf7AqHWYc-q4X6glXG44nO-9iROfmSsg-wjCqsIdMgymJNIEfqT4T-Q9GNWQkPg9FtYRI3iBe1JyIUxWT8seqMS3_PzGrBV__aBqwyno8v_ASHRJBIx35XSM2Slt27gZKiJDgM5QHr873JPf0PMZq6yLD0HS7nT-yP_oKtQ2ofgKBfyJjUG1o3HxIj7bNd8-DRimD5jXnLCjldpLptTxquxOqXcZxdFRJF7WVPX-bpmRDoWostPxpGxftgfAuCeuqAayCj0Bmno6lRi2a__U-HaSOxzdIIEMzOtwp-M9jToOMsDnqYIXY6j6Rj1Ti6nz6REPfwDTfmx3WE-UHlgkgYJ-JfOa7xqdj_JLOZvkvtoHlFLOx0phjftc8tgX3UqSTU8Mltb3wCLyC3hC17ARB-hadnOlQqYOCzWcXfTFWx1rgXxkg43Y8KJNanTkMOr4jS8SPRBEfcOdKMVDHsj-EiEwaOoNbv1jjUbmvrmhDWdxDuCbQndMxdrZ4oVONWf3pdDLPe4NZBJqEKzBtjuLloZZdRxuPjC0E0grnVXa7chwk3S4OgTdkrHk2uFvxnAS_5Hw32te16hShdWpc39qDrd1YlFvm3ARwEvdc9hkMGJECE2KcAZ2XqhId7kqHeryNND0lyBiYV-IkDySacfJjzAwnLj2lR89ZEQ2bgN-7WXHEivMWyWbpqnPNpI5qAbv4R54iQuD23U3Wmw49Zk7CFyiyL1n0ZZoBwvzPRJPdXHkZY0nNJypNyr3Jl6vByyAPLrgbp3TrVR3W0G4xX1zxaA7l5cN64qgJD7-br3d62NIWhMH9g7cwZ0S0l3oR4qF2Ae1a4OnLCoEjyDJmH9eFwU_jmH1T4UT6unOhEdAAI-fLhMFgeKzXZaY8HUZXUqov6YwV_NRun0imLiDJjmBdfBMJ6Fyw1uKnD0uJi0xkp1FUNhuCNJDEPHUZWAyA4Wsh_5pvdjNI1yPMIOefFbkDUpvJeNGq_w3DI_n-N20Y4yOVtkxH9DI7gy6uUjMBsU_2LPWIMmC7BsdsKZB56DMkrfooYkBv8HDXifGgHInd0HSNjjAlm1nVq2uC6iLpMEa3RbWD9Bt7DFGTvYJW1KQG8dAeVwQkFpHFy0dyGRFnONTZ8Sk5MY74SxAp0KoB9dPWjC9WSsBiiqr2Gu5Ok4MHo9Z4qqsBUBhod0DAXcamGcdwz28BcUZLqe858ov2sGupsL2oHQhZaPGxfUmatn4ULXn4zrzXhvCLd5JOtTq39K6viAI8KRAowvoIwNblaiUgz4AFStgHoJzl1qHMyjr8nxr1BIL2CfRSbUn8El2weBHP3U_rMygxqTmV_5OZHz_WtYhI2nSoDcQpGnJSu1rkbW9pXs2FDrXGD2yznHg6Pr-MMv6TGf9ogtsIchzKDlmTVwNkQjUe2vccngQq9_htx8VUJor5jztjYa6mlXHbjLJZa-dpQ6pYqUR6GJaJK_ub0EDFxmeQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTaYhiCjoEEP0A=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=F2E8D65E72CC52B98586950A9DC3EACF; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkjFbTXoi-pNNfgE7S03YvcZN4W2hEh0aaNrMwoLR-meQBeGV7OgrgHA13be1Km6dtDX_7p4Q1tmpCGt86nVUKi5SX4lltM7YkxWmBDdPKjhvRoJ4QwPw3rLERwRX7hnm9GInSQKhFWSjmlQ7stZPcggCNqaErEqFEs59IlM6mZXVxQpvXuMamb8IsE1u0lRRuDJvm-6aFSM4ydF-MT1RGfiSI6nUJJgjhmBBcW0YuKfCuJkbuMmvNO0Yu7kXvqsLmHdoskCDlWyv3AdU3CTcSsrjFZ2Q7zBVwG6mHjNxI1fuvFd25_j2M8uPl0dRLtLrmYRAR7Ns6tgjzkW6ASWTdoUrOFvg0WrK8ASxILBD4crdnymG878_dZHLb6Hughs3vk3Y--DcOZUiXx-JqSjx_VvT26I10nMoYy0kc89mljaMGqUWPLlNtdD0a6QcLaNQEk6IzYZFz1DvtuhuLlqOhc493xkL3imL0-pPIfD7Etc8Lwyi6ttr8MzdURzBEySpvuFH7SOWAqwL8L6ONdYmvx_dFnSLIUGvihX4uCEKLC419WEXSEOL2Xn0k84eBsg0R_jsbm58AwdmGAf71DWQaB7Bx78e_QJ14gEyyKx6w2yp6com2o4nLAyVBlGvTv8ak;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTabjtRjoEEP0w=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtn-RyAwP3AETH1yYcuCTBvYmwYNSQ-H-m5meRddMeL0n9FTNnQmcYRaKc0If-qxGQ_OQxIY8O1IuZE0N2WB-BTmxusow_asPmcnjh-0LubwbDzCE0Pv9gZ6Y8SBiaF1r9G9-JfdtTBmenwn-G-twfp7_nrmlZbij3W5Jdq7re8I8BtGS2ZYo2xfkNcq99LwWkrRnSKZeEF7G1AjvD_g08MZZciC34592Y7YxmLC7P5_KB3KbuU6J8LuX6wYUXD-UL5Q3RtG12DKqVHBeoXXdCypOJdSno4EaBVef35SgdUWxAqNpNwHzDwc4TTzrC2NpRnsvHZAqO4lDKCs0-Adx6tkM77ASlQPTsQNLgsk_ktarUGU_Lz1QqSr5MEsFgNV5gDoAlLJdjCh6M0iJidhja0IBNr-2qFrbcaolVr6R-6B6gvQouHGFUsvKORrCI1driCfaHA4ZBlSh_dWu1XXw-Q5Wc7FCMWnEIcA91OfkmdT3NYoOGwmUSIQKCPKbXHbkcwkLBEA4FkxKLMOEEIc_Niz_XjUtAGeH9iA_sjN8uyvgSVmHGqzwIx1UQy-_lLHC7d1OMLhNots_S1hTPWZSBZ_RDFN5Mnt4N9ODFxwFCYcszySyr74U7B36J5D2DosRspMnmMPlyu2qAAtbCVYGdAqhk0iFS-Va7SndNUnOHoxaw;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTadiw1joEEPZA=
     status:

--- a/tests/api/cassettes/test_set_power_off.yaml
+++ b/tests/api/cassettes/test_set_power_off.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtm-KMiDomcXxTdn4RYUHftrhHY8Mgx8miOxbWvzo_R-biGb_xRCH0oQkUBm7gT53sTrKxBcM0ulf1CSdr1IuqCyKCeWL46CXQzfiJoH1Bk-C2izb5jMg3ab3b2cY_M3CIhPwWs_1L1VC9g-cGA1ILA-NeTEUszCqHbJUq2vqQIhmtDaczfXnCRoUbOA_1j9PAgr9aqai0Mx2FlWsyMatYh4GKgIAtJJEf4SzNjhfE7SbbrEVg21cpw7bLhuSA2zlI4=N;
-        expires=Sun, 12 Apr 2026 13:22:19 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.l5Uk4g4byQr4_9LBim0GCC74KzMtfN-dUVFKBS5nDGM=N; expires=Sun,
-        12 Apr 2026 13:22:19 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZOi1YjoEEPEA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=a714a993-0071-4c21-a81b-cea95d07a029; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960394361367.NGVhZmJjYTYtZWU2MC00NjUyLTlmNDItNGVhNjgwM2VkN2I3MTE4MzQxNGItYzI0Zi00ZDRlLTk4ZGQtZWRjZjM0YTE3YmRh;
-        Expires=Sun, 12-Apr-2026 13:12:19 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960394361367.NGVhZmJjYTYtZWU2MC00NjUyLTlmNDItNGVhNjgwM2VkN2I3MTE4MzQxNGItYzI0Zi00ZDRlLTk4ZGQtZWRjZjM0YTE3YmRh;
-        Expires=Sun, 12-Apr-2026 13:12:19 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=dOl0EXimx-PSAx1CZP_r1oNqpNXKWrEjWT6fPB84UUU&amp;code_challenge_method=S256&amp;nonce=639115960394361367.NGVhZmJjYTYtZWU2MC00NjUyLTlmNDItNGVhNjgwM2VkN2I3MTE4MzQxNGItYzI0Zi00ZDRlLTk4ZGQtZWRjZjM0YTE3YmRh&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkXjoCEu8_-l9D4gJBaoq8rOAWVtCMMDb_PDG_9qh503BVo-ekhYOL3oZBRmIWwZBPpqytu1OqFPQh7yyh0QztiRd4ykVFG1CMdcuXz1he7YI_OSGJ5cDP9Up9n4TIgu9ii4V_jJ-HGdR1tgtoZVVwl07A8c4uB84SbrvhMl9j8HmJ-Mskm0PHKWA2fZhnfWG9OnUtB8J48F0nJRaz1v4eaNSqVYPEbbDknQLg63TnTLHKksDqyFRdi-ic2CblWd3mYe4WIcqm9Gl8o18shdxbM7UDb8IYc2umIIlYFT9TlHQKYxa0I6yTgYeqiIErhiKwjWaE_Tw9EC41OEBes7S1Rf9hEaq6f-Izjv19W_Yz_JGHyeRYoKPHeZ7QvLV9n74reyQQFt5ldTFYC8JANmZrySy9hQr_Ssp-IF2jkg3-uk5XdVQNNY5EtAJw0p7ozcPdQC30zPatRitDZykdzJx6WUUKSKKldiBO5Rcgq7Ktcs11fpdkB9LuqI3Ddtd9sO0KEdHY_LJQiAFAr9i_tz6vqDsAtPj9aFusmk771IqVO08bJP4WR4KoDqOto0OaXI2PbcYhhkho2tyyl8Oud89IyGNka9HkiDzBUQXCW5XiB-A-ppsutgg9F_pUPBq93uzlEPUdFdY-NqUGyr9RJ6mBA\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"a714a993-0071-4c21-a81b-cea95d07a029\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-597d73d9cec9\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=dOl0EXimx-PSAx1CZP_r1oNqpNXKWrEjWT6fPB84UUU&amp;code_challenge_method=S256&amp;nonce=639115960394361367.NGVhZmJjYTYtZWU2MC00NjUyLTlmNDItNGVhNjgwM2VkN2I3MTE4MzQxNGItYzI0Zi00ZDRlLTk4ZGQtZWRjZjM0YTE3YmRh&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkXjoCEu8_-l9D4gJBaoq8rOAWVtCMMDb_PDG_9qh503BVo-ekhYOL3oZBRmIWwZBPpqytu1OqFPQh7yyh0QztiRd4ykVFG1CMdcuXz1he7YI_OSGJ5cDP9Up9n4TIgu9ii4V_jJ-HGdR1tgtoZVVwl07A8c4uB84SbrvhMl9j8HmJ-Mskm0PHKWA2fZhnfWG9OnUtB8J48F0nJRaz1v4eaNSqVYPEbbDknQLg63TnTLHKksDqyFRdi-ic2CblWd3mYe4WIcqm9Gl8o18shdxbM7UDb8IYc2umIIlYFT9TlHQKYxa0I6yTgYeqiIErhiKwjWaE_Tw9EC41OEBes7S1Rf9hEaq6f-Izjv19W_Yz_JGHyeRYoKPHeZ7QvLV9n74reyQQFt5ldTFYC8JANmZrySy9hQr_Ssp-IF2jkg3-uk5XdVQNNY5EtAJw0p7ozcPdQC30zPatRitDZykdzJx6WUUKSKKldiBO5Rcgq7Ktcs11fpdkB9LuqI3Ddtd9sO0KEdHY_LJQiAFAr9i_tz6vqDsAtPj9aFusmk771IqVO08bJP4WR4KoDqOto0OaXI2PbcYhhkho2tyyl8Oud89IyGNka9HkiDzBUQXCW5XiB-A-ppsutgg9F_pUPBq93uzlEPUdFdY-NqUGyr9RJ6mBA\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"a714a993-0071-4c21-a81b-cea95d07a029\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-597d73d9cec9\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=b72dd7c6-4060-4d7f-85c3-aacb179938ba; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/SobYsODFn3CTFu+Q8VIOdV30+ycoF4Su14Ls4Y82+guFaurGhOQd6SEXki34jW6UxXCds1lJGFMJ1+OTDR0Y5ViLmAqQJDPMG+b7i0qjE+q8vXkhkWTWcfGPBS80H2pUGljt/3wjUVFSKPfIVm0s4hh3U6uoz+wGxN9w9BVGb2Re5Qq0YLqRo5S7tDnJlBPpyM1TEUNcQxUGOTFpNak+0Ap0PIPJfrsvEKNzXbtvGDWPch0Q4uK7iMj+W8XAJnv/qyhpSN8CGH+VaCK09cJV9s8fH9R+u5wQRWLlOLdbsmdEpmq56X3iAAAA.H4sIAAAAAAAAAAEgAN//FOEuXf+BfsgNON+ss9BeUzs8MtC7aWbAyqYP9JBR3xSPv8F0IAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:20 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.l5Uk4g4byQr4_9LBim0GCC74KzMtfN-dUVFKBS5nDGM=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtm-KMiDomcXxTdn4RYUHftrhHY8Mgx8miOxbWvzo_R-biGb_xRCH0oQkUBm7gT53sTrKxBcM0ulf1CSdr1IuqCyKCeWL46CXQzfiJoH1Bk-C2izb5jMg3ab3b2cY_M3CIhPwWs_1L1VC9g-cGA1ILA-NeTEUszCqHbJUq2vqQIhmtDaczfXnCRoUbOA_1j9PAgr9aqai0Mx2FlWsyMatYh4GKgIAtJJEf4SzNjhfE7SbbrEVg21cpw7bLhuSA2zlI4=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkV-ccNQ2u4c3tF-aYljZBI0-PiCJjFIvj3fouU7hnbJEmY99J-COSXEDwuopFLF1g6DJ6giy6TmgjxKigZlXvfKM0SdAGLhHVTJG2gG-BPEptJRCa5QFYmkeIThltM325n_fIDXcXU0399OWcWUyybAbLF1zzj6MXuE-eWpcNYL18ffOeEcieo_kj7pf0TyvioX8ZFE3Zer5st5laVc8ZOGGZWzl0bBx2eA03yOdHeMKtw7q4DHWHOSto-YP0fLVBizkBhNdtlZe0U24hMhobluQjb1WroW00_OpBn34KCgVTviZnLk2CIvVFhD0WYgOErxFYajIDMu5iE_Ujq5oievFGja_HcOWshBP4scuHjT1Pdzr-3Tm5lZrldW3yBDVVVNAjglFX89Z7MC8gBWQPNovy46ZopaaBKfLQ5gsiUy0v06iwE6stwIAYKwt87wdbBnYyXv5zeoRWTzGc_PDhFtHucZ4RIt2jadBWKPYNSU-QNAp0aF62F5TMOWQyWwtzMPoLBQtCnEPk9yGpvtNHI25ox2pXBR4aLHAzPXEidN5wkfBwNdf8qZxtfJ-tCgTAEnVFdhz9cZEYX7o5Cqa5h-xOD73pDUJ_jJ7iszEDKsvDqsC_Iuu1P4yLJoFmZ74s6LQxzyLzUIiW7X3LN7j0oRw8bMMQDM3ST4XDoPhmarO5TG6KzJkGuRrveM-cVNetx_aYswz7j6wOMvKFChyMVJq8FgQkfbarjPD_8lie36J9TpvxQhzN8tfVuWDPwbMdmuiGB-ntGPev0mdnAhn3IemtUxPQN6OkvBB-dxrmgr7R1PchCujzfwHgMAk6PVUHRRQdeX0QPwhlGguJTRiehUFMSWbKfAgnIAwMenKHiFrTWLU6t3UVCO1fEDoQR5jrry6BLKYPjLgwgTeycJATV0l6I1OAop1l2yFV30u6m9qpz2nYoZ9SIe-xMKuneEJ0YTiMB94WtkvLuMWpnL1vc7rP7wQInAKXei0o6QAPaX7NbbnFyDCkVhYfo0jjyDVAnr4evjMHTEmGFbmc4mIApB22MilGedc6RbvhnXHoVbl5ZfdqzNIIma49UP3NWiqNbDPMUdDT_2KQ-l8AAl-4lBwF6EEkefI_1f5Y-6dvM4MciyrjRc7LWNy3I9xWgojJqF_YHfBlHL-uPMT2rMn6BkR5QmHr0v_tz1tQaT0garjPR6t078idVCkwFoMYh7hAOhMdqB18wTxv3dPhICh0GrZgYE9QZp64-D2K-hw9C_j8TD7meMAP0u7jvM4aZqnpRlOJMKwCySXJu9gE0P6lToHwDMGeLufSjOz0dwk-q3fq4RgHVpAdC1rwRyz8M0-AEFvVQmibxqdAnWbUavLGSp9vFHWiHKIPHCtUqgHNI8eDjNx7kMBh13kEh87DIFHvp6maQMZpaTgFOG65BryNf2uqIJT2ji6VpUzC6rkFU7-sGg_h5PZAuirbsY1BF1PV_5ajFFCYKxPjKgQFMKQUzierRufVsWwERuGeOQDrEutx2ejR9SqSOPOoq3RVJY5nzgAciuj7RjK41x0ExgFUJF570IW852Hpy_iZnLE0EWMXMw9HuDGpFNwuCixL9uhDvnGQ6ZpQ76OBXarStMmy8h2VvYfE-Gs_nacq5d3DaxqYxb8LOiG6tKweyN6lC0-rDbHhjMsjtqBisHp8uG_BA-OUW7GwCVB8HP-wzaLbcOe-R3tSLdUgM4ZA2MqsA-57fl1lEKoe9TRZQA22ViPLMU05HN_rpx72BCWOTqD9pp5gwa7iSH9G0vc16ipgLEHux8jG6acaYeoWxJJ0RlL3UxJKMqHiOIHj86AC72CpCM7scGqLgAIEsBxi8IApULpoLBU85eJz1H7Q9_CvmiK2youqhULQHmS5afxScVmrUqwhprwQ5YOx24Wq-PI91XuvREtU5JNFv11X2P13BqLOgbcTEDCgPRBZTfsfMe6x0VKPc4_RDQ_tDvlYT4janA3TPqjEI3d3j5O275wVOAMppy4YVFVzipaYl9KV48IM_EH_MeWOH-PrMEN0t1kOJuhY10SLTjX5tGR6UG9EtsKlw3nYn71HsWVUMOfegUOEXuK7lDCSXfNCeaiDIVWI6tvvGaFC7brZrD5Ft-g7c8h4LlNU-0woYdLAQ0UPq29OerY94SL-1VzyJdBzcTt-PXqP5y_FTfM7vbS-MhDkggNQBVkbHtcxO2p_zhgthqWBP7Pyn8mSsvyk2bRJ5C-Te_ctkSkbj9H1Txs_5yH9nFQxGmv28TRnfjAZ4oIfcfU1qY4pBrWdhC90ens2dLEP_lYP6kwsC9z-vc_1HSaZ_yQoolXJx4QqoDBj7ZacEc5vz6KDkBvZPNHRHVsEPzknIUBxWR-LvTeUWaqw_XNtPZyO_xElM_iyJeaU5XxaB-krCygyvkrpDCgSjBzPl8V-6okAfYNmMWRM116lMecQffPc6k-MqkDEtQXa_Z73ZENsD-Q;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZWisjDoEEPEQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=13830BBE4903B0072FF4F3D693E6BAD0; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlZVe0JNFOQWwtLnu-vwNmKg-_lpH7JsKaZEaazuW9VgT69DSLaaLobf4U58tYfQS9X_F7LYSrC6sHgI03Epg6E3ZU31QJIldI7dWMMYZ-xeB1bPEPl5lpVPIbT5hK-qucNtb6Xnw4RgrXh8lJldvHKL6V6m1K5QJPIbR3OE0pi60qOTSQbsqmofrxUMoNZGIQGvx61mkuqmg3BfW6g3R0N91nG-vv_rvQrVLqPqMm7MLkPvgL6LCkppHN_OHP-ki57UZpgatxXAB2vx3nNhQNQoVI8yTBDtq3_PZlZ8dY1y8ynVTo_2n1TNlX73iAzVIPShMrUASyX_EEEw2091xVcm-3hVZzUpgWexOLNkmw89kPArdKB8EbHK1DRlcK9difrWY78AZZhdvzJnEeLwIrEjTBFmPWL7tw-JBLS4wmHhEBHXmuSUQNyH_JIsQf4ESumqOHAuYtTgfTVnXatYB8UkFHC1ivCzJTcIKsKWEkvwU5CAmAZmyI5TF4sMX9oXnbhW5gWke_tI546U9bMCvTAZ6z4GwgK90JGJ4k9Yr-qqWdFiNB2EyE1bgoRoowoNG-LtVa2FC4aG2YgJsZhYyvh9CNyqLcQJyTnFtOhJSp0hWpaTcvT07ZV5s-KVRwkqqQ;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZYijnjoEEPQA=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkCBO8qpfIIj9bukU7s5XX-hQQYNZ1OIn_Wgek5DV8reW8wb33iJGT45Ae-vAF77otNXzRD9c0uz4mT3Epb1P63278zFbkUNBJkwCmqI1_2VattKlfR6R4awLlRVqcMrrQXlwP7DcQEcxcVAwJ5yO0VLUB6YAMweQhHXKS1JOHnRrxR3QX4uvUs20x23V0LvoIQukpzK0ncyKIcTFb9KUuN3DGA38wr6nlrrtcxqxMs2eYJfPpwspbXvIe5LYJTMzIfiPGx6hd7xYPS-lSOhvpvSLISaJZTmFB6XduTd7tPG0_ZR6YqNgFr-U94Gza-hbV6w2bbHzTIdmB5-GVcJi7MhxmvrS1XchV17tCMdkB7nqKeyN-xwOUbMJjF6taN3gj9gsH19P7bVicO4VHvpIzDZfC2fzjUXlSPg9RFotp--j5xCHVgMYQmpbLg6i5EIPe7CVwhDnRvNoqyPRvhD05NWjHQoJBNITXmQl-hkUZZWXhFoFhQSdbR1uy5_xKXlNuraGCpd_R3KLdGP6RRAezxF84cS8gYH1PORPJp4FtUQvcdhaCGo7-9O8OjwsiKdGnWX_k9_cydqOGk1iHwKzpmvXPkBjSHGpMKtDaEDoKiQndiYV87yJDPwcvWnuEuvdFMPzoRjZZOQl7d5sgHlJ-uWYCzhPbgrBn37KzbkY1sZA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZaj5CDoEEPmA=
     status:

--- a/tests/api/cassettes/test_set_power_on.yaml
+++ b/tests/api/cassettes/test_set_power_on.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlKYRnow97cviz7fMDv6ua0n6XZftcGIcxU6BBHmgy8mZDOCauTzC4ImuqddMTxCitb3hH8V_Q4rAoI5v463Mfufu_ufy9MVN_3ZOFTlrTaXmOJPiQHgK4LStE2Bekc7VfGkzkGJLgQ_y3A-dJoVHvqWzPTKVeVIJIXSC-NdB5JxUh3T7FhiJOwUnOC54rDIKKn54QDvgKeE5pb6RkI1wNaV-V0ZYzWYIMrKn9w33gpT_gLUvD4vn5CzGN-ZihwKiI=N;
-        expires=Sun, 12 Apr 2026 13:22:16 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.nQXSKf3SMMqQUTUn2Kr0CaEGVOxYCuWIsgE_l-XN_f0=N; expires=Sun,
-        12 Apr 2026 13:22:16 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTYthcFDoEEPPw=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=dd86a04c-ff84-4a7f-af20-7b03115d2467; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960361813174.ZDRiM2JiMTEtZjIxNS00NzA1LTkxNzAtYzgxMWQ0ZjNlMWQwOGI5YzI3OWItNDE3YS00MmVkLWFkOTYtOGI0MjUyOTU3ZGMx;
-        Expires=Sun, 12-Apr-2026 13:12:16 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960361813174.ZDRiM2JiMTEtZjIxNS00NzA1LTkxNzAtYzgxMWQ0ZjNlMWQwOGI5YzI3OWItNDE3YS00MmVkLWFkOTYtOGI0MjUyOTU3ZGMx;
-        Expires=Sun, 12-Apr-2026 13:12:16 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=rLGwTznl3n1fmx7fn2r5mgQwx85LUt2_T0SAWLxE3To&amp;code_challenge_method=S256&amp;nonce=639115960361813174.ZDRiM2JiMTEtZjIxNS00NzA1LTkxNzAtYzgxMWQ0ZjNlMWQwOGI5YzI3OWItNDE3YS00MmVkLWFkOTYtOGI0MjUyOTU3ZGMx&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlZxAyuNQPXzhMC6jk3NZM7zW1U4Ug0vRo5gy8RU15-GKag6IQYaAipI8Y9Jy0VmQc_9UJTYJvaX12WtbrlcVPoCwfndYJm41YMucrRl6bf7gx7kLSJ2CH1QI4pltMPUeovIsc4P_j6UY9FNEYXiYX7-2X0_ba2zqd-rn2AfmKR0AhxHgE7NBvS2h2uCnIDanAEtt8fpJC0UHbeBkw4_Y3XiXot_lm2bRRczrJgRH8s8U1XkGUYxfY8RgjHZ7a3HDwwVhw45OZIEetM6N1a4VGC348df06kuZjuWq569Cbjl4QkMBJealLkmP9AlKBggG3PQMWX7ThJqkUj39fOjDGjl9us9NaSEbL_5IoB8TdfaNjVF43kBSERSstLj0X_-4oNo9ulEcvLkMJurRKTuYxoSHjBO2IJKciM-kC_RiLLQtpZG-OGsoieazJbQIhSqmI4JBlgCpbmuMvOeT1On4l7GYq3W2oLl8MIqlyRGWsoJIXIdRwnO2714FLQn0pLNsuA3fpGldHFQN7GAMtokDjniSRr0EO5gzfSrtzmLDe9PgkFXeyaBEUzSVfRZmjsLD5et0IdSzzTZUvyg8BiKCGEenhs253MR4485BcqQlZNGUkW4PONZpKEY_WJC9x3I8EgfGvtyHXOVJNoXkcI_gqo\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"dd86a04c-ff84-4a7f-af20-7b03115d2467\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-e2dac7d75ed0\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=rLGwTznl3n1fmx7fn2r5mgQwx85LUt2_T0SAWLxE3To&amp;code_challenge_method=S256&amp;nonce=639115960361813174.ZDRiM2JiMTEtZjIxNS00NzA1LTkxNzAtYzgxMWQ0ZjNlMWQwOGI5YzI3OWItNDE3YS00MmVkLWFkOTYtOGI0MjUyOTU3ZGMx&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtlZxAyuNQPXzhMC6jk3NZM7zW1U4Ug0vRo5gy8RU15-GKag6IQYaAipI8Y9Jy0VmQc_9UJTYJvaX12WtbrlcVPoCwfndYJm41YMucrRl6bf7gx7kLSJ2CH1QI4pltMPUeovIsc4P_j6UY9FNEYXiYX7-2X0_ba2zqd-rn2AfmKR0AhxHgE7NBvS2h2uCnIDanAEtt8fpJC0UHbeBkw4_Y3XiXot_lm2bRRczrJgRH8s8U1XkGUYxfY8RgjHZ7a3HDwwVhw45OZIEetM6N1a4VGC348df06kuZjuWq569Cbjl4QkMBJealLkmP9AlKBggG3PQMWX7ThJqkUj39fOjDGjl9us9NaSEbL_5IoB8TdfaNjVF43kBSERSstLj0X_-4oNo9ulEcvLkMJurRKTuYxoSHjBO2IJKciM-kC_RiLLQtpZG-OGsoieazJbQIhSqmI4JBlgCpbmuMvOeT1On4l7GYq3W2oLl8MIqlyRGWsoJIXIdRwnO2714FLQn0pLNsuA3fpGldHFQN7GAMtokDjniSRr0EO5gzfSrtzmLDe9PgkFXeyaBEUzSVfRZmjsLD5et0IdSzzTZUvyg8BiKCGEenhs253MR4485BcqQlZNGUkW4PONZpKEY_WJC9x3I8EgfGvtyHXOVJNoXkcI_gqo\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"dd86a04c-ff84-4a7f-af20-7b03115d2467\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-e2dac7d75ed0\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=a09145cd-7915-48c7-a957-f5f5a9d40e99; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/o8nqoaYBIa48vcm7wTv1IKlr4f8EDeV01E0lV902U+ATsO58L8FAvA3uwak1T4g1tcN/2Cwi4sNOk3+7aviqQIYuSJwGrUym/fshQUohKLcjiIHi6xYHFtFBoowPkBIaq/yD/mtA/F+piwG6DxNAIAZxKeAXu/bQuW8yLd2IqvQO3AISJOsLsH4UqOq4/LK0HtAVi7W1WNO+ybySMQfuwa7rsqkHXRyQYGZ9DGmKu29oIrHPReQ996Sp4xQoIwIHIjJfyGA7RePaHJ/3FMcz5QOmxhL4SzIGZgWtQ2wFkyiKhSqPG8XiAAAA.H4sIAAAAAAAAAAEgAN//AH7zg/14pvaXTADcAQ5B6dOwvhJxkT5NzNQ07BeDsF8xpRUIIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:16 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.nQXSKf3SMMqQUTUn2Kr0CaEGVOxYCuWIsgE_l-XN_f0=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlKYRnow97cviz7fMDv6ua0n6XZftcGIcxU6BBHmgy8mZDOCauTzC4ImuqddMTxCitb3hH8V_Q4rAoI5v463Mfufu_ufy9MVN_3ZOFTlrTaXmOJPiQHgK4LStE2Bekc7VfGkzkGJLgQ_y3A-dJoVHvqWzPTKVeVIJIXSC-NdB5JxUh3T7FhiJOwUnOC54rDIKKn54QDvgKeE5pb6RkI1wNaV-V0ZYzWYIMrKn9w33gpT_gLUvD4vn5CzGN-ZihwKiI=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtkj-jZBqW8iW8tC5wFqOxwnZN6KvLD5FeK5D7v4zO-EwQYErinJSIM5pwdoVQ7pS38c3Yr6ypnJzmGRrDujPyDHciFDMiepLF6yPRuUDuETojmnTaccagVyOPImAOoWRsacsNPF8e9-b5Up0i1MKsyXnie-YQ4lv352AGpIqaL2WwTdDfP16sUiGH5rGru1zVW70ZdUIGdarP4l3psPU0hlAXBKCc4XGExf5Un0-0rWrWRl4x5tMG9JZDyDDZj0T-Mw0_CXKTaKzT3mSmvprMOtKLZR9Mrz9XTfRAAMHPx5nNtrvpPu2EtUdm4MWqb1he_JOYEBVFIeWcJncn3kpgcCibVHLC17H-b_hk7XISlPKV8EjQ6WW7vtWkP7nMzYIN8z3SDTuxTy7_LuCD-L2YxDXy1_vQDLurnnuh-btpj1IAoT5cR32v7Q8SeoN6wor2t5zctIIto9osYYYDI_aqwOn-7e4BjrDC1B6JFS_N5kxka_lYrwImoDD5lGaIsBpKTbtkLfd-IMDiixVkv0RtTM-GczA94sKX9KWx6SKhXI55g5SWVLciNPrY2lwnawwBsKwqn11w0OmgAvbQq68BiLjCup-ckfyteHxQarapoMsP5xpsVKn2-cIEtq0rw0iF1glEv_mOLz7jpO7GbEnzpH4tX7yJLxXytvtEukWc3o-pzh2l3y3P3g9sk6n3nY5VGODy4s4xZo119ZqPUF4tSAAwUGXQdLWTzEE0A6I9fJ2ZZOR9TnJTe1m76WTkbCMPHYggbZOAffM33geHe3cBi69rQiWx5wbSBtXBTNEskD0sPVIv7Sn1Qcs0-iWLqGfFtld2dHrUjKa-g4aHN3Jo719ZhoYYcUz3hHYPl09I5SIbq2VgXemlWs7c5IagXyMXtq7icrOfALcAh9bRoejqdukyqMy4KaVmUwPA7IdW_YwseY_vsCDjZxyNbKsfSt0TD739Urf7MCqa__yHmSIUWTY9nEULdPN_mfz5mV29B_LrFfwf_RYgYUEmA2elX91lfsdAgRaAyyGqZRhmAaAcpajcwHv_LwOsjRq4b9seO5fYfQzNN2vyb1zFfzUmSBB68x-Lt6_tRKQzp69fucdcRdothgjdcuAtOAmpatVLFQ4nPv3CGzwKzsvIAatT-BwT-N-bKMjm0TFObP9rMyce-VqgIDKgkssTtkOddKxaJ02skSTF4QoCmc61H9ByGjhJfE9XWV2kRHbX8sZoUT0J-VCQUVdzk4gX1ncmBw5j8n_swosOa3_zKngeZJqcqJG42Btm6-8-Z94hLIzwmK1wGDRV4MnSzkzOIParAPxBI76FlnQWnibSoH53cRFk3dpUIjXdKidBSgu20nd4_trcOL9NRF97Gm6v-akz6i3MeEmNbF7alUCszdWGTHLC3MjytR8jm1I9uFY38btRfmWTQRv7GDwWN3rFrY1_pLsI4gzD4W36Wl1hj3giorSIUtk2Mpq1bUVu0DwFuqHE3MSYj5S4qXo2vl4gdM77J9W7nItE99R1SC-NKfEiQ50Ffo260DrOQtSmLxJ-z82NvSJ_4cBpbtdnxYRqY1WP0xTcLRWRqlKFwL0QKqeZSnAU5opBMNCNchJgCPBhnXUQA7pQFUkNEc_7Mwjiu4J-pzcUFI8eZoAHW8lq1ZsuE2J_1CnSz4liQdXFIoWWwHaH15-th7v8a6Ua8jhl01uIISZQzdfR7seyVoOUlrFiKDVHECxXPsyOEyga3RaS7KgJpfAAVaoWunIiUI8o4P348QoMBIr_CFdSzDWdiTUoTZb-b433p7La7RtxlzosGFCcvX8vGCWpmGHQaoJFp8D8uMgZkwAemsMEy01rhQz_ycPn2aqFo388X7uEIa13M-S8CK51pRi0zV2ohb6V4yY8cmDxoKEkNTvxE7Fwk5cQF5G9lbkCzCtA9DX7yji8QoqBCgQS_ICkE8bz15VrcbDQ2gKeAgPctAzEduJWHf2iiBQRSjeFPZI-nnpyUzAgHbNHAcfm5RKDScXRA9Yx3B2MT0U3-ZWzSWGHlz8f--D0ieq9lQNKq9W0CeQTC5c5t6R_UK9_8D_pT6mEACQA2zsApRhXpNw3L2SQLePPId-qnSV8TOuC7qJuqOrACRX7qWIUoqut8vO0rqcYrzu78rVoEAUwINgcLkq6mFm9B64rsS6AB9FEh9kL5IL1-9WHUmqlGl05nVQLqGp6AdfI-gAQ3LYxqxzQriPwCdwghi5eiBgctszWo0Ib90E65pKW32LtAI9bQpFXyuNEi7C8nchFPnUw7E52zIrAhu65DSsexpse8L_SaG6G0TSoTDHxIAat712XNyTOqtM32Z1gHtiwXazrlOoiSEkjgofwZ9xt_0-Z2uYw4DXnVgwwdsMDAub9jRpfa-YNCPn9y_caWaLmeldwp4fM0OiMQPDEpap9SMXS7G2pkGn60fnfIKzN6goPw38GUvTUCUaawseGpTvzuaqojm-g;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTY2g3KDoEEPkw=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=EBDE31E5F2803DECA1910619EEF56FB7; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtksSn1lR6Z0Lrkzf48PWYd1aDWsRs4HCIbXcqALOMDlmXF72_wtyn5e5xsQB1jSUBerH9xS35D5iPbwrlzKb87Hl2cJWaQJU7MKP222ZP199tpJsc00AKPLSwIdfSJGtguUUrq4SwP23pyin5tiTw6aMslUT1UBf1gc5wKit2UmOr-TWP6E3V2iNIGydWMHXWgWP7ri16lhRNNhv1vajkjxEnrvCAoxCVCJLzw14sSs7Xqki9nO_0Y7sZC7r2MVU6Le6nXjDlmeaf7lYyb7LnOnhIyOmxKbNnwNqreTbeJvpBoIX-nFPbv7N40s0tPJ5glaDxLVLv4LJ8z5RpG3XJdEWy47rS2qyvSrtd58IqZopb-7oHmw7WQJK1Nm8mv7tYksPqDqyujEJh5ysjWtCgijUMvcUvLZ4h27BLVXHFbjf3X0NKshZqyarz1ManBvF5IzQOyoLFBczgskiGKHRWFZM5hNrTtSY7APlMCFZleLc7ISJF0oglvCapVy1z764fsPaSJ3nDjU-atGQiHMgvqdZq_aJ0xIAjs37SAvrm3QJ1iFfZnCBGFIxKRAk3W2kHNesBUN6Q-jh4-YWEIMgqHp_mbgH3dTgON-kOl2NxaitmjJ8RB-tNama6A1ee3PmJU;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZDg7ojoEEPkw=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmTK5d8hOGaXPRxIWAEIh3hzbAHHGUOcKZHXosagpEoDwVLlhjRCXbQOmNsaK-tTtEHa9gtEfPijVDvehzig61VZTkT8xkEXieE25G5DKZtqqNRPWKTAupsnP5Vllxb_GFiOZwfwi1Ox6U9FWMHM7SSm9r2bNlAK98DvS6e2BHnxDyPIjJvNjMbZLRm-vHdo1idLqfFd8hehBgaXWfcXkgIhCt7Svn37jGQBOydsw2AP_YoJxXiB1Ilne7mMWNz5SoHoWfMS2YnuNzkfbMFmEsPxxtee39CkdYvd4PKrsfBsmNpR2BdrKXsPzPiajYoSxGtKDGvkEdrevfsK4FqG1wnRwTh9gYWKLOeB6XnvUWjUs8f9ABwd5MPnDjPMSnQ4TP-Fv4nP467CKPKNDRny26IzHuef-1jjIvkUAX6WNMkBfMwMz233hNoT1mnl8AhnEysW1eAY8HZlgin5mJCb6oI5h5dy-0wAzyy2OdjU3RTvFCA0xf4U6t6wUDmpGAEh3aj0NXjCHFVLiv9Izs3CDlbz1dlC6gMWg5g-93eb5i2Os4qzGE7TVl9TEKhjw5z-DZnjhTthHZqOkga0gqz1cdDea9Gly2vvfNgYSfSAVaS_n28_hL2Pz9ADDZoJLkubkyp8sBGXPAFregRngu0uNNUdT3K8WcOqd1A0pemLmLnXg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZEgWYjoEEPnQ=
     status:

--- a/tests/api/cassettes/test_set_temperature.yaml
+++ b/tests/api/cassettes/test_set_temperature.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkd1dH2MLSx5NAJ_JJqVmtWsBXRWgcl4Ozti4o26DfVhpPOk_JraHjQ79u2zqnvhbKpRPvWfd5RVjm7nCICPdJISlLJiN2fCF35lBeaqb8fuO8daaOf45KVAzORO9YeaVoiMV0DVpXnduMw98dN3M8djBNeC1Oxy3JsJJmfDF1dFSz6zyNdxb72QFmfjjXfef52Z4Z1E3G_PEZHmKoCnuWwMukz0hFMz816TZPQ0EdHdaXVC1dp13E_anxEv_btE1k=N;
-        expires=Sun, 12 Apr 2026 13:22:21 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.FgC4okUpOUMImORQW51zPXJP9j_bakH8e1oVVEEme3Q=N; expires=Sun,
-        12 Apr 2026 13:22:21 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZjjhlDoEEP9A=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=3e8479ac-56d3-4343-82d2-ffeb97038a0f; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960415985069.ZmQ5MjljY2YtYmUzYi00MDI3LTkyZmEtMDVlZDI3MjRjMGIxNTVlYTdiZmYtZTQ1Yi00MTYwLThlMjYtYjQyZjhmNmFjNmIz;
-        Expires=Sun, 12-Apr-2026 13:12:21 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960415985069.ZmQ5MjljY2YtYmUzYi00MDI3LTkyZmEtMDVlZDI3MjRjMGIxNTVlYTdiZmYtZTQ1Yi00MTYwLThlMjYtYjQyZjhmNmFjNmIz;
-        Expires=Sun, 12-Apr-2026 13:12:21 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=hnFqV7IyGkEujkFqFMZxYW6MuiddMomMLYS8Vg4i2Kc&amp;code_challenge_method=S256&amp;nonce=639115960415985069.ZmQ5MjljY2YtYmUzYi00MDI3LTkyZmEtMDVlZDI3MjRjMGIxNTVlYTdiZmYtZTQ1Yi00MTYwLThlMjYtYjQyZjhmNmFjNmIz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmkqDo1gK2IZKQ-yVsJTKNXGUj_EqyJ6MR1cjywo6D8yu8mtGdQeIAHdLvOuakq5RgOqvuaBN_Pkicvi-nYLLY6-dDwUhzwj-bg4fR_VjrV--rX-If82uha-HX5tMh6MCr0JOmOX-4yur5DwpcUWS7DCPws569sLKCDqkbjiJsIBOqo-UhSIC2uE1KdUOsNFwwIFWraXMytYZxQC6kHjgftRIrBmpDDoqg8OQ4Jd9BixULTAKxvUv1gzOYzS0zb0Y3eeL1pYkNNgjNsoWXB2e4omRSS2lMRJjswM7fXdQj-FpJDOBxuEZgbgUJC9qaibyMrZ2Zx2JnTTJTthF9Z3IdmWHH3ybFUVmcUAwwclgu3Ak1e1FFpIjHHDDGdCTL8z4cSrtEn7kZo0cdpoqGmmyy6djWCS8aD3TyWRxZx1fOV6OX88DQmiWgoD7y7CLK5n7Bl8lktEcbDEVNTfXKec7Ps4vojE8MRFFUrCNnYIb1TmuCGzFxUfPWXq3IhsXuzPFvIZzk0Qx-gfSgjSGCqoAdAZ_fSRjjwD1ZfVCmLYSg36bmrjIZzPsRZPR8d4kR8OcoX0sRZc34b76ppNxeknzg6AUphH_RSRd-8Yiop5-SvtwrNaUZw1J2a8Os0TtIIo8zVidLwkRkjE70j7e5OVkAg\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"3e8479ac-56d3-4343-82d2-ffeb97038a0f\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-979f9732ade3\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=hnFqV7IyGkEujkFqFMZxYW6MuiddMomMLYS8Vg4i2Kc&amp;code_challenge_method=S256&amp;nonce=639115960415985069.ZmQ5MjljY2YtYmUzYi00MDI3LTkyZmEtMDVlZDI3MjRjMGIxNTVlYTdiZmYtZTQ1Yi00MTYwLThlMjYtYjQyZjhmNmFjNmIz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmkqDo1gK2IZKQ-yVsJTKNXGUj_EqyJ6MR1cjywo6D8yu8mtGdQeIAHdLvOuakq5RgOqvuaBN_Pkicvi-nYLLY6-dDwUhzwj-bg4fR_VjrV--rX-If82uha-HX5tMh6MCr0JOmOX-4yur5DwpcUWS7DCPws569sLKCDqkbjiJsIBOqo-UhSIC2uE1KdUOsNFwwIFWraXMytYZxQC6kHjgftRIrBmpDDoqg8OQ4Jd9BixULTAKxvUv1gzOYzS0zb0Y3eeL1pYkNNgjNsoWXB2e4omRSS2lMRJjswM7fXdQj-FpJDOBxuEZgbgUJC9qaibyMrZ2Zx2JnTTJTthF9Z3IdmWHH3ybFUVmcUAwwclgu3Ak1e1FFpIjHHDDGdCTL8z4cSrtEn7kZo0cdpoqGmmyy6djWCS8aD3TyWRxZx1fOV6OX88DQmiWgoD7y7CLK5n7Bl8lktEcbDEVNTfXKec7Ps4vojE8MRFFUrCNnYIb1TmuCGzFxUfPWXq3IhsXuzPFvIZzk0Qx-gfSgjSGCqoAdAZ_fSRjjwD1ZfVCmLYSg36bmrjIZzPsRZPR8d4kR8OcoX0sRZc34b76ppNxeknzg6AUphH_RSRd-8Yiop5-SvtwrNaUZw1J2a8Os0TtIIo8zVidLwkRkjE70j7e5OVkAg\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"3e8479ac-56d3-4343-82d2-ffeb97038a0f\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-979f9732ade3\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=a577ec7d-e81d-4c67-9e88-b3285251fb16; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/c/7n51ITVqeDspC5YVUjkJXW7tag8VVRvi5hYATWAfYblhV1VqHbMCXTFpYothTkwWLm7w46gcWQEDM25edhJ1hOlrchZ2FJ/OVnW0x8wyH2nVc531c4/wRm/lTHZeWxlEK4P6AVTWcaBLRKdmgMuWI7b7/RcGnaCoIpBUSdjQnuzkCB/GPQMuQ9yvj5B60bQRPanC5SNIBtMuze8OFkT6hN2PDQe0FVq/TMaN+UsSbBC4i9qbg12vw4CNSzT19Qa+rkY3Hhx8p8CbMhuKaJmCuLeWK4D6ne1RcRfdTjM0k733b/LV3iAAAA.H4sIAAAAAAAAAAEgAN//jYjqWv4hxO+hfuqGVwmqsZiWokOL5Sh4hLZEx0Kv0sfW4V7JIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:22 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.FgC4okUpOUMImORQW51zPXJP9j_bakH8e1oVVEEme3Q=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtkd1dH2MLSx5NAJ_JJqVmtWsBXRWgcl4Ozti4o26DfVhpPOk_JraHjQ79u2zqnvhbKpRPvWfd5RVjm7nCICPdJISlLJiN2fCF35lBeaqb8fuO8daaOf45KVAzORO9YeaVoiMV0DVpXnduMw98dN3M8djBNeC1Oxy3JsJJmfDF1dFSz6zyNdxb72QFmfjjXfef52Z4Z1E3G_PEZHmKoCnuWwMukz0hFMz816TZPQ0EdHdaXVC1dp13E_anxEv_btE1k=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtnNyKvJjKDt8-3OCXQ0YnmCNtKwhlV8OcMzemKYRBvUACkvYz_MdCHNTVW6KdcEpR4B2vESxyJHJaMmkdLNKdy9Hd_hWY91r3V_yZQuV0KyGh0oHrfYqmZ22t3tlHcRqTAEwviJeBUunvDdQrVe6xfm54ZnWmhrN7NLNaOgwlHPGIEkdlNJJjCDIMJjqW3KMJZOzXKvOa0rvLWwcHYgRin_zxb3PqTrbmoyKCGKmitISo3Ur8rhro-zx5GNkbv0fVfL4nP3uEZHRMIVJFO8XM94R91wApjD-fcpNm-ooFO4TLxNqO_RtzNo_5yHH2f4BesS9LNIpwcuzyRG7pyw3Q1LN8BzP4hqz7j34gzZFp8e4d-gNP2hTzJorPgwlTnG488KVnNUCR7-N2kfr2ubt-4jCwGrZdRKUum6BcoXy-oOlkuFBwz787WGy3IYkZoCIbpF5o2ox5Px6AFVWNlATIYLXAxoER6XUHI0tA01Ccn3x8IlT-PNB1CYlAzvUNxDmlNP9V-2SE93QiLdMfa8lkXLXTWosEBmi2pgohjJBTxroJTt6318Kj2NIgOkud7VrwjNVeVLLoGM3B4WUK43ZKa_P9FS1pCOkd2Qp72CkCiy1jWe7Zv5xZT_WtW3d71b3FUTxXDiA0k-ajBKdB0uDFmYw71Ul5y8WTcyOrh-fDZb4biC-n4G8bJXSn1i08m529v2t3hQZKb1dMAkk8N5xGzFwvKYslLHqdrPgx1vb5wEc17wf4smfhT1opcu0v5ceOjj--DsHcLYmt9YMM0Q1VMqpasR7s6cpaJS5noItQu9kU5HD4IYyDU5CMcA7ksQkpVYjyY5F24qNX_OFZoPlCQ65v2YuZXPVWxhGeWtu-MCT_sFTVeG59KfqnhCeQAocEtiRytkqLDLxTfFhqdaaFO1A_5dTyro9y8ZX4QGeWcnvuPHz9QVhfJuY_y2BXGGCgtPyouaSFLLjduy3NLB1ZY9vawvKW0yqNHJc77dVL4BbxZWMg0uKlQHHLygoBk-nid5oel7qaEfdLaRT1h3vnKwWUZZftLEozmU6Mi1WDXr-liMao5_8ToDGyUy68dYhRhD9PcXa1_H7ysYBFNLbGf9NpY2cSo9YRQnRc9rnAmWQSo_etBn0V8SnZtPc1XwWdg9Xp6TuUV5MDA0YO4d2-KOCEiVyhYDV5S7n6a6m28kut40KW5V7-mysq9hwgy-Zt95937Cy1R1OOP7TJTDTBnA9uqgCTUyZCIEsz4ihx1_jne7vChDA3-Ti1xv2IYDAjOzPsP8dU7c-Yp_Z9CUJ3m0UJbPt5J8boV4yW7Z1iNt43BggD91oZrw1n97nhNcV6W9JolaDM0Oe_v9ZdHi7dFYxNFgh5iW2tz5kT3LqUuFVxlm4Ui5l6eoa_dH2BVnygR6rlgGCvfj3WNgxT6VQr_-y_1ydC_9sf6AXFQIbW4INRzpF4Q-NAKihmECmu-Xz29E1fqcuPGlyViXvd33-avqSD5ZbHItC_KS-nGHdMo-qQop5M90pHSzGS7ENcwyFdW0p9tX2G2E3HpnpBlaQi4rdMcvzZY8uUjdFLiy83jvFW9sDFrQwF51M1eMeA2pLv9aPi9dObE_pjPVGOwJIFIz_smp-VE2zjFuU1i8hYa8usCFUJHPkeEineFYyPRrlP6DUbSwJUYrcRgOtrpubukhKoxod2P9ilrNJTcMy2IsSu_396Uui4jtg1OC8_9Snh9PHoKc-CY_ZiK87rtk2zEoCwE_okyxOHv9dtIWHHp3wdn9MobOlEgY8TzNa29wPJJg6XIJNcxvsXUC3R59YoJ6cBgd_0IDrwcMCXXYrOnESaiyPGRDhwZCgek4pJ9duPrgXt4l4qtvm1ux7IV8VvRe4RWwyCJyNig0DVr7HvMc6gsUAchYZ8awHNHXAc2XeQthIhbX1iFGbiCiTIHGvgh_OLeP4RN8oB0UYEV5fpb4eJ87Rx9-0X3XxCa_67v1anJiJSWxXSzNwZOEn81j0Vmpnu-OPJOOdyI79me99xW7OLagVHx_IcFncQ9QlMGn8njhr3DRJHy0ghVc194MERC5FWF4oNfiXJMIiPQvWr8StZ4mRRPHoGsAM2ey-yW47UWMLH5oEPa5BE-yhf1XTGHTonIf6uBjyoQHdMTZscqDJJkP7cA-aERoAONPG4gY0HzXeDi4z0_kijS-dK3LBL4hfWqI9EstVGA8wo0B4K6KG4H3VaavRVBdJ4K0MDDWlzYFWAwTuvBfrmQw7qJ5LVQcyupJ0yw04D1_zhC1Y_FsF6TBGQ-L21B5FUurWt04qIo-RcnBqij0xG8npPcmt24iRgI9P8jGXT3IS1SogkU7HpXmmCHlDkk30jXB55TKzNcsQuLNBNUbwB3z73VrXFoRm3MJWoUU4YgprZiKwSO6184nR5iAraxWWU5VroeQ8DVBPB2f44vYrxiBZKEcvnUpVZFk1kZpJXgpa0qgeAXZWg;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZsg6xjoEEPEw=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=F1A0AD9C74299C417EC06288BD832868; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtmHciFyVDu5B2Iu0lDgGUSuAxVT6BV8mOJL3Iso9uDHlz55fNLu0qqCtMnppQJ5XueDhhu6Rb6A-yjTUcaMDGh0_aBoGxaSon1clL_GF16cSN-c8P46Fmomni_uAqXUisNM-Fmz1llwV25wNZeKxlO_UBsCasfFBm5-CdboNWMnjMJFcNmXm9o-4y4GUo6OALrE5A22en7pzsD-76VK3SqBKs-a9WtcB8DapEss9LEVhY2sJvASg5tgEzNV4pmGVftUKW_qRsIGDRWeIVuVQS5Ei73sZvbfJd1DAWpL0kEVqzbwafHDlETuGARSXWV_8iovpRhzAM54R7Vz3h5_tlNajVKC1VMtEe6rB2sXCTe8pZBQ0MffwApbCqJobP1aBDTLdiicypcsml1lb7EaEaUmmobxy1c3VJka5puviFDLMxW7oxn0mhYnZ7Zt1Xt4iL6kAbj4VLr5DX8fWkbgubI4K2VLUPBlM6co6zBUk5vCP5EGnHDpfMOKpTpZDi2u1cQsMQ_lk8i1kAb8xS-wlwTsdAL62dbsNSWxrGAEQ3aABXQ9wCo1LPN50aiGJNFCdJ65yTj75fv4ZYU13HM8jEcE1MNPUDOt4UU0yliil7x1RgIDopIpLphyv-hGeMGLCZs;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZugy3joEEPtg=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtm-2I3CaPmdHMmLtrfgy6me67bpn1oKCyOV7m0nAr2MiItfB3MPaSaowgkLOWR5rUVlRv4C9NOS8yJ70ovPU6f2z2oRQtDf1Ki3VafWrDRbbnJ1oE7FluTOLTrBIkq4lekwkR08Q-vqQHnglhr9HEGlHNtrOBEQ4aaljPbH8Wi6pGZCiCdMUzDqSJcxIxmMyzIQh5lPF_0WirP9TxSvNl8QDmlcsdtigzm2y9cn3zlxS43ojpV0HpoiE7him2XjADVeuBnaW44xQC0nplzFS0_F4LNy5qqCSEPkm7fPuWVzl2vglLC1X1tIOoP_d0roxzJEkEbcUDzAEKFu1Xzj0UdE-8wMJSEZYBmesgmCKre3CNEEnuCGjQ1VwBeKPWidGSyPFv2sqNbloFvLaedGh6Iq_BidA72cF55nYxHAOWSVknNUsGpMXVC1ARDNit-b5fD2luVO9a9OC73MbLlsNnpxwYNHEh8RKmd7fpSMGgxLkSjFK7XA-H2xREFWLAEcYZN7zZDE0dRG49UoiZWIl2x7e63XxEdTnQbCB6OKj7iwiaSeCRfGF8RWS4arwxV-TWiLallOGdbEus8dVG2hHx-p253zXjmU6QzSD_YozTfauFin9uvvinCb_wWcpTn6Jfw_fWdZZoXPMYyWJITuOJDLh8VZg62PuBOnrB4Qj2XKvg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZwi1VDoEEPEQ=
     status:

--- a/tests/api/cassettes/test_set_temperature_half_degree.yaml
+++ b/tests/api/cassettes/test_set_temperature_half_degree.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmTTylVuD-GvGgI4mgM350n-WF4TrkXbMufBLW79jkYHV0-Y_8z1xQ6aSBqv17cZJIJIp1rArLSnHTfQX-QBNXCbYuzYtGOWUc5sdFDMGzWQNh0cQVqpT3qVGLCpHA4A0Vfp0r2uoYazZNybq6mBOQ6GANUxWthNpiyGuAx1Q9RiZREEpgbmxZp6caJJ12Upt9ttCkzNFzUvmZMzp3lOHk7nxy4FI0Biq-tnYn2kgMJ043iYL2aNp89a2SSZGG8wuw=N;
-        expires=Sun, 12 Apr 2026 13:22:23 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.06SJJyzlNUH7tN5L5aX4W49o2YS0rl4-1VbuWIK85v8=N; expires=Sun,
-        12 Apr 2026 13:22:23 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTZ4joYjoEEP9A=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=cb65f6fb-614d-4c02-9483-bd9d6911230b; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639115960436864879.YjBiNDhiNmQtNDU2MS00NWM0LTk1MDgtOWE0YjJlNzgzYWViMjQ2ZjEyZTYtNGQzMS00Y2NlLWJjZTItMDc4MjgzNWJjYWEy;
-        Expires=Sun, 12-Apr-2026 13:12:23 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639115960436864879.YjBiNDhiNmQtNDU2MS00NWM0LTk1MDgtOWE0YjJlNzgzYWViMjQ2ZjEyZTYtNGQzMS00Y2NlLWJjZTItMDc4MjgzNWJjYWEy;
-        Expires=Sun, 12-Apr-2026 13:12:23 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=gjnYuUNLErwrP0yYbVygJ8xbB3bdOi3ZuxaguIlW59s&amp;code_challenge_method=S256&amp;nonce=639115960436864879.YjBiNDhiNmQtNDU2MS00NWM0LTk1MDgtOWE0YjJlNzgzYWViMjQ2ZjEyZTYtNGQzMS00Y2NlLWJjZTItMDc4MjgzNWJjYWEy&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnviA7sNip6wQQfgqi4IZBoPHFuogO6TjXJXLfcyladXfou4XPLyRUnl5AFckq-NWHSnjg5I0GIf6zzR4_L_A2RdaNSfe78dwIpVPXaYeI_X0FJjsOPuoCvXvAuybZAPyX-myOLyj-1HUfJmI5eVp0DlEpDOzoXmuMel3sESJTRte3vDkDXtEX0-oKVQkpCR2NQNL1SgW5srnfGp6IBkuE86Avqz-20A9ieQ2s5JTzD7ojs_d34oxLHscDkucDnZOVSnvSndRiD05vqRld4kqlhSFGdNwM3bVSZ3s8B93a3_sUuPjdgF0n1Ed_TU8eCsIPnrr_KRamMo_VMIZ5oyhYKuZ9EmpzNtXlX6ELjnhNGe5zM4DTb5HsIrlrNMn1j9QYkcYIcincjRvS7tFb0bZbqrzkQm3kpti4Sex3eGow1p2ysaroHqy_R0SWR7rbjixThk2XtR8tA5wrz8QzgH54Y6Z4bQYR-UR3MfWLFcDoFweb7CufuJ88nm1xg6fT-mIPCc2el2TKCAtvdrM7P5yxew6ok11GUjwbO25y8cU66bgySNTyUuTQnd4vsbVpFql3Hp11LRCFZ41y9WqPfBF6BOpF3mXMax3bq8XXJpei50uhO-mUwakjk7OHmZcEG2A7NU5zjw27cq8Dl7gDICfrJ\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"cb65f6fb-614d-4c02-9483-bd9d6911230b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-ca33591f85a8\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=gjnYuUNLErwrP0yYbVygJ8xbB3bdOi3ZuxaguIlW59s&amp;code_challenge_method=S256&amp;nonce=639115960436864879.YjBiNDhiNmQtNDU2MS00NWM0LTk1MDgtOWE0YjJlNzgzYWViMjQ2ZjEyZTYtNGQzMS00Y2NlLWJjZTItMDc4MjgzNWJjYWEy&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtnviA7sNip6wQQfgqi4IZBoPHFuogO6TjXJXLfcyladXfou4XPLyRUnl5AFckq-NWHSnjg5I0GIf6zzR4_L_A2RdaNSfe78dwIpVPXaYeI_X0FJjsOPuoCvXvAuybZAPyX-myOLyj-1HUfJmI5eVp0DlEpDOzoXmuMel3sESJTRte3vDkDXtEX0-oKVQkpCR2NQNL1SgW5srnfGp6IBkuE86Avqz-20A9ieQ2s5JTzD7ojs_d34oxLHscDkucDnZOVSnvSndRiD05vqRld4kqlhSFGdNwM3bVSZ3s8B93a3_sUuPjdgF0n1Ed_TU8eCsIPnrr_KRamMo_VMIZ5oyhYKuZ9EmpzNtXlX6ELjnhNGe5zM4DTb5HsIrlrNMn1j9QYkcYIcincjRvS7tFb0bZbqrzkQm3kpti4Sex3eGow1p2ysaroHqy_R0SWR7rbjixThk2XtR8tA5wrz8QzgH54Y6Z4bQYR-UR3MfWLFcDoFweb7CufuJ88nm1xg6fT-mIPCc2el2TKCAtvdrM7P5yxew6ok11GUjwbO25y8cU66bgySNTyUuTQnd4vsbVpFql3Hp11LRCFZ41y9WqPfBF6BOpF3mXMax3bq8XXJpei50uhO-mUwakjk7OHmZcEG2A7NU5zjw27cq8Dl7gDICfrJ\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"cb65f6fb-614d-4c02-9483-bd9d6911230b\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-ca33591f85a8\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=c35949d0-ab55-4f71-8757-956a54cb57bc; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/i4t8qhPOpBxKYlYkdoJPr350whO4Yo76FjX6vrvUV2h87FzYL0WQcxsIBXAmvjUkU+ysOY+HJTpTKWbcTsMMkDnhP5Hnmkl29hl7h5ohMCASVOfWI3S7VhznoggW22QQ9wdt+kgzkXBR7YbwoalU1HLH+8CXVbP7ku8PkeiiQuxDM1xSw39lsLwZp8TC9J6fr07Vv1lQRqamq4IfggEtPQWm4VNaOpoGn/P+6iMiBYfM0p4e+7JLzpABaUkrPAzel7ubQcnofkeH62oF8LFoi1Zu7wBeLAqRu9D9Zb/7lQGg6TeDrWfiAAAA.H4sIAAAAAAAAAJO8mVezKqgnxqMl7/LSAzxts9Il2xY5ecRZn5dYIrKzcgMA66Q3CyAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 12-Apr-2026 14:07:24 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.06SJJyzlNUH7tN5L5aX4W49o2YS0rl4-1VbuWIK85v8=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtmTTylVuD-GvGgI4mgM350n-WF4TrkXbMufBLW79jkYHV0-Y_8z1xQ6aSBqv17cZJIJIp1rArLSnHTfQX-QBNXCbYuzYtGOWUc5sdFDMGzWQNh0cQVqpT3qVGLCpHA4A0Vfp0r2uoYazZNybq6mBOQ6GANUxWthNpiyGuAx1Q9RiZREEpgbmxZp6caJJ12Upt9ttCkzNFzUvmZMzp3lOHk7nxy4FI0Biq-tnYn2kgMJ043iYL2aNp89a2SSZGG8wuw=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtmBoeQTuKcBTCZoCSn4qhnUeo2v8Pzgw7fysM-aXQRCuxU9NArbY4xqVWC7TP_u-FxIGT5E9Teq3BVJTBu2y3A0_ofev9s3GGaUkwDPFBv4g5W1WTFQ85304KDJzzUailkIHjN544NOakvRUGfkWerUhhafB46_dFMF2fWOPn4AxKlJdGJZgf2wYFYrn98L61sRrUXuxnXJH0ahuLfgYFBbJle_aCCL3AFc5C32mo4MiN73Czxao_Gn30shDzdVOm_jhWIFChgGDQc-bEO1azBzs-tId0BGmlidAgc99EGM4f3ox1bPlHHsW4zJiUDATm5AkiAOLtI2_hAItPIMkTtNHaI8OWZlpEB143FvJP4rI0cV-vlbo-dyGAeFluMXHfVlBievZ2pO0Ha2CU1Nj8xdNLo1FxM55iX2oQ2bO5D9Dq_ZOrQ7PdCekfpo7r8KGePNFbG0MUQuoOpOmbW5Hp6W7Sg77bCMARqVTvS7qxQ48zrm2oVfB-wjTz9uDBJBDTpMFCsaQkIEw0SGaOOHBe2hLIaSTwlz5H4JG5flUWILSVPX_jkV1lIvTLEJ3_EIfUihLds7IgtGjyAj5O-6aUjNRjROhGspv_dbLBCaVeiH2cIAfbRddbmWijAGcErVL5Mh7ySIQhCEUMdOlwVELJaKcHP8D89ppbqTDZFH3ssJBBa4l3Pydw_Ta34w_ElAPvtp-W8Lx3C46-7sz_1SbBVcab2ByiEHEqmqzs85UbIYRke4ziByk1_b0aWE-mBWOcdbpE_qAbcazqFcYFXDhr6-MgC4WxEEJlg9RUI5653AKSUDU0-oSbGuLqqeX4nuAs9pbojrhjVGz-X5wkEmEqt2WLHXZX4kKsEfHToKJxw5sDTKoq9MLg4uZBc3W8E38ceIbYKmL70D0s6LLjD3KNlOOjD4dRyEVALtGO2uAZIBp9qOd3Djg5Djs8xVMeiV9bwZ1AZ7Ev8hR5TjvPCNG4ySRMF_XQKyPhpRnK4vN7cwiRX959IYuRoGf6xHaMWn9thzk9gngcA2cjujnOWR8LxCqOMtuJUyfZ9ZfvCp9zs-D_1s3xd4kK-FoG35a-Elsf43DuB1ciDxUj9Oj1dy1seXs0swhKFcgbZpPEY9_E3sr-fChL15MYaXJmX8fCYPGBS8hrIPWrcRFoC1M8gOusDEN0Lwvy2IXEi3EGp0XXETWd-S4TXzv99YxdaY6IWmP4ZpnCKD7uHBYSNpilU3nmhzjie3fmSEV8yO9SjkV460vKPsP-ahgZEVf0RnnLp17xKXjEy5kanrPwLK_UOeJtrSsJHWGGl9Uum4acon-1Sivr2sY4R9rrI1dyWlIbjCtIF4Gl6j5E6y9vdi9XOp2O7hQGk6DKng6SrwQI8bEdMb4L_L7U4cQReR7FIC_ksfEov_kPYoUWzfXtnT5zyZLOwNK4RiYIPJN15wX77NK8BhWOjwmjs0w-JZIIy1o18vcdeTd1tWrdhbCU6uxNtlzqsbFQHombi5Yh_UCePyO4letyi_NRYD4nLc-5V8pqBaeuYP51vk2I-OjvSdfolMOIhbm_q7TJ9yefKHvLjZCBtkPGcmljQjdXDnu7CkgylFbww7h_kaTz4jbcCXY5hn4Q6tWzhTWtpvUQpkvR9qEkJLRsjicMSkWrujbpr_kSPgLFmocbnC_vUw27n9FcyYcy7f62PuYF6jsKrSl_E4cC_zH58wYhVcU4_ojyN7liJp9vElfR5e8RXKsPUIyAXMDIIfCgI0uvI480XGtMFPYQpjkfL4a0QJsvb52ZfBw4PrHfl56Z0LSRN63LzuKcHN_MnwpUxk5Bn50ZLzO_f8ci54FcPGLxQkTE_4X86bDN2duHrsSzlZMdyZFBTAWm-Apkrq0UdDtRDmW19MYgQNfT3HSdoPVy6SM1O2ExHliW1sf7Sm3qbq2dknC68VoTwoezZ7URNB4jUpquN_Axt3zzM9xMeC8-PlJprUC-lwjIVB-Vfzh9VKvrkIG7klfGq-nqIiX82vGJhtCTpIkigkMWpeUlu8HY638ia6-S2Ho_JA2JrJPX6jnxPs8iTdx5kv5RdDf7_JbxD3EgQJ1lDf1r96cSvCssPfNM9IB-NiDU3t81pRDQhzmh0stEaNxIvOTQOHj-lxFl4sPayonxeNwqYz6JZ7FwtVr1VdJetm9V01hDxbUUMPWoSDh6LHTUvdfs2ZT9YYE3dHvlaD7hhoz2sWxk3VLq5ifG-jQu9hLxaiKbwi2AG8IGkTXyo3Mm17fBpadNainthPF9AntqYRKKTNKW3wA8z9lkmDsciqxp88W-oKdJ9qLxWybQ76lI-F0IV2-qxMR7Wv8rXMuLWTW2hJkP4ZldiHimobBm5WnKC43Zmt3QDEJ7INuR02mhVIjNMTd1G6hyvNgSegQcfosW8fCjuSMhywYxyzBCHfmeZUTQcaig_f0POt7jJrA9PuelrFYCB_NYrZatIMrMXYGK23kQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTaAgIFjoEEQlA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=AADFAF0842C2FA2B9965EE572BDD4D12; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtnaCejBsjYhXrdXlEIU4y9gF01XwY7VjswFEKZdlmBtHD1QlqO5mF1g3BL--m6JgL5NpeKzVmR5br1p6HnEJBLIMiu5wFUgc6BZx7yEYplC8I4AGWDdyd4BGAjahng8h-fmEaGzmc_iqMDxyDxsDaaStzPN5AK8d_ebFol4rf-Ib39q4B0b7PdATO-MDZcpAGTNnEsj79WXueFCM0BDGNyjucdVz-5D8Ekra7siiXaIXY-g0UT1ae_TjnM5QW06axMjYm8LA1EkYkqYiqjGoyNAKp0AMWeAs1VPvMkCAcPoBvXrlf3-WPkpo1guE4pHpn06S8qijkfQbc08RAr4zueYg2fc2JS0XgJN0HaDaXiZWwKzqW_g5X-OL3QV2dyE5YrgsaaBcc-w3yd954y4mwbSx_x5777nhwVDGLm2wqbkTisIcpoQfHP99-7PGXFLACg-i6fx89UiXtlGir_gP66CSdpI80x0EpbqbQIMp-TOakwcFjn1R4horPDJ7gWRKbffJjWHC9GivZDoBP7sEk7fyOn7w9tCZ8IEWS8pg5oCZ3tIC0_aRpwXWlCkW9YBYNFztvUjkmIA3hasaftvhwDrwcwkOvkgM0V_ssalsjFvmLRNWMUPY76FkpWauhizSRw;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTaDjsaDoEEPdA=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlOtHa3ZMWyGSNS4QipZ-D5lwrRoDaTNLfaCeeYv6zBmmgBBAFLhgIIwW_ITiuObDLct5wHMO_I5AKiKZrAgaWsEo816YkN-gIuW-0aUlWVlU4lbinq0RZAjVZ2_COruw2rmqRWpGq0EdHSQQImH6Zc76Grd6XDNT1vU_RdNZ2xF7R3WS9KfFzjyOAB_XuJDxX1y78hzAKKguhhr_Gwl6MX6i_kPFL2Y7Db0TSQHBMwUDgKyHSKTAj-rzf9Zf--50-wmYJiXykBOQtER2QfzCV5UK1B_owAbzROjYjGfISr92Rpfqfj4S3USmmXAq7DNs2zZwDnvX1QuLCuF9sSg9ROWYO3w1ygeqEujwpbnMoNsYOBP7aP2zlbzNgNSC1HmrbxQ8rXDp_OwdGM7E00SHe7RDN3yRpHIcjnNtVANB7SWyrjFXiC0ykYYTp2RitRDN3yCIwlqmCy4BjnoS4hHcogjL23DE3qCCZjVM2K9SXHJnoSu-BqE784kPfjYanqM4lE3Fw2BlcAc9JVN1UFbD8rZHB7-Clr-PDK41Ah5QgsQr7A2x71p5dLIiIFSFtOXjNAR9JZ3TDytTD2TeXFGbYMdDVNj4TOw_ArUmWlWmgR2rmCvQy9crfi8BTR8IVKjIepOX5Z_ubx0TmOc8NWmDbzgqKl-niWaDgl-tXz0uJm0A;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - btTaFg0QjoEEP1Q=
     status:

--- a/tests/api/cassettes/test_set_vane_horizontal_auto.yaml
+++ b/tests/api/cassettes/test_set_vane_horizontal_auto.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtndMnLbl_Em9UZM-Iq9sreZ7boYM2lLhrVwDgIzGNLuY4GBDVO6tZD6tb7OQi-5OgT-_5e9FUQxSI4kfXTNtK6qsUl1lJZHMQVPxbD5g0QxoMsAMTiSUY2k7HD5iePIXI1REk0xaQcb5clc_XAkaEA9L11B-tHgFp_dY7x4jreOKMUh5XIJAlEfJ8KBJ4J7oNqfqyARYaKZvkV6AF1wuLjD8UADsOtyHEj4qOxu84WmMm6UozaCASGxAyCnj9Zq-9E=N;
-        expires=Sun, 19 Apr 2026 18:10:08 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.hqNm_tY3_7jabPu4myqI8XWWXSxAlLQCYh1SIz4nYCQ=N; expires=Sun,
-        19 Apr 2026 18:10:08 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHjhtbjoEEJ5A=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=133785ea-8ef6-47b4-b8c5-e5dc06551695; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639122181087109390.N2FmZjdlZTItNzczMS00YTI2LThmMzYtODE5MWFjMTQ1NjhlYzMyNjM1MmQtODA4ZS00YmU0LTkyOTQtY2RjOTc3OTU5NDQz;
-        Expires=Sun, 19-Apr-2026 18:00:08 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639122181087109390.N2FmZjdlZTItNzczMS00YTI2LThmMzYtODE5MWFjMTQ1NjhlYzMyNjM1MmQtODA4ZS00YmU0LTkyOTQtY2RjOTc3OTU5NDQz;
-        Expires=Sun, 19-Apr-2026 18:00:08 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=HHJzmAUxzO697HO9y189CQoZ0rF6jMmWDHLI4prSSIk&amp;code_challenge_method=S256&amp;nonce=639122181087109390.N2FmZjdlZTItNzczMS00YTI2LThmMzYtODE5MWFjMTQ1NjhlYzMyNjM1MmQtODA4ZS00YmU0LTkyOTQtY2RjOTc3OTU5NDQz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmscx2-Du6rO2kjxLTgHtr-UwNgOMMv3VDb0PVd5GK46wx12LEiGNkThg_ZPgQAqMR44AtYlCl6rUYiiYrZKUT3Tz4stKdg_mCgiCYEfM7fdrWtTrtiBZ3mJVdP7VWGkGgiK2MwYRD92_copBvACnqb5DhFmKx2OG1Cah9KOl_jXzmVsoSr0z2_L2XaGRCFijNMsxAnAqrbgIUTVVSxvQym4OdWfjFfPHEmq74traAA9bfR4XTp-_dKB-sY7Ybq2wtwlIi7-Sc1IkEnkBL_ThWTldheTlF_dyLtrBcTNiJYUruaCn_olxPQ6K2NsUvhH8WHWPRc1zuQgr4_ZaD-UGYp1CEU05Z5cd9v6sIBrBxT5yAncFOYJZFvAo7qT4spdMKc-DQKR4SxgAjJylCUyf5hVE92rWCWQ0JixHjsVJd48iCP5-TPRQ61n07BJhho9lQrgazgFsHUq-ARO1NSFDyqLMYQlHuZaBGEfPqIUf3zfPqm_YmhA6d-oaaEoM1yhxaJXXpw9mCpkta_1dDRagT8Z8I2h489ZCBRb5HavFCpGgkakIHOgcy1SvzEJcmRmdvm2PXii1yL7FZnQjlSMeggTI2co5Mih2Dt-zgmRtKNt0gu-ux-l1r8XTj-s_lPoGPh7mC90G7pceDyo9nYmJY-\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"133785ea-8ef6-47b4-b8c5-e5dc06551695\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-056a8acd8267\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=HHJzmAUxzO697HO9y189CQoZ0rF6jMmWDHLI4prSSIk&amp;code_challenge_method=S256&amp;nonce=639122181087109390.N2FmZjdlZTItNzczMS00YTI2LThmMzYtODE5MWFjMTQ1NjhlYzMyNjM1MmQtODA4ZS00YmU0LTkyOTQtY2RjOTc3OTU5NDQz&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmscx2-Du6rO2kjxLTgHtr-UwNgOMMv3VDb0PVd5GK46wx12LEiGNkThg_ZPgQAqMR44AtYlCl6rUYiiYrZKUT3Tz4stKdg_mCgiCYEfM7fdrWtTrtiBZ3mJVdP7VWGkGgiK2MwYRD92_copBvACnqb5DhFmKx2OG1Cah9KOl_jXzmVsoSr0z2_L2XaGRCFijNMsxAnAqrbgIUTVVSxvQym4OdWfjFfPHEmq74traAA9bfR4XTp-_dKB-sY7Ybq2wtwlIi7-Sc1IkEnkBL_ThWTldheTlF_dyLtrBcTNiJYUruaCn_olxPQ6K2NsUvhH8WHWPRc1zuQgr4_ZaD-UGYp1CEU05Z5cd9v6sIBrBxT5yAncFOYJZFvAo7qT4spdMKc-DQKR4SxgAjJylCUyf5hVE92rWCWQ0JixHjsVJd48iCP5-TPRQ61n07BJhho9lQrgazgFsHUq-ARO1NSFDyqLMYQlHuZaBGEfPqIUf3zfPqm_YmhA6d-oaaEoM1yhxaJXXpw9mCpkta_1dDRagT8Z8I2h489ZCBRb5HavFCpGgkakIHOgcy1SvzEJcmRmdvm2PXii1yL7FZnQjlSMeggTI2co5Mih2Dt-zgmRtKNt0gu-ux-l1r8XTj-s_lPoGPh7mC90G7pceDyo9nYmJY-\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"133785ea-8ef6-47b4-b8c5-e5dc06551695\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-056a8acd8267\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=f34e74ce-75fb-468c-85bd-00d67ac9ff18; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/mFchr3KjTUWTe+8gbAPjwyKB0B/SEJxxMaTym+W/f5YEtlzvxEYyoie93cYbh3uGAg4aIJ1hq7CqOLPwC4b03D2j0W5g5Do3xN/Mdj1X2Jc6hOdiQ2Pey9IcdvqRoPpvcBqcoTxpwZu3qcpKq91DK0U3s/QnkF9nKYu4Vz/vYepTdGSWy6dcZvVVPABntxo8pBcqurSv/TZzKpJzXDajenX8JQaK8rXqgyxIWC/B5SnNzcS6wnoXSAroCl+swqmuB02v84uEuCL3jRCzItr9aZ0KUSnEs+i8Cl++GWgoFI+nuFYMDfniAAAA.H4sIAAAAAAAAALvhnJOvZrTWbpP6UZbtbtE7b98I/cyo6LlGLuhSbgZDcxYAoRczASAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 19-Apr-2026 18:55:09 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.hqNm_tY3_7jabPu4myqI8XWWXSxAlLQCYh1SIz4nYCQ=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtndMnLbl_Em9UZM-Iq9sreZ7boYM2lLhrVwDgIzGNLuY4GBDVO6tZD6tb7OQi-5OgT-_5e9FUQxSI4kfXTNtK6qsUl1lJZHMQVPxbD5g0QxoMsAMTiSUY2k7HD5iePIXI1REk0xaQcb5clc_XAkaEA9L11B-tHgFp_dY7x4jreOKMUh5XIJAlEfJ8KBJ4J7oNqfqyARYaKZvkV6AF1wuLjD8UADsOtyHEj4qOxu84WmMm6UozaCASGxAyCnj9Zq-9E=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtm6xFfP38x5G_136O6-9sMKoboATE8yR_2-BHbc7EKxSJCWITTbrwKVGS_MglYrg2Jv8mGGu-651Y9QcmOL-JPz9U2yKMKdMrcPitKQscobFxVa2T_XXdUl8xo31eR5b4GveaXZCL5nIDMAkaHr0oGRIQsL7oBBL57eUCWku85bGpENXUFOeSgNK3Rf3_YsZxlbAvngcfPf5jM5nGSwhPx9lTjDziyXSTknM_KhxBtyQG44BMvaI_XB2nrPma0coktJI5AKNrlb5VX7mUH6dmjvH7sVj3u_FX7yAElLpWzLvlbFCKLAY99mmDh1iR8TMKGDC1H1EzhqHvVq5dqWWGQX1uY0UXSc7Yt0YxVLmOA9JaXqxAOzsBh_pM4TNmKcNrqhXhu0xrY41D2XptGXxHQJ3C-5qgYDvPR0y-UH-dQmEnXeWxvXWIF-4JTsRcNZVIcORiYURMZFQtlOWBKrghuIw57JnsmQ_Zw941QzyyV854Ew16uqmMx_NGwGGJYWNZsILIF2-ZEzyISWWNGtJdyl5snscgTkkBUT_1mFQYaoM0h4lSFXksr_BnxR5n2kD_jMdxq0GKxHqgSBx9RMfhT1SoLwHcQsQ7GbEdvQecVWjoRMjD5Vube1ArqCCLWjOlqDik5cK-i1m8IZsdgK2L2dT9u0OGQhUq6a392mKxU9IIS0zqNkf0hOhH_AX3wFLIWKT8UIIZfTcvysD08jOZ2BMNFh_6QUffZLEXA0jhC09tF8IQm4PjWdgsgQqfeC_mb5amt9cjRplCGjp7XUgU7WvmnHcqWIgnN90yAtBJEvK2t4ylQ2ljcHs-_npYA9lW7YfBF-ndKeO1efT0cuaN9TqgKbxaCyTaua6JyuOCP42_OjfuA-96LMO9MMBxXJW2UmKEteorj9KA_SAmXw8VsJ7GVaM1TFimBnt53LJfX81GGoYD1nykgAe3OtsyyeHQlvttFlcJMYJN7kt8yYsvmysABcW7OALvRGq_pzUdVFTsyXLw2I-iFa-96MkEV3opM9wiC5geFwfsn-OTdvThmYtdN3bsZfKBIuq-N3Fmxp33R6a1sAQ7XNM8ibw653D2ovcEvcKxqlmXG629vO_-vvQ5DWOiI2jXpw9CwyIE0rbDx-VS5pz10srVRWnD98b0LS4hQwhVRew4aAVN37jOTxKdk-9j1-cvygbLbBuTJ9oAF9WxJ9AweMAwTPTN6N0MFXy8l3DvD-1lYxUB7LeJGwECABPXZcmiYxZe3hDK3IontmXpDtU3rQepRDQBO2_KjGUVRJVcn5Df5Nt6P3fz0b5FZnXQnP9L2VvFfPtzEPmAxsztM2eTtlmjVslyF54Bt1LCFzrpqzlVpMVEZ2STZXhHOgcu4crufcZeimzmJPASlOBRgumZQOV3eAgI6TSjaAkFrWW2Pt6w6zAqyZ2-rH3F7w4F78iTaDpXPwV0RcBOQRk9FGA_6Fm8bwsEatsX5iM9asUSeyeQRJaKD5e6Av3uC9c5utnA_nkFUejSzjpMGxeLBdXct711MAMjuNG6qzp_8DcXjUxlQSGGXiVkhOrYU5TjU72kz0KuN67NXSvKhbszBA2WgrXCtnQPRAqFMaucMnxKX3Tc-ptmKhyLiH-N6HruiNLnaG5dgjKV5pGcLlEzFgd2jeQl8bMtestkbnBLKthF9foTxIWbU47s9fCcY9zevys1L1lU0DgV4ICQAnNeEiRrIMEppkEB8Ji6xw1TZxnekSVt-m3dS-fd6icZauuf2NidDadvSiBj2Jbz9-LB_Axh-ix6KMAYf1PNPM5vg7VmCDIWpGyjAdZwIumKIbD-3YG77eZvLAozT2W9-Xlyje27b7MPlxQ333W2mB8Ex4oMyPz1II8rN9B8vm7HDFd12dk8bwkTU2G1YidfjRPLzxcRClZK8P-njcv8JP43PWVaH58VGBLnWHUDOdRFcPL5jxoDeru1govoXv2_4ZVm4J_DlXzbCT9Yx_X3ZQHsxrxdwvwZNWDG1xlG-bgu8S6WD2tkTRz7VAQngk22sUDz0qiWrAO7y0zyEp15yv6QuHLiuURRWV99Haj5SvYZh9GT6Fvivn-4TK9-fHDdBd8eJMvqRz7TzhO3DgqD_vxSRplEiso1tL4n9izoLElFx-ruJIT_BrsMW3BC67R0LyTazd911WSH1RuLbyNr8neJBWhzpXveO676Vb5MeHf4I_dzTLGXTbnp0uUV1j8d4EnhM7tBJ1iZlzbMdgpN-kHSLcld_S0-QfXPy0ofK0vpAUEqa4bsUryCbg86ZBOx_RAN-qzeK9lEHDStOqyg1IwcOif45moNTjWgqihtXV5mCueFf_cxviowl4o6FDFvravaLCWgVkrEHlMrTj9LH8Dmi01kHu-VbbmencKftx-UBrwFcPxgvkCFT6wqDkO4Ygxe52nfTjhmUfW-28woZRtkv-9XKEmRdRK5dx843ihvjZb5rO8UPPKp60TjteFw;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHpjJIDoEEJxA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=BDC9BD923F50BB23DBA7AB0ACB73C68B; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlrxLnGi0BAoi8Mayd2sHlhMoJ9p-SxhgIdm4WWV10ldcUaN18wBtaLWI0wVH0hBWPkh4QotIyGfQBFWHzDHtIyRzkJMrR4e5pjETKtsocbwf-ZBjjUnyQh3sInfdZS3dxL1CCcK17Od67HE8aCRmW8d_PruZwGYPNstmfy45yuhiIAqoXC6IE3L07kGe8IK13l2GYkjb688sNQKeo8ifhgnEjAgoGxIeDiZ8AGYEz2UVhznH_Pd666uHvmuHR_YDG4O1nFRA4b7665_vu6usapLkgk6dQdFCHD4eHn0H94GBu2KFsLdSg-xye3dfI3pO4LjZVC7gcw9ckVCFoJKa7eYJg1UvGYveSaEe4aPn3xNTq-q0s_8ahPV_UmvHd8vPv3GVdTSpS-YxJAfAxl9dF65ltQadn3BLSVzUI2oYedD6sL6toupyTTZDweha0dAisUMY8C5UaS9o2BwzQkIs-nuxO2puqwSzCeZ-qBMZwA0e3pnjZxRRvd5CuR9nM_yXomtfnSxlqAy7Oo3CJ5nbtBcrx7NzK5wXVv9PwgRxvxXk7hNsIPL_F5EzeM5PkeIoTdBtHK04qjw5tIOxX0-n1eFR3QR74loUZcYvqCZyWua4gGrWyWITicB0hM89koiU0;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHrglhjoEEJhQ=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtlPEobaa9vsumUaJ5m_STmvjuo2bqBMaePB-90G_M4ZSwxn1OstKh_K9kVXXCtYQMQaHc_ofQWGX1q8UORtSrR-gYbucz6zt8OCefC_5gqWnA7qVZcHpAQX5LOCNWIDJ_JyWimIYai4UZXS3YbpMBjDao_sr72YrZaljocjJchjlb-5AwCtpOC_MjJgojMxFh0RCqMLdrp25D9TTeDWEu7SN_Lvge7gEiARazdrsTmnzX0HnGiaVbB7LE0ktTMMlgoPoAHhlDMe-O6bxfVDnyo4zEMOMnG55NtUkYFIFeMLdSO3Lf8eniDXjTc51oEB2jDwvHJ7ahS0TghTZ6Gq5TA3rlPb-K3o4I-Ze2_OQWJQ8QYqEDsrzNY2k-jebO59cuE2v8nunbHnc8imTn5I9a59SB038b-ADNm_lWR6YBFANc5kDMnq5q_FDshxEU0O_U7kuOaO3uM2iWKSegje6JdrX-TdKPS53mtHkjLs3xBXOzOOyUJ3vrdxLAqEHt6hUiZ6m6ggk3vnPtE3rg_8JZ8cgVjsQYcSydb9HvzVJ9zTv9y7O52GMpI71z-aMwyUIx2CSiPtoDW91IVMvqY4htzeQbp1b7CF3C9-3MLfYa3mOswHd0bZVgpRzs6oxhg0MkjvWIa_teNkqGZr41V-X7GnywboEAwW33Ck8_c8cwu5xg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHsjhjDoEEJ4g=
     status:

--- a/tests/api/cassettes/test_set_vane_horizontal_swing.yaml
+++ b/tests/api/cassettes/test_set_vane_horizontal_swing.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnthve_XQBkKABseLFnw-lI-xiHQAj5uzvxwkq4nb7tVEvylStQeAov5WZrUrF0rUMsHtt5DgIx4GFMHj5usLC5rGFPWlLyvh92pBpFWe6Eugb4uDRK9qkQifA0M1fLcdweJh_7EQSM2lE6lLFLz42IgZ3tSJ__8hHivsjlvWzreJ3Ubs79eznR90aVGYJx7rfaxZrmEwuaNNLOYG3IsZkP3HQPQeBe0ufVEjz0J1Jn-gtRKxPH8H7nPj5MMsBbTiU=N;
-        expires=Sun, 19 Apr 2026 18:10:10 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.VcSaaHnEe4E2ZjngvnFrDMKs_Uk3q8ZPfTIrOKly6EU=N; expires=Sun,
-        19 Apr 2026 18:10:10 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCH0i1FjoEEJtQ=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=151a7745-1dce-43f1-a27e-67c77ac78ead; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639122181104939147.ZDA5NjQ1NjItNWM0Mi00ZDUyLTk5MjktNDdkYTQ1ZGExYWRkYWU5YWNlZWQtNzJhMi00ZDNjLWI2ZTgtNjk0MzRkNjNjYmMw;
-        Expires=Sun, 19-Apr-2026 18:00:10 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639122181104939147.ZDA5NjQ1NjItNWM0Mi00ZDUyLTk5MjktNDdkYTQ1ZGExYWRkYWU5YWNlZWQtNzJhMi00ZDNjLWI2ZTgtNjk0MzRkNjNjYmMw;
-        Expires=Sun, 19-Apr-2026 18:00:10 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=zTNoWEA6-z1nNlx2we1SLVSbhAguveIQf48VonVACZs&amp;code_challenge_method=S256&amp;nonce=639122181104939147.ZDA5NjQ1NjItNWM0Mi00ZDUyLTk5MjktNDdkYTQ1ZGExYWRkYWU5YWNlZWQtNzJhMi00ZDNjLWI2ZTgtNjk0MzRkNjNjYmMw&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkQKsLhdCdP_sl5cwu-v9KzSuwNHR6vHxFsiD_4mwcPmq8yhd6oZmFaVyi7zc6H72pGg3YY4t36K4iNd2-LTHMGPV5_RL3kRT3StxNd0nm8305KO3RyMoo0Tzx_BLrx98stS23iOKZ1pLvjw50NQ0TT3-xkQDPoVizKla02gzdGFp94NRm5Q86hKW2zd1FwyaMTI54zHHyrVLHofjcoIoV8jPQ6BNzU1Q8d9yavXJaWmDrPHLbpMYFNVHpGmi-cfg_L7OiL-LhxJYl4qr-9Jl7bzxrJnqWb1vE1DTvyalSzupN5piTKXxfj1LEC8UWTZPyVl9WN8ToG-5yaIdS3Wg-T2EhPqDd4kyeFhNfLaGw9ID_Nn6cM22-Oyfu-BbRA7V1RzAYBEhYnNYbhRher8zQ2HSPQu99DE5v-C8I9_LVO7wOYObjPMrnS3SRv9NrXLtzXphhRlloXvq7b-hyOFvj60odCOsObOiNy30sIArzedtdcvsk_tbkEEBWGyVulsboDkSUGD3fp7GB6qT8QczMaZC0BZM--X6p7d8WsTvUtN6LpwcZEc866wbxo5CgyzKFf7rwz6WBCBtIh2O_-5ozYWbmAW2X0oBsBcbjFPeM2Bg88Dax1aqzBfxnJwSIabXX-CIySzz6JpG7V4Mc-AaxF\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"151a7745-1dce-43f1-a27e-67c77ac78ead\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-0dac2be5e2ab\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=zTNoWEA6-z1nNlx2we1SLVSbhAguveIQf48VonVACZs&amp;code_challenge_method=S256&amp;nonce=639122181104939147.ZDA5NjQ1NjItNWM0Mi00ZDUyLTk5MjktNDdkYTQ1ZGExYWRkYWU5YWNlZWQtNzJhMi00ZDNjLWI2ZTgtNjk0MzRkNjNjYmMw&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkQKsLhdCdP_sl5cwu-v9KzSuwNHR6vHxFsiD_4mwcPmq8yhd6oZmFaVyi7zc6H72pGg3YY4t36K4iNd2-LTHMGPV5_RL3kRT3StxNd0nm8305KO3RyMoo0Tzx_BLrx98stS23iOKZ1pLvjw50NQ0TT3-xkQDPoVizKla02gzdGFp94NRm5Q86hKW2zd1FwyaMTI54zHHyrVLHofjcoIoV8jPQ6BNzU1Q8d9yavXJaWmDrPHLbpMYFNVHpGmi-cfg_L7OiL-LhxJYl4qr-9Jl7bzxrJnqWb1vE1DTvyalSzupN5piTKXxfj1LEC8UWTZPyVl9WN8ToG-5yaIdS3Wg-T2EhPqDd4kyeFhNfLaGw9ID_Nn6cM22-Oyfu-BbRA7V1RzAYBEhYnNYbhRher8zQ2HSPQu99DE5v-C8I9_LVO7wOYObjPMrnS3SRv9NrXLtzXphhRlloXvq7b-hyOFvj60odCOsObOiNy30sIArzedtdcvsk_tbkEEBWGyVulsboDkSUGD3fp7GB6qT8QczMaZC0BZM--X6p7d8WsTvUtN6LpwcZEc866wbxo5CgyzKFf7rwz6WBCBtIh2O_-5ozYWbmAW2X0oBsBcbjFPeM2Bg88Dax1aqzBfxnJwSIabXX-CIySzz6JpG7V4Mc-AaxF\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"151a7745-1dce-43f1-a27e-67c77ac78ead\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-0dac2be5e2ab\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=c521e1c9-72c3-40dd-a846-07e0644bbf59; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/4091YOX3JYEdddHcId+MC0U9tXIofJL4KCjdQ77XV6bZ2WqBorFrzNDU6pZt/RBU8xMbxV7cM18pR0IR0aGwt9J1SqgsXNFpsApXJGzVgDt96RIBu6kConp8kRozRCzNEyStmDj/eC9mpKWF7X+wc5myvhBhZsXxdPko4X+079AEK6kGb7ognCG/ouVIgrkEAKUc4xBjI0EDnyCHhwjOkvLu90lQPGj3a64hv1cwYxLhlXJ5CzxwL7EvK5FLpY/kA3rcmcdcxIlw4yfA1VHSZ1D3hxxa7m96Nn3cGV2hpTP+ehR0MTDiAAAA.H4sIAAAAAAAAAAEgAN//96TVed2w1WtFyoopXCXtge7dl1FbgAlbqBjhjLcKPKZTlB9iIAAAAA==.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 19-Apr-2026 18:55:11 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.VcSaaHnEe4E2ZjngvnFrDMKs_Uk3q8ZPfTIrOKly6EU=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtnthve_XQBkKABseLFnw-lI-xiHQAj5uzvxwkq4nb7tVEvylStQeAov5WZrUrF0rUMsHtt5DgIx4GFMHj5usLC5rGFPWlLyvh92pBpFWe6Eugb4uDRK9qkQifA0M1fLcdweJh_7EQSM2lE6lLFLz42IgZ3tSJ__8hHivsjlvWzreJ3Ubs79eznR90aVGYJx7rfaxZrmEwuaNNLOYG3IsZkP3HQPQeBe0ufVEjz0J1Jn-gtRKxPH8H7nPj5MMsBbTiU=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtlJPe-zvD598D2Oyp5atrEr4AXN7GXuLLrLdPVSB3OQkLxbZtXIrURim4goY51ySMbTsqWhMnzSUt3g8w8tgbwjF1KWpgHXTdeDoUCudCf60BGW8Uawf4mF4SKIykpHFPepuhznNpYEVPAzsS6xtAHirwOAL-iUy3DO0w9gtkVQVG93V4Y9tECGnH93aSM3v8Rs23-0KzFiow7gUt5DU658xkJzr-3Yo9OuFWZ25mZJ0TrkinxG4HdqUyKcOlFKI-RL2tcwssyUwdp2K2C6Rc8pWEW4OWxAgMd-5f9dW1xz1ShAfpjwpK6Unuvh1WL1UN-cc0gA3wA-IzRY55SlvPVPY3JW8w5qs2n1CgZDzpxNpTnzJpwcmkHNQQVlbsel1IhtUjQRYPlrROyvUWLoKliwO4qcJeGHmuJP0NeFT3NVDGS4lDfiJ1isk8qOsMqzP58JTYVlA2pWHWCuTu8cifCp4G7NZEEtsv9pfe9bJro6E-gJSGmurLFx_n7bwDZHsy1uOsIA3s5k-k5VC4euMwd6WH3v_WFAEVoREkWapQpR42hjlvjrYjbQ4lnWpjnSMJJDFm0mbrdsR0iF0Vh2k_gBO7O1L7ZRyAeCEP9S572Z2m8w47ieZgPSZa4wbQqKvHuCpgyhVqzqpZtOpADDjB_RN64ZevqDN9oNbR1XucYOnqqTYnfxW-dAjNq-NlsEBYkP6a2Cu8_HFMYewMlzpcVGVMMNhP-zuC4XWE5GoaMMxxE2kr3LM118PGI1JdTR_ptko9_uYMK44uGLoctoFNMmui6q4RNf1eTb3Scp5anSDBK0qiCeQ1dmnjiosNTsbLcruBWsnCybZIWKgCoFp9og4EUURA8gceqRmEjvRkSnRqEJGV_mw-dkqotoGTbn7av-qv1xt5V6God0nJGS6bby_FXwl5aLqp2r-hRGM6LHahNaXY9zw7qPrTtr-evlb6m7wQqlXj2SRJF7myNgR_-2jfm1XTa9l4AuVTZAwCdf1M45CYwfKYiEJSBE3OYARVyReTd7UhuO1ciT0Yk7ZkD_u0QlD6r5j0Eegj8qbTKYB8P6wIzQDm8YXUQREdp2UBEcWQrxB4QqImNhmHv1nXGQKZ4EY-pef69dPk4aqCFlZyJQYCxwPZhSLNGQvv4XgLoilHWYerah6fYn2uMUfNhqGS3oQCzhEs4YOBOx5eBeqt9ojz_RM4Zea17qmOCNRv4HYLqzhe4aCJ6fXqzwoV2HPdvVIKbctEC1oU1Qlpebf9xUAG5wbrfbKt7lwWv74qRp13E89mRuphkW1iEekPb_01otOxML_YQKcorWIdfjGXasUEo5elsGRTtZruLO3_T5fFcnB5f2vHpK2xa8du-rKxqJbFwl4gVtsra3X2OJb6rTAMLu40UHGeBpI7Ks_i2msqPswiiboLkiCMrbAliGzs6Vyxzqj2Sl7h9StnSc-ury_wuErT8Zgrc1MdmGU0VoFR6TQI8LJQ4GQsGxQH2BrIEDGqDxFF75mJyK5dAXeh64K0_fdpJwWJTKI3h-DEJObPDTUXeGL7xWY8-K8xdnWz0KCyM301hSvU8oLDjrltfAbBx3yNkl3WXaAHURGjlvku07poO0wHyyl7O0NllVcbOwwX4F9n1OGdg3Gl8li9bpP6qhU15EeRUsXDPLUDfEdIaeOUXv0tC5bGItrEnVryiX1T5UzVRFOJjJ5HwrIy9I5WCfJZc3NavLFhlOgaPVfJkt6eElnz6owccovusVz75ye-0BjKQsdUV47P-yal9Lo2NjYw5b7lb0WKYcuIeTFVgtDAw9wlK8Yt2H-3VV4Z-2JKc_J-CK52MbCGhTNRckz0U2eBmxryaaLZLDKjI0umt-oL1YhynXobO-6HroJTrgn8_E4T_Q2Pp19vWLA8m_FdWVgtHYX_pkJZPJxXHHLlV0JCMRRwC5FWTuo_3GdjrJ76Y-K9Gn8H4G8DDfwRZTf1-YRDSxQUe4LrTvqVtoAdsLMbUAooEg5N4fIyGz8Du5D2kVqgSs4rpJexUCUcVCEswmNtqGvZUi9txzX8YuQ72UoyhqNR9cmU7wiN5gtbi71UZCBuBRu2qkvM7USG_iEpjnxthaIaEd3ftp5SnnOCflrtstHMRx8qS_FK_G25F28XD4nC-DUFCzwEFKKMLdtF4YCyu607FiHjKUs0aWFfIE6kJYjj0x7oC5_cE4M24sbr2bCvgwwUB4uoIgUHlSyrk4LAiAMsibkl4rd9MRS6uHb_VysbShqVJkEimEdB0KLzKJgLgJhS7GrSoUEIv12Md-pXIUKRkPDAYQ5MBIUuLR8_CVp9xBJXXsNSt44nfD4Td3BBUVPGjHEo9pQl0GZznPgr1as_b926s_tKfYFl7qz2Sg7grer4bBpqKvbguNqxTts9ftlyx_U4P6csGnWKLSCMGNAjh2QNlySoGlQME-4XHgZfvm9pY_5IXxKL2y9uSJq4FhdL4kyhbGoQ;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCH7gKgjoEEJJA=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=67C86371C69C6949CCDEB03297951CE7; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkoh-qJSBoYSf02eGB9Z01qOYiVTsN0ETjKr7mtSZiyj0fv5twmExnWGtMl5SucirF6p9nzLGQjH2jDSVo6CoicJG6MGOw_Hsd1JalBdrVM3j-32KgRMiw72JIs2z9Tx82JNYvzh41CkuyzJFrSyEIDAEE00g_L7HJAWakkuv-EYwpP5jwuK07atg-eh81QHZDq960O3_Wr9ivBuc8OiKc-GTG3o9HHfYLrf-5mcuQlF7eZQCSqOxBAA9gwd3ngwj2G07lbTsE22XWf2zjX2EuKoOOSTK_z4QiPmHtu0K9vwV0jzKPN7RXYEArFchPYsDZ9PBmhUghqueYRIaiqQR6X-n_9aBkdvs_jHwAZ8DF6R_kT08a8JHECRn196Z8unKlwWFpCQZrMUSCf829GyLY6OcPa4fKh6Rkv8OD3BB70yk3_cQ-tLnML0rqLCSiHH04Wu07KO51mBvSpsZuReKl4sMnkSo4BvDbvQcu_IF0iyi5cF2QxIv_LnKJdPJ0LAIwXL35L-LH6jFSuuTOqgOYfUYvW2Tbe9RCSnANaz5-q3tmZf0b__S9Wuv3GIKS-hJUCCg0m6VKOrh6W7ZPEAh6lui4u3p2tNHlT5jQGDzBVwn05KIgodvL29mATL_sO5PY;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCH-hczjoEEJ1A=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtk2Nxked6MIGSuPbZ76KcSv_7MRqExeNNqJzfDnXgHfgA0z5bE111lcZlL7sQoPDnAFVGmOjbnBZUWwHonHm1FRu-laJ4-oFWQce4M-ZYkbUzdXuyjVJiDsgI1uZ0jA-0HUhGV7govG0Huq3A9ZbTOlQ7ZedmEsraVQTXrbBMlqviUKzhOEl6ArnXyOgHdSETCRU3qXYisnOG1KiPbwIUl0Dw0mBVMrCTEzNTUiKdVWPZfv4pCihqi_vwDak3aDyoSLXkcFubtk9qhfQmiALwmbzCEiUKmYqQ64A89ce4UsG1rTuF15q9kCk88pwPrrXe1zwo7dZgFL3vzN9Bfkr2gyihjym7tu7PP3zXR56xlC85NU7x8ZJppzKP5xlK1wMzUw-A1LRMx5IbqxmEDwI06B3JBy23pqXQm8q-0cwa8LOK731qCJrw2Wz1ZebdjvN__81AvLu1LXbV8tODvlhpR4NhIFCQqPCP7YBz9qjGYX7xHJz6JCBmughdP_k0B-Ptf4EUyghkmw91Gc5n-ZxcYAa6m3rqHpAeJdrvT41Scbht8Kv7dj8PbxgxyB7H277XVIqp9Vx0ImesGlQXnfqDdEBtIgIXV8g947ebyJd_zaUXZE3WWFbFN7gIHnU29AzxZPL1UB34IBz9RJrim1x6lHCudh0V3Zy6zbDXt_0zxn0w;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCH_jPHDoEEJCg=
     status:

--- a/tests/api/cassettes/test_set_vane_vertical_auto.yaml
+++ b/tests/api/cassettes/test_set_vane_vertical_auto.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlGYIKgmf1ZVkMBedbUdMBdw148OWywlMH65mMv15rmiK2XfqerVPLy0xdeXnl2pYDWe6CLftVENLwO2KH0IRGt4tMcXBz8qqGKrkKVFxPfDy1_U7uE4XQ5bnUyRnbGUB-CVsYkAcLOc0rk63ZJOlduqovuIFlz4GDthqyMqD4kvOCuZKn6arbixP1rv0e77PFdNxyueGNbX4K76fuyef8IaPMCQY5GvDDe_v4ZB2GxHy0C2yK7RcAqBb4tKWhnPgE=N;
-        expires=Sun, 19 Apr 2026 18:10:04 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.wcTwwNg-KBs_SUwPi9FXdeWb0YU7iUydzDFFQnbIqik=N; expires=Sun,
-        19 Apr 2026 18:10:04 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCG6gGlDoEEJWA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=a8d3689e-49c7-4909-b0d2-451d99ab45cf; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639122181046712264.ZWZiMzcyZmMtY2RjYy00NTM1LWE0ZDktMDIzOGM5YTY4NDJmMzkzYWY4OGMtNmI4Zi00YWMwLWEwYzQtNDY0MGE1OGIwZWNk;
-        Expires=Sun, 19-Apr-2026 18:00:05 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639122181046712264.ZWZiMzcyZmMtY2RjYy00NTM1LWE0ZDktMDIzOGM5YTY4NDJmMzkzYWY4OGMtNmI4Zi00YWMwLWEwYzQtNDY0MGE1OGIwZWNk;
-        Expires=Sun, 19-Apr-2026 18:00:05 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=9_u7F3gbroDBURteRJdGEKNNucDitLQIUAnBw3VcO0I&amp;code_challenge_method=S256&amp;nonce=639122181046712264.ZWZiMzcyZmMtY2RjYy00NTM1LWE0ZDktMDIzOGM5YTY4NDJmMzkzYWY4OGMtNmI4Zi00YWMwLWEwYzQtNDY0MGE1OGIwZWNk&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkXg7mrfG9qPw6DOXi7yXmdIB6kKX4C5mBTHGhNz8GhdbRabhht_zb3Nqbp72HT5ZxYLj82Z5EZhwsDGrVqa1dyw7EH430UzR6B5jqe8xiy092xX0SWQ4pioFrBfkzgnAoRnUg48Uhap_wOjCJGymOWzqur5O6LKc7r445Lnb_g9ZBnWflYQJ442U2dZORa-i7WHlA0S7VXLIgFs3kjFekgF0SD95cnY6Jd2Imb5omqrXZsrVy_Y5YZ4l8I0oEB6RM7CPU7LK1CwlHmWalxxe_85Cc89JRdBTfL18ejjvlnUZ1mpEd_Y3Ecf6BlgG-OKM122WTuUMXHIlTBNDW8AwDKejLE7afPHZ3nAyeiiC8olA_ztAov7QHjsXPXMbKpYI3YH-aTA_vBm7F0g68Y4XGHJMY9gd_t3Esa_6fmaRv_enOnjktVgnHAMq9SNPkkrwwwqreIuuBZ6OKRrfNEeKaaQ_M4ERMRwJP4soYbdMH__b6Yei3j9ckjayhM27eq7EBR1IfrBtGliWleBpG9xVT3NigOZCyXo4Wuue-neVnekf5GrnPt9_-aVAikPhJMieQjhnCxMm3aR-MfXi5wxM_LB-l9q3tg--uVx6MzrrZyxRPjzdG296n4WHHbTj4GFUBrFIdxOeUsVjStU8_kc-aL\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"a8d3689e-49c7-4909-b0d2-451d99ab45cf\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-fd61e2034977\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=9_u7F3gbroDBURteRJdGEKNNucDitLQIUAnBw3VcO0I&amp;code_challenge_method=S256&amp;nonce=639122181046712264.ZWZiMzcyZmMtY2RjYy00NTM1LWE0ZDktMDIzOGM5YTY4NDJmMzkzYWY4OGMtNmI4Zi00YWMwLWEwYzQtNDY0MGE1OGIwZWNk&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtkXg7mrfG9qPw6DOXi7yXmdIB6kKX4C5mBTHGhNz8GhdbRabhht_zb3Nqbp72HT5ZxYLj82Z5EZhwsDGrVqa1dyw7EH430UzR6B5jqe8xiy092xX0SWQ4pioFrBfkzgnAoRnUg48Uhap_wOjCJGymOWzqur5O6LKc7r445Lnb_g9ZBnWflYQJ442U2dZORa-i7WHlA0S7VXLIgFs3kjFekgF0SD95cnY6Jd2Imb5omqrXZsrVy_Y5YZ4l8I0oEB6RM7CPU7LK1CwlHmWalxxe_85Cc89JRdBTfL18ejjvlnUZ1mpEd_Y3Ecf6BlgG-OKM122WTuUMXHIlTBNDW8AwDKejLE7afPHZ3nAyeiiC8olA_ztAov7QHjsXPXMbKpYI3YH-aTA_vBm7F0g68Y4XGHJMY9gd_t3Esa_6fmaRv_enOnjktVgnHAMq9SNPkkrwwwqreIuuBZ6OKRrfNEeKaaQ_M4ERMRwJP4soYbdMH__b6Yei3j9ckjayhM27eq7EBR1IfrBtGliWleBpG9xVT3NigOZCyXo4Wuue-neVnekf5GrnPt9_-aVAikPhJMieQjhnCxMm3aR-MfXi5wxM_LB-l9q3tg--uVx6MzrrZyxRPjzdG296n4WHHbTj4GFUBrFIdxOeUsVjStU8_kc-aL\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"a8d3689e-49c7-4909-b0d2-451d99ab45cf\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-fd61e2034977\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=7a7ce3a0-be76-4017-89f2-8f1e9cd34543; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/4yDqxvnLdH+neZ7koD8DZM/aChzrJvRT5MuVniDBbTM5pyd1I+p4xzdB+QPw8vmvFXWc+kUzhiDgXiSomJDKSewWAkFFwiI/FGCwXLFz5QQpu+N25soX+abZD8UcklW3OHxS0E08Wja6ZlZLOOcaUwv1GUsjpg8KmoxKzmx8tItIdgJbdVcRLLdKociIaXWGQ/NIn9ryyfC3Y60XZM3mLLsnkmLwwPodlASXDi3l2j17JGk51oQebAtmnWhHEFY55avh+V4qpeEpTzO/4cCS/xOdWhLJmfg3iePjhZIOs3WVstE8JBbiAAAA.H4sIAAAAAAAAAOtTifXW+fO/pedBtHzrTQbL21MfGcle+1JvEbzjgulTppMArEDTDyAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 19-Apr-2026 18:55:05 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.wcTwwNg-KBs_SUwPi9FXdeWb0YU7iUydzDFFQnbIqik=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtlGYIKgmf1ZVkMBedbUdMBdw148OWywlMH65mMv15rmiK2XfqerVPLy0xdeXnl2pYDWe6CLftVENLwO2KH0IRGt4tMcXBz8qqGKrkKVFxPfDy1_U7uE4XQ5bnUyRnbGUB-CVsYkAcLOc0rk63ZJOlduqovuIFlz4GDthqyMqD4kvOCuZKn6arbixP1rv0e77PFdNxyueGNbX4K76fuyef8IaPMCQY5GvDDe_v4ZB2GxHy0C2yK7RcAqBb4tKWhnPgE=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtlKSZtjYByYCZehePYSkblrOkAGfp67TCCX_JLgYJRc9GXbXEQIuc62RiAPWOa618i953oubrnICbUnqfmXdH8CmOKZi0YY4LtxnZ5wCT9Kay_EDKUhVWlsS4y07Ay-kJAGy-GSprEDQrB7KIfmujEHFHTvFYQyfavmFO4AJ_xBRmUwF26bp9u7kDC5LPEUfl1jdG5c2bHLqCZnKhxJCKsvIGEwBcAGROKMiYrHgaUCHPNL05Un3b6TrGHYhlRDq3jZStiPqGfhVm6UHxGh__AOu0fwlhroKB-nrbjV3rUQqGF0X8AE0bwSnxmjIWeSrP-_jYNR563mqjUSWWbbYKnec4atVj8_4D5zJqNuf01aSEsU2uv_o4hh4VjmQZ5bVB27hCKg4q19FTJaUBu2w0afmtivQ7hPrvlRabi8mqimPKLZMan-fsePP8iOxPKX0gvKy7ZdbzgB3_l22x7BJQV5M0ho_AabKyPY515c9JIhIZhcwvfHKfDeifYQ0RE9OSN9iyVBQ8z6euJxeOgcPT8oJT5AShu8_edg8OHQWdQ4xbe9shNZirvIjdAgYdGLEm38EB_fUbha2dL_RN0yOLh59G6AHXKlncNlArj5lp-KxR7ZwQHb9jcCn9GRn_CfULgbY51VhlDi0iGOuzY_0wVW07kS4mqHPpIuda2y7pftRbmiaXfArT3z8c8zy9j3bELbmMbI41mL9_f5oAYy6aDzX4hU_0fqz5oejLyllxDr-H3WeY3Aod0f1AfQHNqlrs_77Znwm_lX2UyqLpE5v24eM8uMYxCeXGJw_wSIjOG76l5NDuc1ks0CDKawYCXNmB7DTUtELewPNjPgqvopSRkEUY1jKPnI8OgrE-sHIbjyA3CEclXcbLJTATvGRq3z8Xva6txmb7fGYYKmApvVpaXV86RFGEVld-U3Tjyv_1-K8BI6krjwGmKng160Jg-KNDReYVWZmY6MAOGdZaSH319qJUIegISwGNCxRdsEZPiyee1kryQxrSuKZsNJ97R7NSvP8_MR338FwIZbFyCawOdZogcp9Ye7IrLkzUTNSHFn-VBmBRiv_EApzym5RM2Cq-uydauFXjRvzCy4-gTlUDkOVIoJ_m79t4ejCQpcRy1bsbg4cccp9fYYrWCaBWxNfFEbIbo3nCv5XT5pjR2aNMJToL0vR6EcA8NS9Yi42qtoBQDyxU6WjK4q2nnLEErF1dfPiQw4ET_cBOrRGsqy89xR8T_GOfhnEnb2dHawLe8ESM-RkDY3k5BgwU8c7JZtshGqjDKDay08_41pbUeuZFpGuxfAL7Yp-9PCx6MhCres_9X51vZCzWpCy03yDXQpOSCzgQ1foZzoal9Fz4dreb8d-AiG_ejiTIXFRYnhvrn2cxEwvdnlUlaQXdTRypBPpTipf6Yn-3tn-wNDD4rgVVCy3lHWvB3zMB0YmDQRAEsF-ucjNHFJvpculMRrsT4Pwt4vZMSyx6t07fF5f4oVUivF7t8WjmwA5TWtIn29HMgp0JI8LargUlx5HOTKetdv1jisnbqg6u_4KmHVfy0jqb8j-djsSEPnDr-vif7MmxNSQVMZPtoj8SdCaKJNCmPTO0tPSPmPUeVeuWI4uNn5UqnqJJXDSqaacxI--YsVSweJDGT9ekJVteBhlmDZc45rvgD9i4ywM3ggh0KSga4kcuetr0w1kLu4T6ZLJ54X87RezO-NgzzMnCSG-Qa9lvHiiwaY6OgPfD5irwqpZQtHut4IyhJu3yRIrZ0UVI08lPP8XMyzAvEr_ARvDBijLjbRvLouyPC1MGb0-2snKK7hUBttnYj089meY3BEhE3xF5aA42reVeTYEboeyX_Kkp3-bXty514y0rQtaPe-E7UkXXdYZgBCC3EeQEZKw6JMezNnIJ_fu4h_2eOgoEPrxcfYxzA--tOMc2RkDOQtqNsVQWSvdHC08H2eXc2z_KOk5bB0ikd9w98DV1rGlIm235HbeLo_XxyQdteTS1UkLxGBay_iqLfRbljeOmQeIGFN6w9lOrnPWagBYxhWb19wSVcgSy1AjAkn3QGNFDeSE8wIyFjpCVDTtvDJta1L7NrAD7IJXZlB0_DjNHRnAUOOwk3NoFf-z47bXjj1gNKrc0vGMDit2y6fcMvRodWGILtQE7RATZGB_ym8GEXUi2qOzudJmuSd4vf0n5KR-CzC2eHVATIsWjXHokxzjkBg8wCHVSVPQQ1H5VZA7FhwSZBftURqekJAd4-g2FNE3eXNdFq13_WIBLBr5r0ZvALjdnIvHErbFOIHP9iHgW4rkWOtKY3mLxqNYL58zMBJWFuefpG3D623YKEYxaS0ohQmCE7SKSxi5iwoYtpBKdDE_h0lyBpirhUEGnwqgV9c8GUi9nyz1QOLz39AbEEIyR8n9Y0eHv3X0Kvr2afDXOfv2Q8_z8BxtaCP2gwOaPZiRFtkInXdK64jGQqzU2LJXwGvk5rDOBbouA;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHEh-lDoEEJ3g=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=3DA9798D7D395D0BD07053DE361F6962; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtme8e7LaGOzx5otoA7-O1-3wanV4nf5uKMZcziewwe0QsoWDQCuXlD3hCaFEqVoeXK_sN-nJxf-8hJ6dsU6aDbU4o6B7_wCbavlNPxN_pKfuAq3_ipJzeBP_zli7iRliAFzZ3J5k7FNL9vtIrAUV1neyYHvzN3vslAQbsIsiHDAQI-kFoa4AoetknorybcFj6TTahLGY8gk20TW7z8JPvhtEN90XZwtx7IlpVMMPFvgi1Z00RmQ81TUmoWe-hZBx9FwJw5b-hWu2Mu60Syr2UCXQjoKgR9B70vNE8WD-VA9TLLsnqLCxU96tn9u-Y9O-s6uQSmvyd12_C2x59eiLkZJuF5lYo1gFlFKnvTOMdR5T1N4bUJT8KcmbkGiKYeavr_z091lbBj32F95eqEf1bOHBMPy7W-fwwOukMbXoUVKczGwoz3cyhvtr4fF-TUn_nelH5T34hmD1ODVMGZVaB3o4XXADUDOOE8fJwWEFWvfDpI6J-RT7QKuEuova-c2jvRrVOLbGyP1RPiBJWTAQByg7_fItCCd5HaRZTWv7TGOuULeHNGJWBpMHer1q9MlhSQ69SfGiyNIPAQEytTnRm_crOq6IT-AI4r9JoaXB83oazOx2Yuhaapk8zLdicntxtI;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHGgpoDoEEJ6Q=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkhNsCxirn4mYRQbXnxQDv8J-3DMaK236_gPHnjoooIXJOrLrSskdVOGWTZRR87RHe9CxeYswFxd9CPYR89T8XX4TvzNhln1vl717XL0FUkWVMtC9U-H_uI12Bpv4d4GsTX_fsrHUbcv6-r6mWiEBAR9igIsnU7NjluJPLJr6u9aH0eK-RyoZadFc48lxPa1WTgG1ofGff9pzOpDaW0LZgJxxmYoqfXHLnRRQW5IDj2pSb7_SvMbg8RzBuKwNoNN_HxMPyNekLXliZ-tQru9S6LsZEm_C89HhYnpssDBRbLgKwJYCgj9Chiq7Ck9KG9IJB90KEIEhALD6Vm-2tF9s9yuIkD880Jb2mIGPLZk5lckpvz9KGdu4pyWMmy6YjZQqLkJhNj9gcENDq6Xry6irk0eI37_aSoPYrGmRi5enRPj0GoBdbiQeNXbMvsVm3XFryzM9H4ig8SFb9t_aMWakIZgqYPjhGrW04mGtm3MBcWozGeN-i82Bfbs-ddjWgLY0zWLypPcAwQXsz-tpAdgB8YBtdSLFEZpmtodg8fZWRF7UVECU509ISayC-K83JgVLx6w9sSalgebIXg7_2fvlCCaX-o0xp1uR1OrNxB95lpW8BRYYejZZ5cOvQbgCOUhp4gAguZrTFhqtW1uNYflczA2ffLDfe8-d6cPjAW9c6eHg;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHIhJhjoEEJYw=
     status:

--- a/tests/api/cassettes/test_set_vane_vertical_swing.yaml
+++ b/tests/api/cassettes/test_set_vane_vertical_swing.yaml
@@ -127,11 +127,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtl7AOK5MQ01oQxZoDxW2t32uOrM34KlPf3CfSoXg7ZraUDnFVuhZkyc6KH_L_f0xdk69wly6-E8nvVx6S4xPiI-NA5tmf4uf7VLqWB0c9cju1DAk7TkbVfG-3Od6bInKieWAUjNQqL6VPCqieFs1WjeZi5Wlm7zYMd8I6UVUnnyQv_SvGwGZ8EeiaEXkCM-ThCglkRdLfzHPr4up0mdocuDIh5nNVmULtGAn32N4AKP_Es1nwjwrk_H2_XYptC3fz0=N;
-        expires=Sun, 19 Apr 2026 18:10:06 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - .AspNetCore.Correlation.L1BLoq0Z2ftfPE7G2Rd8110KEQtDq6ydhPusEqI_bHQ=N; expires=Sun,
-        19 Apr 2026 18:10:06 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHQj3IDoEEJJA=
     status:
@@ -168,12 +164,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=9d5bba14-c17f-4d66-82a5-cdd22a7a2adb; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - csrf-state=639122181068769104.NDMwMTNkNWMtY2UwYS00ZjFiLWE1NDQtNTkyODBhY2M5MjhiMDcxMjdkZWEtYTUyZi00MzllLWJiMzctZmVmYzM4ZWE1MTY2;
-        Expires=Sun, 19-Apr-2026 18:00:07 GMT; Path=/; Secure; HttpOnly; SameSite=None
-      - csrf-state-legacy=639122181068769104.NDMwMTNkNWMtY2UwYS00ZjFiLWE1NDQtNTkyODBhY2M5MjhiMDcxMjdkZWEtYTUyZi00MzllLWJiMzctZmVmYzM4ZWE1MTY2;
-        Expires=Sun, 19-Apr-2026 18:00:07 GMT; Path=/; Secure; HttpOnly
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -247,7 +238,7 @@ interactions:
         profile&amp;code_challenge=mzxwgSkH1Shcu1_u7WJc6PPk94OnJk-9j9znBwkgcg8&amp;code_challenge_method=S256&amp;nonce=639122181068769104.NDMwMTNkNWMtY2UwYS00ZjFiLWE1NDQtNTkyODBhY2M5MjhiMDcxMjdkZWEtYTUyZi00MzllLWJiMzctZmVmYzM4ZWE1MTY2&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmjfiFN9p6Dr4mYIpKvxU7QZtDmn5joE4JNcdG45MfytnzarItiJuOm_bP5d31ObCH52XrdBprCsNpG0ofgaB2nigMPT_tMKenRjgh2dl1Dq0ndBM7ehQxD8NDCyNdeeWOyl3qmy5ppDCQUhch_qIbwfxWC5iCta5IppHEVrWvxRcdleNvBm6MsEZ_M9cj26oFcJlHgXchmJqoxv9KOqV5V0ub8ebsbn07Mt7r0AXG0k-WMfKYVyCR9lQ2geqOIfWIy7_fKEoaW4OE-EI7hZ0SrHhRQA8LMxQTCZjrTWrJXv9q9SjCW3f7g7qMT6r2QiRd-8ehuLJJPAVtiqSXjRuqB8pd7b2Kc__czGnAaZ53MkSFQg4j9X8IobXrlNR9qOcT-lkewRNsmccFTfdHN1W9x5cae5ORRdOJT2uXY8ohAaOGyodmargs42FsYGiSFp1-EMGrlcUv3k95WvJvNErMOe9CTnjtFzUFArC7F4XhBkhL3JITJGVgKyHIRKy2bmoz07cyFnKyM6WYmSQ-UJXfKvwLqwywiqbBykTiwnPiiaSUBZTzDXsWJp0x82GiLpyccvYu2wTBTECZTWRxx0ZkT8_ZunMOd1kEmJTmuxICL3A9Sh64xtU5edZcuaoGwkhkOrrfkKiVAOUnuVlkgx-Xc\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"9d5bba14-c17f-4d66-82a5-cdd22a7a2adb\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-1925c50e4dc5\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -277,7 +268,7 @@ interactions:
         profile&amp;code_challenge=mzxwgSkH1Shcu1_u7WJc6PPk94OnJk-9j9znBwkgcg8&amp;code_challenge_method=S256&amp;nonce=639122181068769104.NDMwMTNkNWMtY2UwYS00ZjFiLWE1NDQtNTkyODBhY2M5MjhiMDcxMjdkZWEtYTUyZi00MzllLWJiMzctZmVmYzM4ZWE1MTY2&amp;state=CfDJ8IRLia7XffNJh2SAFm28gtmjfiFN9p6Dr4mYIpKvxU7QZtDmn5joE4JNcdG45MfytnzarItiJuOm_bP5d31ObCH52XrdBprCsNpG0ofgaB2nigMPT_tMKenRjgh2dl1Dq0ndBM7ehQxD8NDCyNdeeWOyl3qmy5ppDCQUhch_qIbwfxWC5iCta5IppHEVrWvxRcdleNvBm6MsEZ_M9cj26oFcJlHgXchmJqoxv9KOqV5V0ub8ebsbn07Mt7r0AXG0k-WMfKYVyCR9lQ2geqOIfWIy7_fKEoaW4OE-EI7hZ0SrHhRQA8LMxQTCZjrTWrJXv9q9SjCW3f7g7qMT6r2QiRd-8ehuLJJPAVtiqSXjRuqB8pd7b2Kc__czGnAaZ53MkSFQg4j9X8IobXrlNR9qOcT-lkewRNsmccFTfdHN1W9x5cae5ORRdOJT2uXY8ohAaOGyodmargs42FsYGiSFp1-EMGrlcUv3k95WvJvNErMOe9CTnjtFzUFArC7F4XhBkhL3JITJGVgKyHIRKy2bmoz07cyFnKyM6WYmSQ-UJXfKvwLqwywiqbBykTiwnPiiaSUBZTzDXsWJp0x82GiLpyccvYu2wTBTECZTWRxx0ZkT8_ZunMOd1kEmJTmuxICL3A9Sh64xtU5edZcuaoGwkhkOrrfkKiVAOUnuVlkgx-Xc\"
         method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
         onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
-        value=\"9d5bba14-c17f-4d66-82a5-cdd22a7a2adb\"/>\n\n            \n\n            \n
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-1925c50e4dc5\"/>\n\n            \n\n            \n
         \           <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
         \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
         type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
@@ -379,13 +370,7 @@ interactions:
       Server:
       - Server
       Set-Cookie:
-      - XSRF-TOKEN=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - XSRF-TOKEN=599e7283-12b9-4087-ba9d-d82d14888647; Path=/; Secure; HttpOnly;
-        SameSite=Lax
-      - cognito="H4sIAAAAAAAAAAHiAB3/y1+y0/XUJ8B531cxyvwZk43T5TAn9ALzqT+Y7SaSWK9Dgh8GOOe5I4j7+0uEe27RdMAceShCYSrw0MduVrPBPsvwWAADKT3uQ/1VICUBAyJJyzzvK6wg2RLbsFESveVdD0Jpp+Lirp0qQnR55ss3xDc41Dku0j+Is22/5CCcwrtONx8s+hkLWMPtTy3CmA55FtQLzCEtW/3IO+DxfA4PTcjU3fAQmwQPe6yLxqZL31k3ADPQ5zLbgMoWGF2bwsGsEjVHbYlMG81NHYOQMcKorzksLn+nW8fUtWw7z7SwnsuNqkv3YCviAAAA.H4sIAAAAAAAAAAv5/YZNXnvDnUWRJfb6v+svqTqq2PpOfRyvZHjk+fp0Pm8AFjtgpSAAAAA=.3";
-        Version=1; Domain=live-melcloudhome.auth.eu-west-1.amazoncognito.com; Max-Age=3600;
-        Expires=Sun, 19-Apr-2026 18:55:07 GMT; Path=/; Secure; HttpOnly; SameSite=Lax
+      - '***REDACTED***'
       Strict-Transport-Security:
       - max-age=31536000 ; includeSubDomains
       X-Content-Type-Options:
@@ -441,13 +426,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - .AspNetCore.Correlation.L1BLoq0Z2ftfPE7G2Rd8110KEQtDq6ydhPusEqI_bHQ=; expires=Thu,
-        01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none; httponly
-      - .AspNetCore.OpenIdConnect.Nonce.CfDJ8IRLia7XffNJh2SAFm28gtl7AOK5MQ01oQxZoDxW2t32uOrM34KlPf3CfSoXg7ZraUDnFVuhZkyc6KH_L_f0xdk69wly6-E8nvVx6S4xPiI-NA5tmf4uf7VLqWB0c9cju1DAk7TkbVfG-3Od6bInKieWAUjNQqL6VPCqieFs1WjeZi5Wlm7zYMd8I6UVUnnyQv_SvGwGZ8EeiaEXkCM-ThCglkRdLfzHPr4up0mdocuDIh5nNVmULtGAn32N4AKP_Es1nwjwrk_H2_XYptC3fz0=;
-        expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/signin-oidc-meu; secure; samesite=none;
-        httponly
-      - idsrv.external=CfDJ8IRLia7XffNJh2SAFm28gtlLAzA34uH_PREs89bYzbI0vahJyu5EDCg85h7dRO0sTF53ElFoLqsQA7g6Vj3ZUS1Wgdqp0vT9bbJ03UF3HqjqX7OptPOz_O9EhqUi5FJ8duNB4FzyC8LJxF1abo--lrKvHlvOPbwytFOCiZGhrwnyDpwhOlk4Xo5s2Su0yr9nfJKMm47HA7XLoJX-2xl8t6YXe9nz-zOD2iB1_PeRvdM6zCmVvDXLKmyamIQxsqFuosA9jojYbGrnA_pFTB6RI_TuN0a8f5AZ20cZ01HnkSQ4A02KLrrJEy9gUeXAERKLf_R61YCbOETjBCZF3R0TSpqp_ZiPN8y6eJHxgTGX2lYdPetmG8rnIBJgCxFiKuQ9psl6ep1g-Sf8vfNep5BZs2HU-vttfcYqrViTxyNaZ0mwh_qblWPyc5uw_NMDbkJNW1M06Xoqn_hC-f-nXaKhGFmK4UO1bR_fGv15-xtdAJPpwrpzASabpzYSE7EaJBWvyYEGh9730Er1m44j54gjkA1zACTjmAfm47uPgRXgyxox9bs-qJ2H6CWW7_COy4_I3c9p2vbsReCSal37_xUpDU4tGqFIfXSrKHHyudRyXDoAoOT4LA_XBlgqBEBuoDRbN0MiwQi2wlxiYiIz6loBDf8omZ-BiaiRUtB2fxHHw4lnHgdAAwypnUO9zN-vOsBWF0MTVC5In0JV0pNV6FQChQ2IWun8JGokEYcCc74_vMohfWe8hLGPVzE1cmQXufpqL9ScQbi9q78Y-i9wkJI-AZ7-RROeRCpCQuoOdDkiTp-BZTxyKq3WZ-Yi5p8M2tn7WWswME7ngee3yW_vUZ3L_VM5OuaYcNoDhsxuMD1vBMPBLsue8trjsexeF2WxwmqmtPO23slDAoHFwwIFnJEIxdadFIIIniMim7_cl6xUVsdaH7MzjnNrYqJHGCrOrbqyzdfD9lK0qTVbdD-ywr9rs4vUe6Vidt_6GSMygEI91OK3_L3uo6CDof_dcrsl3YJdgfm4uYCDo0LgynPv4lVTt4JdiG0yRxPZr5n8tJcigcgWXFD_VkcdFJSobNGFgXt6N8ZutvAJWUEYbbq0EOTlO6T0EdCMSzgdVwB-ZGbHVGXtedFmbzkPPPtuvpR6qZGMd7zq6O84LC5A23CaksvPimS1ZFAJA93unzXhBrlCFr9ZkUPrEKjuycpnP3hkcMvRM9R3jyNsG9C6X96zZ9UuFaZUOZGKYstpnmIlxO948L7gcArFokI3_mPaRDHNu6HUDqPSs04iO9r9GZABr8QZ1gy2EBjRDVu74rp1Xn_qzupvHHTzmSLtClk3GHP2bce2zehvX-BOf3i-oJ9yDRk8WSl38Mm_7sfQtpqwPs1WCDiVaNHQam8Ox3vANLdLO9Wu9VxRMuCIjW77qqaSRcD-6kVpIFS171TYsjw81LflC_gI9OgrRdcHluDeAD8P3B73fqgzJ4xDPQVgb0V3-ksrTpsPuttv9XN3w-D66ORAXrE-87chuBkMt6AJEfKCFt-FwNn4iBdZn9qHfIEakhTq7XKg-obLNdfkXX4Js22zr__VH9FTn04rmaBPm4F4SYwiIJ9ftgYu-J9ARb0CU5u5NMr_8B1G2elaUiN3pqI9RyZcKTEQLcLbOSSRF7nbVECBil1KVXZu5fcwfLS_5FDq7uaXgTQKW_X6CGXFPtJo3R5pgOcKhLYy56Te5IlfIqs99XUWyKO9C2F855NERlbl_ZV4pQGvOAcsHGpRXg7G07FWTFAxS6x-6GMT_fSDTJa-BxgJ5w2FSGKd_9cHbyKJ5oy8c-rAKktvGMfpTkvPhD0wZpPx3nvCespBGOllUxH7Ei5EvCPjPwU_WrdBytLNABDUOtbKHCMHp7g7ZN4cT20AoxeeZN05pAV6uYcHVg6Cpxp4njaZ965Pxq93T-OKkHqmdLifEV6GLh6l1RLXYxEl3P_vyuFnzx7vMsJ0LoOAJSKALDdWX6BLjhUIGu9dgmA-aqdOuJvhU_-_ghjK7-i07m8T23-O303Ns-751uRUgzhvnKUORQLJiTzd8fGLE9LEW65gNkQ85krwhUPdX788UYJlXpkiP1dh_kYFyQsS35koptnBDa6VeYGosmeowy3D-lj1UxTdMQnDWybyb-XpkuYiqVCSM9YTjJ0ucmBIYOYuHVel291l731buesO0W5NARUWa44yHcLGZww51eRSBinabU9Bt47HTfwBwfbV2MreKjiufgJMKqgcTt4fIDTwMzek80L-gvp_UzzYN8LBPLvpsAbf-6IwpCvXKK8r0bbJhT3NdpcU2g5V911GLYG47WJdkFmwyEhnRg3nPXEBCBFeKEe5utl42xiLinz2zEwIu3FcIziCaalM0mbNUCZdaTGtAm0SV9SxO4JmxT8011UU8MLYgE_Mv4p5BQRLrchpCBjuqjY-jjvF-hyzEo783RTihV5AO_BiYYUMfw0vHKFZmlKWgEML3ceokRa4nA;
-        path=/; secure; samesite=none; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHYiobDoEEJtQ=
     status:
@@ -495,11 +474,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - idsrv.session=6453111BBE274BC6969C0549F46757CD; path=/; secure; samesite=none
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtkikiXuHruiturnpREaJ-Vw1VaMjFEdMimZ-gxfM91pcKmaJe5DptxqYY5oSpQjBwYa8lWFgDn7UNLOWHAG0jCPB7OopzNt9iJ4mt8ubljMrX01s_EJemaYbDbY1p8aTOTjywlatftZ5rTU-4ZQ9bnHKWvz1Y4R-ksKSvdCmR8DdwEiXQ-qVcAZRUi-Kl4QYvN5BLbV3EY7GBGJB0WNWWePJiCx6TNTD_2ntMVyMxzJe6szXa4_ia1dlbAdOK3GsWYA_0t-mOlZ0Ek3nkJWhzSoojany9_JwHjrrJRhBLb4Fs7U67KAUaJ_IRXXHPT419Rf2mGG1kA-o741TIpiY7FqIJCQAzjuGbn6e1xiovZCnNcG3YNKtkrE3PdARethOZdNrs3xv5E1tIDdVALRuW0CJSaR2s9H2vcBEbAg9JDev8zydHPuR1KsXy2qBtJR6cj3My6j4_-hNzHYztR3MAkNgMtgxKjd5Zu88NiD6PZuEeaXVBF3RwUdPcVGGzRtRcW7b2Tnb2hfgZsscQTYpQW_TrlRrJwTU1FDjXovKaKhzGFedeKU_U8QAdZUSRNaYZ0LCrijxM2P6OGYmU1brAWiywgNILihmc_MpjTv92Zpc7vtjTYreEtpxl1ngIou0AE;
-        path=/; secure; samesite=lax; httponly
-      - idsrv.external=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; secure; samesite=none;
-        httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHZibJjoEEJsA=
     status:
@@ -603,10 +578,7 @@ interactions:
       Server:
       - Kestrel
       Set-Cookie:
-      - ConsentResponse.7IM8S-vnAEq4zlx2-VFNpeXFYSIpVUhSMnwOESEh5uc=.; expires=Sat,
-        01 Jan 2000 00:00:00 GMT; path=/; secure; httponly
-      - .AspNetCore.Identity.Application=CfDJ8IRLia7XffNJh2SAFm28gtl7W0MGNdVvQWg54JmBhe3fGkRYzDFxcJcfmJAuFNXJShKdfMkKLjpBGyEF2MPhniUUSjFZ-pQ22cBO2fN_2JK81n71OrR7EsiEA2gUlhvyvSL8O9eVj8hDOn36WIVEAWMFUrfle5LvEhQuoE2W3p42TJASdd7wpuhxjwFyt2oar-76dfRmJyrjNrGdqG86iVN96956HpxFVKvu7jgwBaIjD3fI6DpcjtwjtPxKgBmw9zhySq518CiA0OAgv6xxqANXOp5_wOrnB5ESwm-emgD4BC61L__TDjIc5G3T9yfd6u3hTJbIhu2vLxjiyQz1IEUUhweQa6cKSmWZP10JpgBaE8PfZEF-8nw_IyFszR6mC-jo09SRPxVqPEYSWdNIn28i9BUugqT7tggKPcb0aDp6yoNHW-ibMoAcTtFZgi7AgRPP__fS3GYV8a3Frk6-fIN6k5am24-_zJQEhMEG1uSZQGdaWo1FXchVY6VmRO_oxqzBgC7pNUbHDWcnmHUF-n1SSmPKqVPcgrlpVYeQXRdOJ3nbeOJzfeVUalNHsRHdJGwu6l0EF1DZgYCqm1evRRq76YrYLFl2RBi828f-mDvExo_54qnhXPZZS2BCjSZk7Ffr8WW8SMo_wwTRS6f4DpPtjLVOSXcljp2CkKyD_Ju4hqmJuNeMqJgP_w1bSPEEyA;
-        path=/; secure; samesite=lax; httponly
+      - '***REDACTED***'
       apigw-requestid:
       - cFCHbhqyDoEEJxg=
     status:

--- a/tests/api/test_cassette_scrubbing.py
+++ b/tests/api/test_cassette_scrubbing.py
@@ -1,0 +1,41 @@
+"""Guard against re-committing live session credentials in VCR cassettes.
+
+The VCR scrubber redacts response Set-Cookie headers (tests/conftest.py). If it
+regresses — or a cassette is recorded with an unfixed scrubber — the auth flow's
+IdentityServer session cookies get committed, and `.AspNetCore.Identity.Application`
+authenticates on its own (no password). These are semantic secrets with no
+recognisable pattern, so gitleaks can't catch them; this text scan can.
+"""
+
+from pathlib import Path
+
+import pytest
+
+CASSETTES = sorted((Path(__file__).parent / "cassettes").glob("*.yaml"))
+
+# Session-credential cookie names that must never appear with a value. The
+# recorded Set-Cookie form is `<name>=<value>`; the redacted form is
+# `'***REDACTED***'`, which contains no `<name>=`.
+FORBIDDEN = (
+    ".AspNetCore.Identity.Application=",
+    "idsrv.session=",
+    "idsrv.external=",
+    "csrf-state=",
+    "csrf-state-legacy=",
+)
+
+
+@pytest.mark.parametrize("cassette", CASSETTES, ids=lambda p: p.name)
+def test_cassette_has_no_session_cookies(cassette: Path) -> None:
+    text = cassette.read_text()
+    leaked = [name for name in FORBIDDEN if name in text]
+    assert not leaked, (
+        f"{cassette.name} contains unredacted session cookies {leaked}. "
+        "Re-run the scrubber over it (see tests/conftest.py scrub_sensitive_data)."
+    )
+
+
+def test_cassette_corpus_not_empty() -> None:
+    # Guards against the glob silently matching nothing and the parametrized
+    # test vacuously passing.
+    assert CASSETTES, "no cassettes found to scan"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,9 +259,13 @@ def scrub_sensitive_request(request: Any) -> Any:
 
 def scrub_sensitive_data(response: dict[str, Any]) -> dict[str, Any]:
     """Scrub sensitive data from VCR cassettes."""
-    # Remove Set-Cookie headers to avoid storing session cookies
-    if "set-cookie" in response["headers"]:
-        response["headers"]["set-cookie"] = ["***REDACTED***"]
+    # Remove cookie headers to avoid storing session cookies. The recorded
+    # header key is "Set-Cookie", so the lookup must be case-insensitive —
+    # vcrpy's filter_headers only covers request headers, this hook is the
+    # sole scrubber for the response side.
+    for key in list(response.get("headers", {})):
+        if key.lower() in ("set-cookie", "cookie"):
+            response["headers"][key] = ["***REDACTED***"]
 
     # Scrub response body
     if response.get("body"):


### PR DESCRIPTION
The VCR scrubber's response hook looked up `set-cookie` case-sensitively while the recorded header key is `Set-Cookie`, so it never fired. vcrpy's `filter_headers` only covers request headers, leaving this hook as the sole scrubber for the response side — so recorded cassettes kept the auth flow's IdentityServer session cookies, including `.AspNetCore.Identity.Application`, which authenticates on its own.

The affected recordings are from 2026-06-11 or earlier and their cookies are long expired; the freshest such cookie (recorded during this work and never pushed) was confirmed dead within ~24h. No live credential was ever exposed — this is cleanup of stale material that should not ship in the repo regardless.

Fixes the match to be case-insensitive. Re-recording needs ATW hardware no longer accessible, so the existing cassettes were normalised offline through the fixed scrubber — exactly what a fresh record now produces. Scope is response `Set-Cookie` only; request-URI OIDC `state` params (dead single-use CSRF values, matched on for replay) are untouched. The pass also re-pseudonymised antiforgery UUIDs left in response HTML bodies that predate #206.

Adds a regression guard (`test_cassette_scrubbing.py`) that text-scans every cassette for session-cookie names — a semantic secret gitleaks can't pattern-match. Full API suite replays green, confirming request matching is unaffected.
