### PR TITLE
Add missing translations: cs, da, hu, pl, si - closes #69

### DIFF
--- a/custom_components/melcloudhome/translations/cs.json
+++ b/custom_components/melcloudhome/translations/cs.json
@@ -1,0 +1,209 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "Možnosti MELCloud Home",
+        "data": {
+          "enable_websocket": "Aktualizace v reálném čase"
+        },
+        "data_description": {
+          "enable_websocket": "Změny provedené dálkovým ovladačem nebo aplikací MELCloud Home se objeví během několika sekund."
+        }
+      }
+    }
+  },
+  "config": {
+    "step": {
+      "user": {
+        "title": "Připojit k MELCloud Home",
+        "description": "Zadejte přihlašovací údaje k MELCloud Home",
+        "data": {
+          "email": "E-mail",
+          "password": "Heslo",
+          "debug_mode": "Připojit k testovacímu serveru"
+        },
+        "data_description": {
+          "debug_mode": "Pouze pro vývoj – připojí se k místnímu testovacímu serveru místo produkčního API MELCloud"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Platnost ověření vypršela pro {name}",
+        "description": "Aktualizujte heslo pro {email}",
+        "data": {
+          "password": "Heslo"
+        }
+      },
+      "reconfigure": {
+        "title": "Překonfigurovat",
+        "description": "Aktualizujte přihlašovací údaje pro {email}",
+        "data": {
+          "password": "Heslo"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Neplatný e-mail nebo heslo",
+      "cannot_connect": "Nelze se připojit k MELCloud Home. Zkontrolujte připojení k internetu a zkuste to znovu.",
+      "service_unavailable": "Služba MELCloud je momentálně nedostupná. Jedná se o problém na straně serveru – zkuste to prosím později.",
+      "unknown": "Došlo k neočekávané chybě. Zkuste to prosím znovu."
+    },
+    "abort": {
+      "already_configured": "Tento účet je již nakonfigurován",
+      "reauth_successful": "Opětovné ověření bylo úspěšné",
+      "reconfigure_successful": "Přihlašovací údaje byly úspěšně aktualizovány"
+    }
+  },
+  "entity": {
+    "climate": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "room": "Místnost",
+              "flow": "Průtok",
+              "curve": "Křivka"
+            }
+          },
+          "fan_mode": {
+            "state": {
+              "auto": "Auto",
+              "one": "Ventilátor 1",
+              "two": "Ventilátor 2",
+              "three": "Ventilátor 3",
+              "four": "Ventilátor 4",
+              "five": "Ventilátor 5"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "auto": "Auto",
+              "swing": "Natáčení",
+              "one": "Natáčení 1",
+              "two": "Natáčení 2",
+              "three": "Natáčení 3",
+              "four": "Natáčení 4",
+              "five": "Natáčení 5"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "auto": "Auto",
+              "swing": "Natáčení",
+              "left": "Vlevo",
+              "leftcentre": "Vlevo-střed",
+              "centre": "Střed",
+              "rightcentre": "Vpravo-střed",
+              "right": "Vpravo"
+            }
+          }
+        }
+      }
+    },
+    "sensor": {
+      "room_temperature": {
+        "name": "Teplota v místnosti"
+      },
+      "wifi_signal": {
+        "name": "Signál WiFi"
+      },
+      "energy": {
+        "name": "Energie"
+      },
+      "outdoor_temperature": {
+        "name": "Venkovní teplota"
+      },
+      "frost_protection_min": {
+        "name": "Minimum ochrany proti mrazu"
+      },
+      "frost_protection_max": {
+        "name": "Maximum ochrany proti mrazu"
+      },
+      "overheat_protection_min": {
+        "name": "Minimum ochrany proti přehřátí"
+      },
+      "overheat_protection_max": {
+        "name": "Maximum ochrany proti přehřátí"
+      },
+      "holiday_mode_start_date": {
+        "name": "Začátek prázdninového režimu"
+      },
+      "holiday_mode_end_date": {
+        "name": "Konec prázdninového režimu"
+      },
+      "zone_1_temperature": {
+        "name": "Teplota zóny 1"
+      },
+      "zone_2_temperature": {
+        "name": "Teplota zóny 2"
+      },
+      "tank_temperature": {
+        "name": "Teplota zásobníku"
+      },
+      "operation_status": {
+        "name": "Provozní stav"
+      },
+      "flow_temperature": {
+        "name": "Teplota na výstupu"
+      },
+      "return_temperature": {
+        "name": "Teplota na vstupu"
+      },
+      "flow_temperature_zone1": {
+        "name": "Teplota na výstupu zóna 1"
+      },
+      "return_temperature_zone1": {
+        "name": "Teplota na vstupu zóna 1"
+      },
+      "flow_temperature_zone2": {
+        "name": "Teplota na výstupu zóna 2"
+      },
+      "return_temperature_zone2": {
+        "name": "Teplota na vstupu zóna 2"
+      },
+      "flow_temperature_boiler": {
+        "name": "Teplota na výstupu bojler"
+      },
+      "return_temperature_boiler": {
+        "name": "Teplota na vstupu bojler"
+      },
+      "energy_consumed": {
+        "name": "Spotřebovaná energie"
+      },
+      "energy_produced": {
+        "name": "Vyrobená energie"
+      },
+      "cop": {
+        "name": "Topný faktor"
+      }
+    },
+    "binary_sensor": {
+      "error_state": {
+        "name": "Stav chyby"
+      },
+      "connection_state": {
+        "name": "Stav připojení"
+      },
+      "realtime_updates": {
+        "name": "Aktualizace v reálném čase"
+      },
+      "forced_dhw_active": {
+        "name": "Vynucený ohřev TUV aktivní"
+      },
+      "frost_protection": {
+        "name": "Ochrana proti mrazu"
+      },
+      "overheat_protection": {
+        "name": "Ochrana proti přehřátí"
+      },
+      "holiday_mode": {
+        "name": "Prázdninový režim"
+      }
+    }
+  },
+  "services": {
+    "force_refresh": {
+      "name": "Vynutit obnovení",
+      "description": "Okamžitě obnovit data zařízení ze serverů MELCloud (pro testování/vývoj)"
+    }
+  }
+}

