### PR TITLE
fix(ci): align codeql-action/init with analyze at v4.37.4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality


### PR DESCRIPTION
Dependabot bumped `codeql-action/analyze` to v4.37.4 (#237) but `init` only got to v4.37.3 (#235), and CodeQL rejects mixed versions. This failed the scheduled CodeQL run and the CodeQL check on #236 and #233. One-line pin alignment; zizmor clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)