### PR TITLE
Fix translation_key ignored for sensor/binary_sensor names, prep v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+
+- Sensor and binary sensor names (WiFi signal, Room temperature, Frost protection, Holiday mode, and others) always displayed in English regardless of your Home Assistant language setting. Identified and diagnosed by @Jan-Arild-Blekken. (#240)
+
+### Changed
+
+- New devices (and fresh installs) may show slightly different names for a few diagnostic sensor entity IDs — including the COP sensor and the minimum/maximum frost and overheat protection sensors — now that they're generated correctly from the translated name rather than the raw internal key. Existing entities are unaffected. (#240)
+
+
 ## [2.4.0] - 2026-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [2.4.1] - 2026-08-14
 
 ### Fixed
 
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- New devices (and fresh installs) may show slightly different names for a few diagnostic sensor entity IDs — including the COP sensor and the minimum/maximum frost and overheat protection sensors — now that they're generated correctly from the translated name rather than the raw internal key. Existing entities are unaffected. (#240)
+- New devices (and fresh installs) will get entity IDs that follow your Home Assistant language, not just English, for a few diagnostic sensors — including the COP sensor and the minimum/maximum frost and overheat protection sensors — now that they're generated correctly from the translated name rather than the raw internal key. Existing entities are unaffected.
 
 
 ## [2.4.0] - 2026-08-01

--- a/README.md
+++ b/README.md
@@ -10,19 +10,11 @@
 
 Home Assistant custom integration for **MELCloud Home**.
 
-## What's New in v2.4.0
+## What's New in v2.4.1
 
-**Real-time updates** - changes made with the remote control or the MELCloud Home app now appear in Home Assistant within seconds, instead of up to a minute. Enabled by default with automatic fallback to regular polling, so there's nothing to set up - see [Real-Time Updates](#real-time-updates) for details. Contributed by [@mrdjtoto](https://github.com/mrdjtoto).
+**Entity names now follow your Home Assistant language.** Sensor and binary sensor names (WiFi signal, Room temperature, Frost protection, Holiday mode, and others) previously always displayed in English regardless of your Home Assistant language setting - they're now translated correctly. Identified and diagnosed by [@Jan-Arild-Blekken](https://github.com/Jan-Arild-Blekken).
 
-**Frost protection, overheat protection and holiday mode** are now visible for each air conditioning unit, along with the temperature limits they use and holiday mode's start and end dates. These are for viewing only - you still switch the modes on and off in the MELCloud Home app or on the remote control. Contributed by [@mrdjtoto](https://github.com/mrdjtoto).
-
-**You will see new entities after upgrading.** MELCloud reports a frost protection setting for every air conditioning unit, so each one gains a "Frost protection" sensor with its minimum and maximum temperatures - even if you have never used the feature. "Overheat protection" and "Holiday mode" only appear on units where you have set them up.
-
-Also in this release: outdoor temperature sensors now show when the reading was actually taken, error state sensors include the unit's error code, several sensors that could go missing after a restart now stay put, and sensors show "unknown" rather than "unavailable" when the unit is reachable but a reading is missing.
-
-**Requires Home Assistant 2025.8.0 or newer.** If you're on an older version, HACS will not offer this update.
-
-**Now available in the HACS default repository** - search "MELCloud Home" in HACS to install directly, no need to add it as a custom repository. Already using the custom repository? No action needed - your install keeps working as-is.
+**New devices going forward will get entity IDs that match their translated name** for a few diagnostic sensors, including the COP sensor and the minimum/maximum frost and overheat protection sensors. This doesn't affect any of your existing entities.
 
 See [CHANGELOG.md](CHANGELOG.md) for full history.
 

--- a/custom_components/melcloudhome/helpers.py
+++ b/custom_components/melcloudhome/helpers.py
@@ -62,33 +62,6 @@ def with_debounced_refresh(
     return decorator
 
 
-def create_entity_name(unit: DeviceUnit, suffix: str = "") -> str | None:
-    """Generate short entity name for has_entity_name=True.
-
-    With has_entity_name=True, entity_id is generated as:
-    {domain}.{device_name}_{entity_name}
-
-    Device name already contains UUID (melcloudhome_bf2d_5666),
-    so entity name should just be the descriptive part.
-
-    Args:
-        unit: ATA or ATW device (kept for signature compatibility)
-        suffix: Entity suffix (e.g., "Room Temperature", "Zone 1", "Tank")
-                Empty string for base entities (returns None)
-
-    Returns:
-        Short entity name or None for device-name-only entities
-
-    Examples:
-        >>> create_entity_name(unit, "Room Temperature")
-        "Room Temperature"
-
-        >>> create_entity_name(unit, "")
-        None  # Base ATA climate uses device name only
-    """
-    return suffix.strip() if suffix else None
-
-
 def create_device_info(unit: DeviceUnit, building: Building) -> DeviceInfo:
     """Create standardized device info for ATA or ATW devices.
 
@@ -163,8 +136,12 @@ def initialize_entity_base(
         ...     initialize_entity_base(self, unit, building, entry, description)
 
     Note:
-        This preserves the existing unique_id format (unit_id + key) to avoid
-        breaking changes to entity IDs. Do not modify the unique_id format.
+        This preserves the existing unique_id format (unit_id + key) so that
+        already-registered entities keep their entity_id stable across
+        restarts - HA looks entities up by unique_id and does not regenerate
+        entity_id for them. This has no bearing on brand-new registrations,
+        which get entity_id derived fresh from the current name (see above).
+        Do not modify the unique_id format.
     """
     # Store IDs for coordinator lookups
     entity._unit_id = unit.id

--- a/custom_components/melcloudhome/helpers.py
+++ b/custom_components/melcloudhome/helpers.py
@@ -1,6 +1,6 @@
 """Helper functions for MELCloud Home integration.
 
-This module contains utility functions for entity initialization, naming,
+This module contains utility functions for entity initialization
 and device info creation. Previously these were in const.py but are now
 organized separately for better code organization.
 """

--- a/custom_components/melcloudhome/helpers.py
+++ b/custom_components/melcloudhome/helpers.py
@@ -62,36 +62,6 @@ def with_debounced_refresh(
     return decorator
 
 
-def fix_entity_name_acronyms(name: str) -> str:
-    """Fix acronym capitalization in entity names.
-
-    Replaces incorrectly title-cased acronyms with proper all-caps versions.
-    Used when converting entity keys like "dhw_temperature" to display names.
-
-    Args:
-        name: Entity name with potential incorrect acronyms (e.g., "Dhw Temperature")
-
-    Returns:
-        Name with correctly capitalized acronyms (e.g., "DHW Temperature")
-
-    Examples:
-        >>> fix_entity_name_acronyms("Dhw Temperature")
-        "DHW Temperature"
-        >>> fix_entity_name_acronyms("Wifi Signal Strength")
-        "WiFi Signal Strength"
-        >>> fix_entity_name_acronyms("Ftc5 Model")
-        "FTC5 Model"
-    """
-    acronym_fixes = {
-        "Dhw": "DHW",  # Domestic Hot Water
-        "Wifi": "WiFi",  # WiFi signal
-        "Ftc": "FTC",  # FTC model numbers
-    }
-    for incorrect, correct in acronym_fixes.items():
-        name = name.replace(incorrect, correct)
-    return name
-
-
 def create_entity_name(unit: DeviceUnit, suffix: str = "") -> str | None:
     """Generate short entity name for has_entity_name=True.
 
@@ -171,8 +141,13 @@ def initialize_entity_base(
     - _building_id: Building ID for coordinator lookups
     - _entry: Config entry reference
     - _attr_unique_id: Stable unique identifier (unit_id + description key)
-    - _attr_name: Friendly display name with correct acronym capitalization
     - _attr_device_info: Device information for grouping in HA UI
+
+    Does NOT set _attr_name: every description passed here declares a
+    translation_key, and an explicit _attr_name would take precedence over
+    it, silently defeating translation (#240). Callers without a
+    translation_key would fall back to HA's raw entity-key display -
+    add one instead of reintroducing a generated name here.
 
     Args:
         entity: Entity instance to initialize (ATASensor, ATWSensor, etc.)
@@ -199,10 +174,6 @@ def initialize_entity_base(
     # Generate unique_id: unit_id + sensor key
     # CRITICAL: Do not change this format - it would break existing entity IDs
     entity._attr_unique_id = f"{unit.id}_{description.key}"
-
-    # Convert description key to friendly name with proper acronym capitalization
-    short_name = description.key.replace("_", " ").title()
-    entity._attr_name = fix_entity_name_acronyms(short_name)
 
     # Device info using shared helper
     entity._attr_device_info = create_device_info(unit, building)

--- a/custom_components/melcloudhome/manifest.json
+++ b/custom_components/melcloudhome/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.melcloudhome"
   ],
   "requirements": [],
-  "version": "2.4.0"
+  "version": "2.4.1"
 }

--- a/docs/decisions/006-entity-description-pattern.md
+++ b/docs/decisions/006-entity-description-pattern.md
@@ -1,6 +1,6 @@
 # ADR-006: Adopt Entity Description Pattern for Sensors
 
-**Status:** Accepted — `available_fn` since removed by [ADR-020](020-unknown-for-missing-readings.md)
+**Status:** Accepted — `available_fn` since removed by [ADR-020](020-unknown-for-missing-readings.md); entity-naming example corrected 2026-08-14 (see note below) — issue #240
 **Date:** 2025-11-17
 **Context:** Session 9 - Pre-v1.2 research and planning
 
@@ -13,6 +13,15 @@ As part of v1.2 development, we're adding a sensor platform to expose:
 - Other device metrics
 
 During Session 9 research, we analyzed modern Home Assistant sensor implementations and identified the entity description pattern as the current best practice.
+
+> **Correction (2026-08-14):** the example code below originally set both
+> `translation_key` *and* a hand-built `_attr_name` on the same entity. In
+> Home Assistant, an explicit `_attr_name` always takes precedence over
+> `translation_key` — the two are meant to be mutually exclusive, not
+> layered. That conflict meant `translation_key` was silently ignored for
+> every sensor/binary_sensor since this pattern was introduced (issue
+> #240). The example has been corrected to rely on `translation_key` alone;
+> see `initialize_entity_base()` in `helpers.py`.
 
 ## Decision
 
@@ -136,10 +145,8 @@ class MELCloudHomeSensor(CoordinatorEntity[MELCloudHomeCoordinator], SensorEntit
         # Unique ID: unit_id + sensor key
         self._attr_unique_id = f"{unit.id}_{description.key}"
 
-        # Entity naming
-        unit_id_clean = unit.id.replace("-", "")
-        key_title = description.key.replace("_", " ").title()
-        self._attr_name = f"MELCloud {unit_id_clean[:4]} {unit_id_clean[-4:]} {key_title}"
+        # Entity naming resolved via translation_key on the description -
+        # do not also set _attr_name here, it would take precedence.
 
         # Link to device (climate entity's device)
         self._attr_device_info = {

--- a/docs/decisions/016-implement-atw-energy-monitoring.md
+++ b/docs/decisions/016-implement-atw-energy-monitoring.md
@@ -156,7 +156,7 @@ async def get_energy_produced(...) -> dict | None:
 **Sensors created (if capabilities present):**
 1. `sensor.melcloudhome_*_energy_consumed` - kWh consumed (statistics, energy)
 2. `sensor.melcloudhome_*_energy_produced` - kWh produced (statistics, energy)
-3. `sensor.melcloudhome_*_cop` - Coefficient of performance (ratio)
+3. `sensor.melcloudhome_*_coefficient_of_performance` - Coefficient of performance (ratio)
 
 **Capability checks (sensors created independently):**
 ```python

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -18,6 +18,8 @@ The `short_id` is derived from the MELCloud device UUID by taking the first 4 an
 
 **Device names** are automatically set to friendly names from your MELCloud Home account (e.g., "Living Room", "Bedroom") for easy identification in the UI.
 
+**Note:** `entity_id` is set once, at first registration, and never recomputed. Entities registered before the #240 translation fix keep their original `entity_id` permanently; only entities registered for the first time after that fix get the corrected IDs shown below.
+
 ---
 
 ## Air-to-Air (ATA) Systems
@@ -36,9 +38,9 @@ For each air conditioning unit, the following entities are created:
 - **Outdoor Temperature**: `sensor.melcloudhome_{short_id}_outdoor_temperature` (if available)
 - **WiFi Signal**: `sensor.melcloudhome_{short_id}_wifi_signal` (diagnostic)
 - **Energy**: `sensor.melcloudhome_{short_id}_energy` (cumulative kWh)
-- **Frost Protection Minimum/Maximum**: `sensor.melcloudhome_{short_id}_frost_protection_min` / `_max` (°C, diagnostic; created when the API reports the `frostProtection` object — every ATA unit does, as a server-side default, whether or not the mode has ever been configured)
-- **Overheat Protection Minimum/Maximum**: `sensor.melcloudhome_{short_id}_overheat_protection_min` / `_max` (°C, diagnostic; only created once ever configured)
-- **Holiday Mode Start/End Date**: `sensor.melcloudhome_{short_id}_holiday_mode_start_date` / `_end_date` (raw ISO string as returned by the API, not parsed into a timestamp device class; diagnostic, only created once ever configured). Live-tested twice: local wall-clock time passed through naively, not UTC — the building's own `timezone` field is not a reliable way to interpret it (see code comment in `sensor_ata.py`), so no conversion is attempted
+- **Frost Protection Minimum/Maximum**: `sensor.melcloudhome_{short_id}_frost_protection_minimum` / `_maximum` (°C, diagnostic; created when the API reports the `frostProtection` object — every ATA unit does, as a server-side default, whether or not the mode has ever been configured)
+- **Overheat Protection Minimum/Maximum**: `sensor.melcloudhome_{short_id}_overheat_protection_minimum` / `_maximum` (°C, diagnostic; only created once ever configured)
+- **Holiday Mode Start/End Date**: `sensor.melcloudhome_{short_id}_holiday_mode_start` / `_end` (raw ISO string as returned by the API, not parsed into a timestamp device class; diagnostic, only created once ever configured). Live-tested twice: local wall-clock time passed through naively, not UTC — the building's own `timezone` field is not a reliable way to interpret it (see code comment in `sensor_ata.py`), so no conversion is attempted
 
 ### Binary Sensors
 
@@ -155,10 +157,10 @@ For each heat pump system, the following entities are created:
 
 - **Flow Temperature**: `sensor.melcloudhome_{short_id}_flow_temperature`
 - **Return Temperature**: `sensor.melcloudhome_{short_id}_return_temperature`
-- **Flow Temperature Zone 1**: `sensor.melcloudhome_{short_id}_flow_temperature_zone1`
-- **Return Temperature Zone 1**: `sensor.melcloudhome_{short_id}_return_temperature_zone1`
-- **Flow Temperature Zone 2**: `sensor.melcloudhome_{short_id}_flow_temperature_zone2` (if device supports Zone 2)
-- **Return Temperature Zone 2**: `sensor.melcloudhome_{short_id}_return_temperature_zone2` (if device supports Zone 2)
+- **Flow Temperature Zone 1**: `sensor.melcloudhome_{short_id}_flow_temperature_zone_1`
+- **Return Temperature Zone 1**: `sensor.melcloudhome_{short_id}_return_temperature_zone_1`
+- **Flow Temperature Zone 2**: `sensor.melcloudhome_{short_id}_flow_temperature_zone_2` (if device supports Zone 2)
+- **Return Temperature Zone 2**: `sensor.melcloudhome_{short_id}_return_temperature_zone_2` (if device supports Zone 2)
 - **Flow Temperature Boiler**: `sensor.melcloudhome_{short_id}_flow_temperature_boiler`
 - **Return Temperature Boiler**: `sensor.melcloudhome_{short_id}_return_temperature_boiler`
 
@@ -189,7 +191,7 @@ All of these except the Zone 2 pair are created for every heat pump. Not every c
   - Compatible with Home Assistant Energy Dashboard
 - **Energy Produced**: `sensor.melcloudhome_{short_id}_energy_produced`
   - Thermal energy produced by heat pump (kWh)
-- **COP (Coefficient of Performance)**: `sensor.melcloudhome_{short_id}_cop`
+- **COP (Coefficient of Performance)**: `sensor.melcloudhome_{short_id}_coefficient_of_performance`
   - Heat pump efficiency ratio (produced/consumed)
   - Typical values: 2.5-4.0 (higher is more efficient)
   - Update frequency: Every 30 minutes

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,6 +33,19 @@ def auto_enable_custom_integrations(enable_custom_integrations):
     yield
 
 
+@pytest.fixture(autouse=True)
+def pin_test_language(hass):
+    """Pin HA's language so translation-derived entity_ids are deterministic.
+
+    entity_id generation now falls through to the resolved/translated name
+    (see initialize_entity_base() fix for #240) - without this pin, these
+    tests would silently depend on pytest-homeassistant-custom-component's
+    undeclared default language rather than an explicit one.
+    """
+    hass.config.language = "en"
+    yield
+
+
 # Mock path for MELCloudHomeClient in config_flow
 MOCK_CLIENT_CONFIG_FLOW = (
     "custom_components.melcloudhome.config_flow.MELCloudHomeClient"
@@ -77,7 +90,7 @@ TEST_SENSOR_ZONE1_TEMP = "sensor.melcloudhome_0efc_9abc_zone_1_temperature"
 TEST_SENSOR_TANK_TEMP = "sensor.melcloudhome_0efc_9abc_tank_temperature"
 TEST_SENSOR_ENERGY_CONSUMED = "sensor.melcloudhome_0efc_9abc_energy_consumed"
 TEST_SENSOR_ENERGY_PRODUCED = "sensor.melcloudhome_0efc_9abc_energy_produced"
-TEST_SENSOR_COP = "sensor.melcloudhome_0efc_9abc_cop"
+TEST_SENSOR_COP = "sensor.melcloudhome_0efc_9abc_coefficient_of_performance"
 TEST_BINARY_SENSOR_ERROR = "binary_sensor.melcloudhome_0efc_9abc_error_state"
 TEST_BINARY_SENSOR_CONNECTION = "binary_sensor.melcloudhome_0efc_9abc_connection_state"
 TEST_CLIMATE_ZONE2_ENTITY_ID = "climate.melcloudhome_0efc_9abc_zone_2"

--- a/tests/integration/test_binary_sensor_ata.py
+++ b/tests/integration/test_binary_sensor_ata.py
@@ -40,6 +40,11 @@ async def test_binary_sensor_entity_creation(hass: HomeAssistant) -> None:
     assert connection_state is not None
     assert connection_state.attributes["device_class"] == "connectivity"
 
+    # translation_key must drive the name, not a title-cased fallback of the
+    # entity key (regression test for #240)
+    assert error_state.attributes["friendly_name"].endswith("Error state")
+    assert connection_state.attributes["friendly_name"].endswith("Connection state")
+
 
 @pytest.mark.asyncio
 async def test_error_state_sensor_reflects_unit_status(hass: HomeAssistant) -> None:

--- a/tests/integration/test_sensor_ata.py
+++ b/tests/integration/test_sensor_ata.py
@@ -70,6 +70,11 @@ async def test_sensor_entity_creation(hass: HomeAssistant) -> None:
         assert wifi_state.attributes["unit_of_measurement"] == "dBm"
         assert wifi_state.attributes["device_class"] == "signal_strength"
 
+        # translation_key must drive the name, not a title-cased fallback of
+        # the entity key (regression test for #240)
+        assert temp_state.attributes["friendly_name"].endswith("Room temperature")
+        assert wifi_state.attributes["friendly_name"].endswith("WiFi signal")
+
         energy_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_energy")
         assert energy_state is not None
         assert float(energy_state.state) == 0.0  # First init starts at 0
@@ -213,15 +218,25 @@ async def test_frost_protection_setpoint_sensors_only_when_configured(
     )
     await setup_ata_integration_custom(hass, mock_context)
 
-    min_state = hass.states.get("sensor.melcloudhome_aaaa_9999_frost_protection_min")
-    max_state = hass.states.get("sensor.melcloudhome_aaaa_9999_frost_protection_max")
+    min_state = hass.states.get(
+        "sensor.melcloudhome_aaaa_9999_frost_protection_minimum"
+    )
+    max_state = hass.states.get(
+        "sensor.melcloudhome_aaaa_9999_frost_protection_maximum"
+    )
     assert min_state is not None
     assert float(min_state.state) == 10
     assert max_state is not None
     assert float(max_state.state) == 12
 
-    assert hass.states.get("sensor.melcloudhome_bbbb_8888_frost_protection_min") is None
-    assert hass.states.get("sensor.melcloudhome_bbbb_8888_frost_protection_max") is None
+    assert (
+        hass.states.get("sensor.melcloudhome_bbbb_8888_frost_protection_minimum")
+        is None
+    )
+    assert (
+        hass.states.get("sensor.melcloudhome_bbbb_8888_frost_protection_maximum")
+        is None
+    )
 
 
 @pytest.mark.asyncio
@@ -237,8 +252,12 @@ async def test_overheat_protection_setpoint_sensors(hass: HomeAssistant) -> None
     )
     await setup_ata_integration_custom(hass, mock_context)
 
-    min_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_overheat_protection_min")
-    max_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_overheat_protection_max")
+    min_state = hass.states.get(
+        "sensor.melcloudhome_a1b2_9abc_overheat_protection_minimum"
+    )
+    max_state = hass.states.get(
+        "sensor.melcloudhome_a1b2_9abc_overheat_protection_maximum"
+    )
     assert min_state is not None
     assert float(min_state.state) == 35
     assert max_state is not None
@@ -261,10 +280,8 @@ async def test_holiday_mode_date_sensors(hass: HomeAssistant) -> None:
     )
     await setup_ata_integration_custom(hass, mock_context)
 
-    start_state = hass.states.get(
-        "sensor.melcloudhome_a1b2_9abc_holiday_mode_start_date"
-    )
-    end_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_holiday_mode_end_date")
+    start_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_holiday_mode_start")
+    end_state = hass.states.get("sensor.melcloudhome_a1b2_9abc_holiday_mode_end")
     assert start_state is not None
     assert start_state.state == "2026-07-20T18:30:53.79"
     assert end_state is not None

--- a/tests/integration/test_sensor_atw.py
+++ b/tests/integration/test_sensor_atw.py
@@ -371,11 +371,14 @@ async def test_telemetry_sensors_created_without_telemetry_data(
     )
     await setup_atw_integration_custom(hass, mock_context)
 
+    # entity_id's object-id segment comes from the translated name (see
+    # initialize_entity_base() fix for #240), so "zone1" (key) reads as
+    # "zone 1" (translated name) -> "zone_1" (slugified) in the entity_id.
     for measure in (
         "flow_temperature",
         "return_temperature",
-        "flow_temperature_zone1",
-        "return_temperature_zone1",
+        "flow_temperature_zone_1",
+        "return_temperature_zone_1",
         "flow_temperature_boiler",
         "return_temperature_boiler",
     ):


### PR DESCRIPTION
## Summary

Sensor and binary_sensor entity names always rendered in English, ignoring HA's language setting — `initialize_entity_base()` unconditionally set `_attr_name`, which always overrides `translation_key`. Fix: delete the override; every current entity already declares `translation_key`, and all 13 language files already have correct translations, so nothing else was needed.

Fixes #240 (diagnosed by @Jan-Arild-Blekken — thank you).

## Key changes

- Deleted the `_attr_name` override and the now-dead `fix_entity_name_acronyms()` helper in `helpers.py`.
- Side effect, handled: this also fixes `entity_id` generation for brand-new registrations (was always key-derived, now correctly derived from the translated name). Zero impact on existing installs — `entity_id` is pinned by `unique_id` at first registration and never recomputed. Updated 8 tests whose expected `entity_id` shifted, pinned the test harness language explicitly so that's deterministic rather than implicit, and corrected the 9 now-stale IDs in `docs/entities.md`/ADR-016.
- Corrected ADR-006's example code, which had modeled this exact bug.
- Prepped this as the v2.4.1 patch release (CHANGELOG, manifest version, README).

**Not in scope:** `climate`/`switch`/`water_heater` entity names are also hardcoded English with no `translation_key` wiring at all — different, larger problem (needs new translation strings across 13 languages, plus a placeholder mechanism for one dynamic name). Tracked in the local backlog as a follow-up.

## Test plan

- [x] Full suite green: 372 (API) + 202 (integration) + 14 (e2e) passed
- [x] Real-environment check: dev container against production MELCloud, HA switched to Italian, confirmed via Chrome ("Segnale WiFi", "Temperatura ambiente", "Stato errore" now render correctly)
- [x] `make pre-commit` clean