--- a/custom_components/melcloudhome/translations/da.json
+++ b/custom_components/melcloudhome/translations/da.json
@@ -1,0 +1,209 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "MELCloud Home-indstillinger",
+        "data": {
+          "enable_websocket": "Realtidsopdateringer"
+        },
+        "data_description": {
+          "enable_websocket": "Ændringer foretaget med fjernbetjeningen eller MELCloud Home-appen vises inden for få sekunder."
+        }
+      }
+    }
+  },
+  "config": {
+    "step": {
+      "user": {
+        "title": "Opret forbindelse til MELCloud Home",
+        "description": "Indtast dine MELCloud Home-legitimationsoplysninger",
+        "data": {
+          "email": "E-mail",
+          "password": "Adgangskode",
+          "debug_mode": "Opret forbindelse til testserver"
+        },
+        "data_description": {
+          "debug_mode": "Kun til udvikling – opretter forbindelse til lokal testserver i stedet for produktions-MELCloud API"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Godkendelse udløbet for {name}",
+        "description": "Opdater venligst din adgangskode for {email}",
+        "data": {
+          "password": "Adgangskode"
+        }
+      },
+      "reconfigure": {
+        "title": "Rekonfigurer",
+        "description": "Opdater legitimationsoplysninger for {email}",
+        "data": {
+          "password": "Adgangskode"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Ugyldig e-mail eller adgangskode",
+      "cannot_connect": "Kunne ikke oprette forbindelse til MELCloud Home. Tjek din internetforbindelse og prøv igen.",
+      "service_unavailable": "MELCloud-tjenesten er i øjeblikket utilgængelig. Dette er et serverproblem – prøv igen senere.",
+      "unknown": "Der opstod en uventet fejl. Prøv igen."
+    },
+    "abort": {
+      "already_configured": "Denne konto er allerede konfigureret",
+      "reauth_successful": "Godkendelse lykkedes",
+      "reconfigure_successful": "Legitimationsoplysninger opdateret"
+    }
+  },
+  "entity": {
+    "climate": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "room": "Rum",
+              "flow": "Flow",
+              "curve": "Kurve"
+            }
+          },
+          "fan_mode": {
+            "state": {
+              "auto": "Auto",
+              "one": "Ventilator 1",
+              "two": "Ventilator 2",
+              "three": "Ventilator 3",
+              "four": "Ventilator 4",
+              "five": "Ventilator 5"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "auto": "Auto",
+              "swing": "Sving",
+              "one": "Sving 1",
+              "two": "Sving 2",
+              "three": "Sving 3",
+              "four": "Sving 4",
+              "five": "Sving 5"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "auto": "Auto",
+              "swing": "Sving",
+              "left": "Venstre",
+              "leftcentre": "Venstre-center",
+              "centre": "Center",
+              "rightcentre": "Højre-center",
+              "right": "Højre"
+            }
+          }
+        }
+      }
+    },
+    "sensor": {
+      "room_temperature": {
+        "name": "Rumtemperatur"
+      },
+      "wifi_signal": {
+        "name": "WiFi-signal"
+      },
+      "energy": {
+        "name": "Energi"
+      },
+      "outdoor_temperature": {
+        "name": "Udendørstemperatur"
+      },
+      "frost_protection_min": {
+        "name": "Minimum frostbeskyttelse"
+      },
+      "frost_protection_max": {
+        "name": "Maksimum frostbeskyttelse"
+      },
+      "overheat_protection_min": {
+        "name": "Minimum overophedningsbeskyttelse"
+      },
+      "overheat_protection_max": {
+        "name": "Maksimum overophedningsbeskyttelse"
+      },
+      "holiday_mode_start_date": {
+        "name": "Start ferietilstand"
+      },
+      "holiday_mode_end_date": {
+        "name": "Slut ferietilstand"
+      },
+      "zone_1_temperature": {
+        "name": "Zone 1 temperatur"
+      },
+      "zone_2_temperature": {
+        "name": "Zone 2 temperatur"
+      },
+      "tank_temperature": {
+        "name": "Beholdertemperatur"
+      },
+      "operation_status": {
+        "name": "Driftsstatus"
+      },
+      "flow_temperature": {
+        "name": "Fremløbstemperatur"
+      },
+      "return_temperature": {
+        "name": "Returtemperatur"
+      },
+      "flow_temperature_zone1": {
+        "name": "Fremløbstemperatur zone 1"
+      },
+      "return_temperature_zone1": {
+        "name": "Returtemperatur zone 1"
+      },
+      "flow_temperature_zone2": {
+        "name": "Fremløbstemperatur zone 2"
+      },
+      "return_temperature_zone2": {
+        "name": "Returtemperatur zone 2"
+      },
+      "flow_temperature_boiler": {
+        "name": "Fremløbstemperatur kedel"
+      },
+      "return_temperature_boiler": {
+        "name": "Returtemperatur kedel"
+      },
+      "energy_consumed": {
+        "name": "Forbrugt energi"
+      },
+      "energy_produced": {
+        "name": "Produceret energi"
+      },
+      "cop": {
+        "name": "COP-værdi"
+      }
+    },
+    "binary_sensor": {
+      "error_state": {
+        "name": "Fejltilstand"
+      },
+      "connection_state": {
+        "name": "Forbindelsesstatus"
+      },
+      "realtime_updates": {
+        "name": "Realtidsopdateringer"
+      },
+      "forced_dhw_active": {
+        "name": "Tvungen varmt vand aktiv"
+      },
+      "frost_protection": {
+        "name": "Frostbeskyttelse"
+      },
+      "overheat_protection": {
+        "name": "Overophedningsbeskyttelse"
+      },
+      "holiday_mode": {
+        "name": "Ferietilstand"
+      }
+    }
+  },
+  "services": {
+    "force_refresh": {
+      "name": "Tving opdatering",
+      "description": "Opdater straks enhedsdata fra MELCloud-servere (til test/udvikling)"
+    }
+  }
+}

