### PR TITLE
docs: drop custom-repository install steps now in HACS default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,7 @@ For tested controller models and capability details, see [SUPPORTED_DEVICES.md](
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=andrew-blake&repository=melcloudhome&category=integration)
 
-Or manually: HACS → Integrations → ⋮ → Custom repositories → add `https://github.com/andrew-blake/melcloudhome`
-
-After adding, find "MELCloud Home" in HACS, click "Download", and restart Home Assistant.
+Or manually: open HACS, search for "MELCloud Home", click "Download", and restart Home Assistant.
 
 ### Manual Installation
 


### PR DESCRIPTION
The manual HACS install fallback in the README still walked users through adding a custom repository. Now that the integration is in the HACS default store (#83), the manual path is just searching for it in HACS. This matches what other default-store integrations do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)