### PR TITLE
fix(i18n): phrase nl/vi holiday_mode date labels as nouns, not commands

### DIFF
--- a/custom_components/melcloudhome/translations/nl.json
+++ b/custom_components/melcloudhome/translations/nl.json
@@ -125,10 +125,10 @@
         "name": "Maximum oververhittingsbeveiliging"
       },
       "holiday_mode_start_date": {
-        "name": "Start vakantiemodus"
+        "name": "Vakantiemodus start"
       },
       "holiday_mode_end_date": {
-        "name": "Einde vakantiemodus"
+        "name": "Vakantiemodus einde"
       },
       "zone_1_temperature": {
         "name": "Zone 1 temperatuur"

--- a/custom_components/melcloudhome/translations/vi.json
+++ b/custom_components/melcloudhome/translations/vi.json
@@ -125,10 +125,10 @@
         "name": "Bảo vệ quá nhiệt tối đa"
       },
       "holiday_mode_start_date": {
-        "name": "Bắt đầu chế độ nghỉ lễ"
+        "name": "Chế độ nghỉ lễ bắt đầu"
       },
       "holiday_mode_end_date": {
-        "name": "Kết thúc chế độ nghỉ lễ"
+        "name": "Chế độ nghỉ lễ kết thúc"
       },
       "zone_1_temperature": {
         "name": "Nhiệt độ vùng 1"


### PR DESCRIPTION
## Summary

- `nl` and `vi` `holiday_mode_start_date`/`end_date` labels read as imperatives ("Start holiday mode") rather than date labels — same issue caught for Norwegian in #69.
- Aligned both with noun-first phrasing to match EN "Holiday mode start/end" and the de/es/fr/it/pt/nb precedent.

## Test plan

- [x] `make pre-commit` passes
- [x] `tests/api/test_translations.py` (key parity) passes
- [x] Valid JSON