--- a/custom_components/melcloudhome/translations/da.json
+++ b/custom_components/melcloudhome/translations/da.json
@@ -125,10 +125,10 @@
         "name": "Maksimum overophedningsbeskyttelse"
       },
       "holiday_mode_start_date": {
-        "name": "Start ferietilstand"
+        "name": "Ferietilstand start"
       },
       "holiday_mode_end_date": {
-        "name": "Slut ferietilstand"
+        "name": "Ferietilstand slut"
       },
       "zone_1_temperature": {
         "name": "Zone 1 temperatur"

--- a/custom_components/melcloudhome/translations/hu.json
+++ b/custom_components/melcloudhome/translations/hu.json
@@ -1,0 +1,209 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "MELCloud Home beállítások",
+        "data": {
+          "enable_websocket": "Valós idejű frissítések"
+        },
+        "data_description": {
+          "enable_websocket": "A távirányítóval vagy a MELCloud Home alkalmazással végzett módosítások másodperceken belül megjelennek."
+        }
+      }
+    }
+  },
+  "config": {
+    "step": {
+      "user": {
+        "title": "Csatlakozás a MELCloud Home-hoz",
+        "description": "Add meg a MELCloud Home hitelesítő adataidat",
+        "data": {
+          "email": "E-mail",
+          "password": "Jelszó",
+          "debug_mode": "Csatlakozás tesztszerverhez"
+        },
+        "data_description": {
+          "debug_mode": "Csak fejlesztéshez – helyi tesztszerverhez csatlakozik a produkciós MELCloud API helyett"
+        }
+      },
+      "reauth_confirm": {
+        "title": "A hitelesítés lejárt ehhez: {name}",
+        "description": "Kérjük, frissítsd a jelszavad ehhez: {email}",
+        "data": {
+          "password": "Jelszó"
+        }
+      },
+      "reconfigure": {
+        "title": "Újrakonfigurálás",
+        "description": "Hitelesítő adatok frissítése ehhez: {email}",
+        "data": {
+          "password": "Jelszó"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Érvénytelen e-mail vagy jelszó",
+      "cannot_connect": "Nem sikerült csatlakozni a MELCloud Home-hoz. Ellenőrizd az internetkapcsolatot és próbáld újra.",
+      "service_unavailable": "A MELCloud szolgáltatás jelenleg nem elérhető. Ez szerveroldali hiba – próbáld újra később.",
+      "unknown": "Váratlan hiba történt. Kérjük, próbáld újra."
+    },
+    "abort": {
+      "already_configured": "Ez a fiók már konfigurálva van",
+      "reauth_successful": "Az újrahitelesítés sikeres volt",
+      "reconfigure_successful": "A hitelesítő adatok sikeresen frissítve"
+    }
+  },
+  "entity": {
+    "climate": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "room": "Szoba",
+              "flow": "Áramlás",
+              "curve": "Görbe"
+            }
+          },
+          "fan_mode": {
+            "state": {
+              "auto": "Auto",
+              "one": "Ventilátor 1",
+              "two": "Ventilátor 2",
+              "three": "Ventilátor 3",
+              "four": "Ventilátor 4",
+              "five": "Ventilátor 5"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "auto": "Auto",
+              "swing": "Lengés",
+              "one": "Lengés 1",
+              "two": "Lengés 2",
+              "three": "Lengés 3",
+              "four": "Lengés 4",
+              "five": "Lengés 5"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "auto": "Auto",
+              "swing": "Lengés",
+              "left": "Bal",
+              "leftcentre": "Bal-közép",
+              "centre": "Közép",
+              "rightcentre": "Jobb-közép",
+              "right": "Jobb"
+            }
+          }
+        }
+      }
+    },
+    "sensor": {
+      "room_temperature": {
+        "name": "Szobahőmérséklet"
+      },
+      "wifi_signal": {
+        "name": "WiFi jel"
+      },
+      "energy": {
+        "name": "Energia"
+      },
+      "outdoor_temperature": {
+        "name": "Külső hőmérséklet"
+      },
+      "frost_protection_min": {
+        "name": "Fagyvédelem minimum"
+      },
+      "frost_protection_max": {
+        "name": "Fagyvédelem maximum"
+      },
+      "overheat_protection_min": {
+        "name": "Túlmelegedés védelem minimum"
+      },
+      "overheat_protection_max": {
+        "name": "Túlmelegedés védelem maximum"
+      },
+      "holiday_mode_start_date": {
+        "name": "Szabadság mód kezdete"
+      },
+      "holiday_mode_end_date": {
+        "name": "Szabadság mód vége"
+      },
+      "zone_1_temperature": {
+        "name": "1. zóna hőmérséklet"
+      },
+      "zone_2_temperature": {
+        "name": "2. zóna hőmérséklet"
+      },
+      "tank_temperature": {
+        "name": "Tartály hőmérséklet"
+      },
+      "operation_status": {
+        "name": "Működési állapot"
+      },
+      "flow_temperature": {
+        "name": "Előremenő hőmérséklet"
+      },
+      "return_temperature": {
+        "name": "Visszatérő hőmérséklet"
+      },
+      "flow_temperature_zone1": {
+        "name": "Előremenő hőmérséklet 1. zóna"
+      },
+      "return_temperature_zone1": {
+        "name": "Visszatérő hőmérséklet 1. zóna"
+      },
+      "flow_temperature_zone2": {
+        "name": "Előremenő hőmérséklet 2. zóna"
+      },
+      "return_temperature_zone2": {
+        "name": "Visszatérő hőmérséklet 2. zóna"
+      },
+      "flow_temperature_boiler": {
+        "name": "Előremenő hőmérséklet kazán"
+      },
+      "return_temperature_boiler": {
+        "name": "Visszatérő hőmérséklet kazán"
+      },
+      "energy_consumed": {
+        "name": "Fogyasztott energia"
+      },
+      "energy_produced": {
+        "name": "Termelt energia"
+      },
+      "cop": {
+        "name": "Teljesítménytényező"
+      }
+    },
+    "binary_sensor": {
+      "error_state": {
+        "name": "Hibaállapot"
+      },
+      "connection_state": {
+        "name": "Kapcsolat állapota"
+      },
+      "realtime_updates": {
+        "name": "Valós idejű frissítések"
+      },
+      "forced_dhw_active": {
+        "name": "Kényszerített HMV aktív"
+      },
+      "frost_protection": {
+        "name": "Fagyvédelem"
+      },
+      "overheat_protection": {
+        "name": "Túlmelegedés védelem"
+      },
+      "holiday_mode": {
+        "name": "Szabadság mód"
+      }
+    }
+  },
+  "services": {
+    "force_refresh": {
+      "name": "Frissítés kényszerítése",
+      "description": "Az eszközadatok azonnali frissítése a MELCloud szerverekről (teszteléshez/fejlesztéshez)"
+    }
+  }
+}

