### PR TITLE
docs: credit Norwegian translation in v2.4.1 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.1] - 2026-08-14
 
+### Added
+
+- Norwegian (nb) translations (thanks @Jan-Arild-Blekken)
+
 ### Fixed
 
 - Sensor and binary sensor names (WiFi signal, Room temperature, Frost protection, Holiday mode, and others) always displayed in English regardless of your Home Assistant language setting. Identified and diagnosed by @Jan-Arild-Blekken. (#240)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Home Assistant custom integration for **MELCloud Home**.
 
 **New devices going forward will get entity IDs that match their translated name** for a few diagnostic sensors, including the COP sensor and the minimum/maximum frost and overheat protection sensors. This doesn't affect any of your existing entities.
 
-Norwegian (nb) translations added (thanks @Jan-Arild-Blekken). See [CHANGELOG.md](CHANGELOG.md) for full history.
+Norwegian (nb) translations added (thanks @Jan-Arild-Blekken).
+
+See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Home Assistant custom integration for **MELCloud Home**.
 
 **New devices going forward will get entity IDs that match their translated name** for a few diagnostic sensors, including the COP sensor and the minimum/maximum frost and overheat protection sensors. This doesn't affect any of your existing entities.
 
-See [CHANGELOG.md](CHANGELOG.md) for full history.
+Norwegian (nb) translations added (thanks @Jan-Arild-Blekken). See [CHANGELOG.md](CHANGELOG.md) for full history.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- PR #247 (Norwegian translation) merged after v2.4.1's release prep (#246), so CHANGELOG and README didn't mention it yet.
- Adds an `Added` entry to CHANGELOG's `[2.4.1]` section and a line to README's "What's New in v2.4.1", crediting @Jan-Arild-Blekken, matching the existing pattern for prior translation contributions.

## Test plan
- [ ] CI passes