### PR TITLE
fix: always create outdoor temperature sensors (ATA + ATW)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Requires Home Assistant 2025.8.0 or newer. On older versions, HACS will not offer this update — upgrade Home Assistant first. (#185)
-- **New entities appear after upgrading.** MELCloud reports a frost protection setting for every air conditioning unit, so each one gains a "Frost protection" sensor with minimum and maximum temperatures — even if you have never used the feature. "Overheat protection" and "Holiday mode" appear only on units where you have set them up; if you set one up for the first time (these modes are managed by the account owner in the MELCloud Home app), reload the integration to make it show. (#205)
+- **New entities appear after upgrading.** MELCloud reports a frost protection setting for every air conditioning unit, so each one gains a "Frost protection" sensor with minimum and maximum temperatures — even if you have never used the feature. "Overheat protection" and "Holiday mode" appear only on units where you have set them up (these modes are managed by the account owner in the MELCloud Home app); a mode set up for the first time appears after Home Assistant next restarts. (#205)
 - **Sensors show "unknown" instead of "unavailable" when a reading is missing.** "Unavailable" now means only that the device cannot be reached - MELCloud down, the unit offline, or its sharing removed. A sensor whose unit is reachable but has not supplied that particular value - outdoor temperature while a unit is idle, for example - reads "unknown". If an automation of yours checks these sensors for "unavailable", update it; templates using `has_value()` behave exactly as before. (#222)
 
 ### Fixed
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Room temperature and WiFi signal sensors could go missing entirely. If Home Assistant restarted while an air conditioning unit was offline or not reporting, those sensors were never created, and only came back after reloading the integration. They are now always created and simply show as "unknown" until a reading arrives. (#219)
 - The "sign in again" prompt was missing its wording. When MELCloud needed you to re-enter your password, the dialog appeared with no title or explanation, and showed placeholder text instead of your language. It now reads properly in all 13 supported languages. (#209)
 - Heat pump flow and return temperature sensors could be missing after a restart. They were only created if a reading had already arrived, so a brief connection problem while Home Assistant was starting made them disappear until you reloaded the integration. They are now always created, and show as "unknown" if your heat pump does not report that particular reading - if several of them stay "unknown" permanently, please let us know in a GitHub issue. (#220)
+- Outdoor temperature sensors could go missing after a restart. The sensor was only created if its first reading happened to arrive during startup, so a brief connection problem could drop it for the whole session until you reloaded - and on air conditioning units that share one outdoor unit, one could disappear while the other kept working. They are now always created and show as "unknown" until a reading arrives. (#226)
 
 
 ## [2.3.5] - 2026-07-06

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [CHANGELOG.md](CHANGELOG.md) for full history.
 - Sensors (room temperature, outdoor temperature*, WiFi signal, connection status)
 - [Real-time updates](#real-time-updates) via WebSocket push, plus 60-second polling (30-minute for outdoor temperature)
 
-*Auto-detected from device capabilities - not all units have outdoor temperature sensors
+*Always created; reads `unknown` on units that don't report an outdoor temperature
 
 ### Air-to-Water (ATW) - Heat Pumps
 
@@ -129,7 +129,7 @@ The integration creates the following entities for each device:
 **Air-to-Air (ATA) Systems:**
 
 - Climate control (HVAC modes, temperature, fan speeds, swing)
-- Sensors (room temperature, outdoor temperature*, WiFi signal, energy consumption)
+- Sensors (room temperature, outdoor temperature, WiFi signal, energy consumption)
 - Binary sensors (error state, connection status)
 
 **Air-to-Water (ATW) Heat Pumps:**

--- a/custom_components/melcloudhome/sensor_ata.py
+++ b/custom_components/melcloudhome/sensor_ata.py
@@ -94,9 +94,8 @@ ATA_SENSOR_TYPES: tuple[ATASensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.outdoor_temperature,
-        should_create_fn=lambda unit: unit.has_outdoor_temp_sensor,
-        # Units stop uploading outdoor temperature while idle, so the value
-        # can be hours old (issue #171): surface when it was recorded
+        # Always created; "unknown" until a reading arrives.
+        # last_reading surfaces staleness: idle units stop uploading (#152/#171).
         attributes_fn=lambda unit: {
             "last_reading": unit.outdoor_temp_recorded_at.isoformat()
             if unit.outdoor_temp_recorded_at

--- a/custom_components/melcloudhome/sensor_atw.py
+++ b/custom_components/melcloudhome/sensor_atw.py
@@ -95,8 +95,7 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.tank_water_temperature,
     ),
-    # Outdoor temperature (from settings response)
-    # Only created if the first API response includes the field — not all hardware exposes it
+    # Outdoor temperature. Always created; "unknown" until a reading arrives.
     ATWSensorEntityDescription(
         key="outdoor_temperature",
         translation_key="outdoor_temperature",
@@ -104,7 +103,6 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.outdoor_temperature,
-        should_create_fn=lambda unit: unit.outdoor_temperature is not None,
     ),
     # Operation status (3-way valve position - raw API values)
     ATWSensorEntityDescription(

--- a/docs/api/ata-api-reference.md
+++ b/docs/api/ata-api-reference.md
@@ -718,8 +718,8 @@ GET /report/v1/trendsummary?unitId=aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825&period=D
 - Polled every 30 minutes (initial probe on startup, then periodic updates)
 - Uses `period=Hourly` with a 7-day window, `to` truncated to seconds=0 so the `to`-echo point is recognisable as synthetic
 - Extracts the latest genuine reading (last datapoint with seconds ≠ 0) from the OUTDOOR_TEMPERATURE dataset — value and `last_reading` timestamp both come from that reading
-- Not all devices have outdoor sensors (capability auto-detected at runtime)
-- Dataset absent for devices without outdoor sensor; units idle for the whole 7-day window return no genuine readings, and the coordinator keeps the previous value
+- The sensor entity is always created; it reads `unknown` until a genuine reading arrives (permanently for units that never report outdoor temperature)
+- Units idle for the whole 7-day window return no genuine readings, and the coordinator keeps the previous value
 
 **Notes:**
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -97,12 +97,10 @@ Energy consumption sensors are compatible with Home Assistant's Energy Dashboard
 
 **Outdoor Temperature Sensor (ATA):**
 
-- Only created for devices with outdoor temperature sensors
-- Automatically detected during integration setup
+- Created for every ATA unit; shows `unknown` until a reading arrives (and permanently for units that never report outdoor temperature)
 - Updates every 30 minutes
 - Shows ambient temperature from outdoor unit
 - Useful for efficiency monitoring and automations
-- Not all devices have outdoor sensors (runtime discovery determines availability)
 - Attribute `last_reading`: timestamp of when the unit actually recorded the value.
   Units stop uploading outdoor temperature while idle, so the value can lag hours
   behind (MELCloud server-side behavior, see issues #152/#171) — use this attribute

--- a/tests/integration/test_outdoor_temperature_sensor.py
+++ b/tests/integration/test_outdoor_temperature_sensor.py
@@ -91,12 +91,15 @@ async def test_outdoor_temperature_sensor_exposes_last_reading(
     assert state.attributes["last_reading"] == "2026-02-07T11:55:00+00:00"
 
 
-async def test_outdoor_temperature_sensor_not_created_when_no_sensor(
+async def test_outdoor_temperature_sensor_created_but_unknown_when_no_sensor(
     hass: HomeAssistant, setup_integration_with_outdoor_temp
 ):
-    """Test outdoor temp sensor NOT created for device without outdoor sensor."""
+    """Outdoor temp sensor is always created; a unit with no reading shows
+    'unknown', not dropped."""
     entity_id = "sensor.melcloudhome_5b3e_7a9b_outdoor_temperature"
-    assert hass.states.get(entity_id) is None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unknown"
 
 
 async def test_outdoor_temperature_updates_on_coordinator_refresh(
@@ -116,10 +119,11 @@ async def test_outdoor_temperature_updates_on_coordinator_refresh(
     assert state_after.state == "12.0"
 
 
-async def test_outdoor_temperature_unavailable_when_api_fails(
+async def test_outdoor_temperature_created_and_unknown_when_first_poll_fails(
     hass: HomeAssistant,
 ):
-    """Test outdoor temp sensor shows unavailable when API fails."""
+    """A failed outdoor poll at setup must not drop the sensor: the unit is
+    reachable, so it is created and shows 'unknown' until a reading arrives."""
     living_room = create_mock_ata_unit(
         unit_id=LIVING_ROOM_ID,
         name="Living Room AC",
@@ -137,7 +141,9 @@ async def test_outdoor_temperature_unavailable_when_api_fails(
     await setup_ata_integration_custom(hass, mock_context, configure_client=configure)
 
     entity_id = "sensor.melcloudhome_0efc_87db_outdoor_temperature"
-    assert hass.states.get(entity_id) is None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "unknown"
 
 
 @freeze_time("2026-02-07 12:00:00", real_asyncio=True)

--- a/tests/integration/test_sensor_atw.py
+++ b/tests/integration/test_sensor_atw.py
@@ -323,19 +323,20 @@ async def test_atw_outdoor_temperature_sensor_created(hass: HomeAssistant) -> No
 
 
 @pytest.mark.asyncio
-async def test_atw_outdoor_temperature_not_created_when_none(
+async def test_atw_outdoor_temperature_created_but_unknown_when_none(
     hass: HomeAssistant,
 ) -> None:
-    """Test ATW outdoor temperature sensor is not created when field absent from API."""
+    """ATW outdoor temp sensor is always created; a unit not reporting it shows
+    'unknown', not dropped."""
     mock_unit = create_mock_atw_unit(outdoor_temperature=None)
     mock_context = create_mock_atw_user_context(
         [create_mock_atw_building(units=[mock_unit])]
     )
     await setup_atw_integration_custom(hass, mock_context)
 
-    # Entity should not exist at all — not permanently unavailable
     state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
-    assert state is None
+    assert state is not None
+    assert state.state == "unknown"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Found during the v2.4.0-beta.2 release soak: one ATA unit's outdoor temperature sensor sat `unavailable` for hours on a reachable device, while the unit sharing its outdoor unit worked fine.

Both outdoor sensors gated entity creation on runtime data — `has_outdoor_temp_sensor` (ATA), `outdoor_temperature is not None` (ATW) — so if a unit's first reading hadn't arrived at setup (e.g. a transient poll failure during startup), the entity was never created for that session and only returned on a reload. That also contradicts #222's promise that a reachable unit with a missing reading reads `unknown`, not `unavailable`.

Removes both gates so the sensors are always created (matching #219/#220). They read `unknown` until a reading arrives, and permanently for units that never report outdoor temperature — confirmed against `/context` that no stable outdoor-sensor capability flag exists to gate on instead, so always-create is the correct choice per HA's `entity-unavailable` quality rule.

Also softens the beta.2 changelog wording for the protection-mode reload note (the "reload the integration to make it show" line).

Refs #219, #220, #222.