--- a/custom_components/melcloudhome/translations/pl.json
+++ b/custom_components/melcloudhome/translations/pl.json
@@ -1,0 +1,209 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opcje MELCloud Home",
+        "data": {
+          "enable_websocket": "Aktualizacje w czasie rzeczywistym"
+        },
+        "data_description": {
+          "enable_websocket": "Zmiany wprowadzone pilotem lub aplikacją MELCloud Home pojawiają się w ciągu kilku sekund."
+        }
+      }
+    }
+  },
+  "config": {
+    "step": {
+      "user": {
+        "title": "Połącz z MELCloud Home",
+        "description": "Wprowadź dane logowania do MELCloud Home",
+        "data": {
+          "email": "E-mail",
+          "password": "Hasło",
+          "debug_mode": "Połącz z serwerem testowym"
+        },
+        "data_description": {
+          "debug_mode": "Tylko do celów deweloperskich — łączy z lokalnym serwerem testowym zamiast produkcyjnego API MELCloud"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Uwierzytelnianie wygasło dla {name}",
+        "description": "Zaktualizuj hasło dla {email}",
+        "data": {
+          "password": "Hasło"
+        }
+      },
+      "reconfigure": {
+        "title": "Rekonfiguruj",
+        "description": "Zaktualizuj dane logowania dla {email}",
+        "data": {
+          "password": "Hasło"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Nieprawidłowy e-mail lub hasło",
+      "cannot_connect": "Nie można połączyć się z MELCloud Home. Sprawdź połączenie internetowe i spróbuj ponownie.",
+      "service_unavailable": "Usługa MELCloud jest obecnie niedostępna. To problem po stronie serwera — spróbuj ponownie później.",
+      "unknown": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie."
+    },
+    "abort": {
+      "already_configured": "To konto jest już skonfigurowane",
+      "reauth_successful": "Ponowne uwierzytelnienie powiodło się",
+      "reconfigure_successful": "Dane logowania zaktualizowane pomyślnie"
+    }
+  },
+  "entity": {
+    "climate": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "room": "Pokój",
+              "flow": "Przepływ",
+              "curve": "Krzywa"
+            }
+          },
+          "fan_mode": {
+            "state": {
+              "auto": "Auto",
+              "one": "Wentylator 1",
+              "two": "Wentylator 2",
+              "three": "Wentylator 3",
+              "four": "Wentylator 4",
+              "five": "Wentylator 5"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "auto": "Auto",
+              "swing": "Wachlowanie",
+              "one": "Wachlowanie 1",
+              "two": "Wachlowanie 2",
+              "three": "Wachlowanie 3",
+              "four": "Wachlowanie 4",
+              "five": "Wachlowanie 5"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "auto": "Auto",
+              "swing": "Wachlowanie",
+              "left": "Lewo",
+              "leftcentre": "Lewo-środek",
+              "centre": "Środek",
+              "rightcentre": "Prawo-środek",
+              "right": "Prawo"
+            }
+          }
+        }
+      }
+    },
+    "sensor": {
+      "room_temperature": {
+        "name": "Temperatura w pomieszczeniu"
+      },
+      "wifi_signal": {
+        "name": "Sygnał WiFi"
+      },
+      "energy": {
+        "name": "Energia"
+      },
+      "outdoor_temperature": {
+        "name": "Temperatura zewnętrzna"
+      },
+      "frost_protection_min": {
+        "name": "Minimum ochrony przed zamarzaniem"
+      },
+      "frost_protection_max": {
+        "name": "Maksimum ochrony przed zamarzaniem"
+      },
+      "overheat_protection_min": {
+        "name": "Minimum ochrony przed przegrzaniem"
+      },
+      "overheat_protection_max": {
+        "name": "Maksimum ochrony przed przegrzaniem"
+      },
+      "holiday_mode_start_date": {
+        "name": "Początek trybu wakacyjnego"
+      },
+      "holiday_mode_end_date": {
+        "name": "Koniec trybu wakacyjnego"
+      },
+      "zone_1_temperature": {
+        "name": "Temperatura strefy 1"
+      },
+      "zone_2_temperature": {
+        "name": "Temperatura strefy 2"
+      },
+      "tank_temperature": {
+        "name": "Temperatura zbiornika"
+      },
+      "operation_status": {
+        "name": "Stan pracy"
+      },
+      "flow_temperature": {
+        "name": "Temperatura zasilania"
+      },
+      "return_temperature": {
+        "name": "Temperatura powrotu"
+      },
+      "flow_temperature_zone1": {
+        "name": "Temperatura zasilania strefa 1"
+      },
+      "return_temperature_zone1": {
+        "name": "Temperatura powrotu strefa 1"
+      },
+      "flow_temperature_zone2": {
+        "name": "Temperatura zasilania strefa 2"
+      },
+      "return_temperature_zone2": {
+        "name": "Temperatura powrotu strefa 2"
+      },
+      "flow_temperature_boiler": {
+        "name": "Temperatura zasilania bojlera"
+      },
+      "return_temperature_boiler": {
+        "name": "Temperatura powrotu bojlera"
+      },
+      "energy_consumed": {
+        "name": "Zużyta energia"
+      },
+      "energy_produced": {
+        "name": "Wyprodukowana energia"
+      },
+      "cop": {
+        "name": "Współczynnik wydajności"
+      }
+    },
+    "binary_sensor": {
+      "error_state": {
+        "name": "Stan błędu"
+      },
+      "connection_state": {
+        "name": "Stan połączenia"
+      },
+      "realtime_updates": {
+        "name": "Aktualizacje w czasie rzeczywistym"
+      },
+      "forced_dhw_active": {
+        "name": "Wymuszone CWU aktywne"
+      },
+      "frost_protection": {
+        "name": "Ochrona przed zamarzaniem"
+      },
+      "overheat_protection": {
+        "name": "Ochrona przed przegrzaniem"
+      },
+      "holiday_mode": {
+        "name": "Tryb wakacyjny"
+      }
+    }
+  },
+  "services": {
+    "force_refresh": {
+      "name": "Wymuś odświeżenie",
+      "description": "Natychmiast odśwież dane urządzenia z serwerów MELCloud (do testów/rozwoju)"
+    }
+  }
+}

--- a/custom_components/melcloudhome/translations/si.json
+++ b/custom_components/melcloudhome/translations/si.json
@@ -1,0 +1,209 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "MELCloud Home විකල්ප",
+        "data": {
+          "enable_websocket": "තත්‍ය කාලීන යාවත්කාලීන"
+        },
+        "data_description": {
+          "enable_websocket": "දුරස්ථ පාලකය හෝ MELCloud Home යෙදුම සමඟ කරන ලද වෙනස්කම් තත්පර කිහිපයකින් දිස්වේ."
+        }
+      }
+    }
+  },
+  "config": {
+    "step": {
+      "user": {
+        "title": "MELCloud Home වෙත සම්බන්ධ වන්න",
+        "description": "ඔබගේ MELCloud Home අක්තපත්‍ර ඇතුළත් කරන්න",
+        "data": {
+          "email": "ඊමේල්",
+          "password": "මුරපදය",
+          "debug_mode": "අනුකරණ සේවාදායකයට සම්බන්ධ වන්න"
+        },
+        "data_description": {
+          "debug_mode": "සංවර්ධනය සඳහා පමණයි - නිෂ්පාදන MELCloud API වෙනුවට දේශීය අනුකරණ සේවාදායකයට සම්බන්ධ වේ"
+        }
+      },
+      "reauth_confirm": {
+        "title": "{name} සඳහා සත්‍යාපනය කල් ඉකුත් වී ඇත",
+        "description": "කරුණාකර {email} සඳහා ඔබගේ මුරපදය යාවත්කාලීන කරන්න",
+        "data": {
+          "password": "මුරපදය"
+        }
+      },
+      "reconfigure": {
+        "title": "නැවත වින්‍යාස කරන්න",
+        "description": "{email} සඳහා අක්තපත්‍ර යාවත්කාලීන කරන්න",
+        "data": {
+          "password": "මුරපදය"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "වලංගු නොවන ඊමේල් හෝ මුරපදය",
+      "cannot_connect": "MELCloud Home වෙත සම්බන්ධ වීමට නොහැක. කරුණාකර ඔබගේ අන්තර්ජාල සම්බන්ධතාවය පරීක්ෂා කර නැවත උත්සාහ කරන්න.",
+      "service_unavailable": "MELCloud සේවාව දැනට ලබා ගත නොහැක. මෙය සේවාදායක පැත්තේ ගැටලුවකි — කරුණාකර පසුව නැවත උත්සාහ කරන්න.",
+      "unknown": "අනපේක්ෂිත දෝෂයක් සිදු විය. කරුණාකර නැවත උත්සාහ කරන්න."
+    },
+    "abort": {
+      "already_configured": "මෙම ගිණුම දැනටමත් වින්‍යාස කර ඇත",
+      "reauth_successful": "නැවත සත්‍යාපනය සාර්ථක විය",
+      "reconfigure_successful": "අක්තපත්‍ර සාර්ථකව යාවත්කාලීන කරන ලදී"
+    }
+  },
+  "entity": {
+    "climate": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "room": "කාමරය",
+              "flow": "ප්‍රවාහය",
+              "curve": "වක්‍රය"
+            }
+          },
+          "fan_mode": {
+            "state": {
+              "auto": "ස්වයංක්‍රීය",
+              "one": "විදුලි පංකා 1",
+              "two": "විදුලි පංකා 2",
+              "three": "විදුලි පංකා 3",
+              "four": "විදුලි පංකා 4",
+              "five": "විදුලි පංකා 5"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "auto": "ස්වයංක්‍රීය",
+              "swing": "පැද්දීම",
+              "one": "පැද්දීම 1",
+              "two": "පැද්දීම 2",
+              "three": "පැද්දීම 3",
+              "four": "පැද්දීම 4",
+              "five": "පැද්දීම 5"
+            }
+          },
+          "swing_horizontal_mode": {
+            "state": {
+              "auto": "ස්වයංක්‍රීය",
+              "swing": "පැද්දීම",
+              "left": "වම",
+              "leftcentre": "වම් මැද",
+              "centre": "මැද",
+              "rightcentre": "දකුණු මැද",
+              "right": "දකුණ"
+            }
+          }
+        }
+      }
+    },
+    "sensor": {
+      "room_temperature": {
+        "name": "කාමර උෂ්ණත්වය"
+      },
+      "wifi_signal": {
+        "name": "WiFi සංඥාව"
+      },
+      "energy": {
+        "name": "ශක්තිය"
+      },
+      "outdoor_temperature": {
+        "name": "බාහිර උෂ්ණත්වය"
+      },
+      "frost_protection_min": {
+        "name": "හිම ආරක්ෂණ අවම"
+      },
+      "frost_protection_max": {
+        "name": "හිම ආරක්ෂණ උපරිම"
+      },
+      "overheat_protection_min": {
+        "name": "අධික තාප ආරක්ෂණ අවම"
+      },
+      "overheat_protection_max": {
+        "name": "අධික තාප ආරක්ෂණ උපරිම"
+      },
+      "holiday_mode_start_date": {
+        "name": "නිවාඩු ප්‍රකාරය ආරම්භය"
+      },
+      "holiday_mode_end_date": {
+        "name": "නිවාඩු ප්‍රකාරය අවසානය"
+      },
+      "zone_1_temperature": {
+        "name": "කලාප 1 උෂ්ණත්වය"
+      },
+      "zone_2_temperature": {
+        "name": "කලාප 2 උෂ්ණත්වය"
+      },
+      "tank_temperature": {
+        "name": "ටැංකි උෂ්ණත්වය"
+      },
+      "operation_status": {
+        "name": "මෙහෙයුම් තත්ත්වය"
+      },
+      "flow_temperature": {
+        "name": "ප්‍රවාහ උෂ්ණත්වය"
+      },
+      "return_temperature": {
+        "name": "ආපසු උෂ්ණත්වය"
+      },
+      "flow_temperature_zone1": {
+        "name": "ප්‍රවාහ උෂ්ණත්වය කලාප 1"
+      },
+      "return_temperature_zone1": {
+        "name": "ආපසු උෂ්ණත්වය කලාප 1"
+      },
+      "flow_temperature_zone2": {
+        "name": "ප්‍රවාහ උෂ්ණත්වය කලාප 2"
+      },
+      "return_temperature_zone2": {
+        "name": "ආපසු උෂ්ණත්වය කලාප 2"
+      },
+      "flow_temperature_boiler": {
+        "name": "ප්‍රවාහ උෂ්ණත්වය බොයිලේරු"
+      },
+      "return_temperature_boiler": {
+        "name": "ආපසු උෂ්ණත්වය බොයිලේරු"
+      },
+      "energy_consumed": {
+        "name": "පරිභෝජනය කළ ශක්තිය"
+      },
+      "energy_produced": {
+        "name": "නිෂ්පාදිත ශක්තිය"
+      },
+      "cop": {
+        "name": "කාර්ය සාධන සංගුණකය"
+      }
+    },
+    "binary_sensor": {
+      "error_state": {
+        "name": "දෝෂ තත්ත්වය"
+      },
+      "connection_state": {
+        "name": "සම්බන්ධතා තත්ත්වය"
+      },
+      "realtime_updates": {
+        "name": "තත්‍ය කාලීන යාවත්කාලීන"
+      },
+      "forced_dhw_active": {
+        "name": "බලහත්කාර DHW සක්‍රීයයි"
+      },
+      "frost_protection": {
+        "name": "හිම ආරක්ෂණය"
+      },
+      "overheat_protection": {
+        "name": "අධික තාප ආරක්ෂණය"
+      },
+      "holiday_mode": {
+        "name": "නිවාඩු ප්‍රකාරය"
+      }
+    }
+  },
+  "services": {
+    "force_refresh": {
+      "name": "බලහත්කාරයෙන් නැවුම් කරන්න",
+      "description": "MELCloud සේවාදායකයන්ගෙන් උපාංග දත්ත වහාම නැවුම් කරන්න (පරීක්ෂා/සංවර්ධන සඳහා)"
+    }
+  }
+}


### PR DESCRIPTION
Closes #69

Adds all remaining Wanted languages from #69 status table:

- cs - Czech
- da - Danish  
- hu - Hungarian
- pl - Polish
- si - Sinhala

All files copied from en.json, translated values only, keys unchanged.
Validated: JSON valid, 79 leaf keys each match EN.