### PR TITLE
fix(atw): source outdoor temperature from comfort-graph, not live context

### DIFF
--- a/custom_components/melcloudhome/api/client.py
+++ b/custom_components/melcloudhome/api/client.py
@@ -418,6 +418,12 @@ class MELCloudHomeClient:
 
         "to" is truncated to seconds=0 so the server's to-echo point is
         identifiable as synthetic (see _parse_outdoor_temp).
+
+        Raises whatever _api_request/_parse_outdoor_temp raise - callers
+        must handle failures. This is deliberate: a real error (e.g. a 500)
+        must be distinguishable from a successful poll finding no genuine
+        reading, so the coordinator can record it for diagnostics (issue
+        #251) instead of both cases looking identically like "no data yet".
         """
         now = datetime.now(UTC).replace(second=0, microsecond=0)
         from_time = now - lookback
@@ -430,27 +436,17 @@ class MELCloudHomeClient:
             "to": now.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
         }
 
-        try:
-            response = await self._api_request("GET", endpoint, params=params)
-            if response is None:
-                _LOGGER.debug(
-                    "%s returned None for unit %s (from=%s, to=%s)",
-                    log_label,
-                    unit_id,
-                    params["from"],
-                    params["to"],
-                )
-                return None, None
-            return self._parse_outdoor_temp(response)
-        except Exception:
-            # Log at debug level - outdoor temp is nice-to-have, not critical
+        response = await self._api_request("GET", endpoint, params=params)
+        if response is None:
             _LOGGER.debug(
-                "Failed to fetch %s for unit %s",
+                "%s returned None for unit %s (from=%s, to=%s)",
                 log_label,
                 unit_id,
-                exc_info=True,
+                params["from"],
+                params["to"],
             )
             return None, None
+        return self._parse_outdoor_temp(response)
 
     async def get_outdoor_temperature(
         self, unit_id: str

--- a/custom_components/melcloudhome/api/client.py
+++ b/custom_components/melcloudhome/api/client.py
@@ -407,6 +407,51 @@ class MELCloudHomeClient:
                 return None, None  # No genuine reading in the window
         return None, None  # No outdoor temp dataset found
 
+    async def _get_report_outdoor_temperature(
+        self, endpoint: str, unit_id: str, lookback: timedelta, log_label: str
+    ) -> tuple[float | None, datetime | None]:
+        """Shared implementation for get_outdoor_temperature/get_atw_outdoor_temperature.
+
+        Both query a /report/v1/ endpoint with period=Hourly and parse the
+        same response shape via _parse_outdoor_temp - they differ only in
+        endpoint, lookback window, and log wording.
+
+        "to" is truncated to seconds=0 so the server's to-echo point is
+        identifiable as synthetic (see _parse_outdoor_temp).
+        """
+        now = datetime.now(UTC).replace(second=0, microsecond=0)
+        from_time = now - lookback
+
+        # Format: 2026-01-12T20:00:00.0000000 (7 decimal places for nanoseconds)
+        params = {
+            "unitId": unit_id,
+            "period": "Hourly",
+            "from": from_time.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
+            "to": now.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
+        }
+
+        try:
+            response = await self._api_request("GET", endpoint, params=params)
+            if response is None:
+                _LOGGER.debug(
+                    "%s returned None for unit %s (from=%s, to=%s)",
+                    log_label,
+                    unit_id,
+                    params["from"],
+                    params["to"],
+                )
+                return None, None
+            return self._parse_outdoor_temp(response)
+        except Exception:
+            # Log at debug level - outdoor temp is nice-to-have, not critical
+            _LOGGER.debug(
+                "Failed to fetch %s for unit %s",
+                log_label,
+                unit_id,
+                exc_info=True,
+            )
+            return None, None
+
     async def get_outdoor_temperature(
         self, unit_id: str
     ) -> tuple[float | None, datetime | None]:
@@ -419,6 +464,10 @@ class MELCloudHomeClient:
         quality problems, plus a midnight-rollover artifact where the freshest
         Daily label leads the query time by up to an hour).
 
+        7-day lookback: units stop uploading while idle, so a short window
+        returns no genuine readings for them (the bug behind #111). The
+        coordinator keeps the previous value when this returns None.
+
         Args:
             unit_id: ATA unit UUID
 
@@ -426,43 +475,9 @@ class MELCloudHomeClient:
             Tuple of (temperature in Celsius, UTC-aware datetime of the reading),
             or (None, None) if not available
         """
-        # 7-day lookback: units stop uploading while idle, so a short window
-        # returns no genuine readings for them (the bug behind #111). The
-        # coordinator keeps the previous value when this returns None.
-        # "to" is truncated to seconds=0 so the server's to-echo point is
-        # identifiable as synthetic (see _parse_outdoor_temp).
-        now = datetime.now(UTC).replace(second=0, microsecond=0)
-        from_time = now - timedelta(days=7)
-
-        # Format: 2026-01-12T20:00:00.0000000 (7 decimal places for nanoseconds)
-        params = {
-            "unitId": unit_id,
-            "period": "Hourly",
-            "from": from_time.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
-            "to": now.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
-        }
-
-        try:
-            response = await self._api_request(
-                "GET", API_REPORT_TRENDSUMMARY, params=params
-            )
-            if response is None:
-                _LOGGER.debug(
-                    "Trendsummary returned None for unit %s (from=%s, to=%s)",
-                    unit_id,
-                    params["from"],
-                    params["to"],
-                )
-                return None, None
-            return self._parse_outdoor_temp(response)
-        except Exception:
-            # Log at debug level - outdoor temp is nice-to-have, not critical
-            _LOGGER.debug(
-                "Failed to fetch outdoor temperature for unit %s",
-                unit_id,
-                exc_info=True,
-            )
-            return None, None
+        return await self._get_report_outdoor_temperature(
+            API_REPORT_TRENDSUMMARY, unit_id, timedelta(days=7), "trendsummary"
+        )
 
     async def get_atw_outdoor_temperature(
         self, unit_id: str
@@ -480,6 +495,13 @@ class MELCloudHomeClient:
         can't reach further back. 24h comfortably covers the largest observed
         reporting gap (3.5h) between genuine readings, with margin.
 
+        Reuses _parse_outdoor_temp's UTC-timestamp assumption, which was
+        empirically justified for ATA's trendsummary endpoint - verified
+        separately for comfort-graph (2026-08-17): across 108 genuine
+        readings over a 24h window for a real ATW unit, none led the UTC
+        query time, which local-time (CEST, UTC+2 in August) stamps would by
+        up to two hours.
+
         Args:
             unit_id: ATW unit UUID
 
@@ -487,37 +509,9 @@ class MELCloudHomeClient:
             Tuple of (temperature in Celsius, UTC-aware datetime of the reading),
             or (None, None) if not available
         """
-        now = datetime.now(UTC).replace(second=0, microsecond=0)
-        from_time = now - timedelta(hours=24)
-
-        params = {
-            "unitId": unit_id,
-            "period": "Hourly",
-            "from": from_time.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
-            "to": now.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
-        }
-
-        try:
-            response = await self._api_request(
-                "GET", API_REPORT_COMFORT_GRAPH, params=params
-            )
-            if response is None:
-                _LOGGER.debug(
-                    "Comfort-graph returned None for unit %s (from=%s, to=%s)",
-                    unit_id,
-                    params["from"],
-                    params["to"],
-                )
-                return None, None
-            return self._parse_outdoor_temp(response)
-        except Exception:
-            # Log at debug level - outdoor temp is nice-to-have, not critical
-            _LOGGER.debug(
-                "Failed to fetch ATW outdoor temperature for unit %s",
-                unit_id,
-                exc_info=True,
-            )
-            return None, None
+        return await self._get_report_outdoor_temperature(
+            API_REPORT_COMFORT_GRAPH, unit_id, timedelta(hours=24), "comfort-graph"
+        )
 
     async def get_telemetry_actual(
         self,

--- a/custom_components/melcloudhome/api/client.py
+++ b/custom_components/melcloudhome/api/client.py
@@ -21,6 +21,7 @@ from .const_shared import (
     API_FIELD_MEASURE_DATA,
     API_FIELD_VALUE,
     API_FIELD_VALUES,
+    API_REPORT_COMFORT_GRAPH,
     API_REPORT_TRENDSUMMARY,
     API_TELEMETRY_ACTUAL,
     API_TELEMETRY_ENERGY,
@@ -458,6 +459,61 @@ class MELCloudHomeClient:
             # Log at debug level - outdoor temp is nice-to-have, not critical
             _LOGGER.debug(
                 "Failed to fetch outdoor temperature for unit %s",
+                unit_id,
+                exc_info=True,
+            )
+            return None, None
+
+    async def get_atw_outdoor_temperature(
+        self, unit_id: str
+    ) -> tuple[float | None, datetime | None]:
+        """Get latest outdoor temperature for an ATW unit.
+
+        ATW's live /context OutdoorTemperature can be present but silently
+        wrong (issue #251) or absent entirely, with no way to tell which from
+        the value alone, so this always queries the comfort-graph report
+        instead of ever trusting the live value.
+
+        Uses period=Hourly with a 24h window: comfort-graph's Hourly period
+        hard-fails (500) for windows starting more than ~4 days back
+        regardless of width, so unlike ATA's 7-day trendsummary lookback this
+        can't reach further back. 24h comfortably covers the largest observed
+        reporting gap (3.5h) between genuine readings, with margin.
+
+        Args:
+            unit_id: ATW unit UUID
+
+        Returns:
+            Tuple of (temperature in Celsius, UTC-aware datetime of the reading),
+            or (None, None) if not available
+        """
+        now = datetime.now(UTC).replace(second=0, microsecond=0)
+        from_time = now - timedelta(hours=24)
+
+        params = {
+            "unitId": unit_id,
+            "period": "Hourly",
+            "from": from_time.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
+            "to": now.strftime("%Y-%m-%dT%H:%M:%S.0000000"),
+        }
+
+        try:
+            response = await self._api_request(
+                "GET", API_REPORT_COMFORT_GRAPH, params=params
+            )
+            if response is None:
+                _LOGGER.debug(
+                    "Comfort-graph returned None for unit %s (from=%s, to=%s)",
+                    unit_id,
+                    params["from"],
+                    params["to"],
+                )
+                return None, None
+            return self._parse_outdoor_temp(response)
+        except Exception:
+            # Log at debug level - outdoor temp is nice-to-have, not critical
+            _LOGGER.debug(
+                "Failed to fetch ATW outdoor temperature for unit %s",
                 unit_id,
                 exc_info=True,
             )

--- a/custom_components/melcloudhome/api/const_shared.py
+++ b/custom_components/melcloudhome/api/const_shared.py
@@ -19,6 +19,7 @@ API_USER_CONTEXT = "/context"
 API_TELEMETRY_ENERGY = "/telemetry/telemetry/energy/{unit_id}"
 API_TELEMETRY_ACTUAL = "/telemetry/telemetry/actual/{unit_id}"
 API_REPORT_TRENDSUMMARY = "/report/v1/trendsummary"
+API_REPORT_COMFORT_GRAPH = "/report/v1/comfort-graph"
 
 # API Response Field Names (used in parsing responses - shared across device types)
 API_FIELD_MEASURE_DATA = "measureData"
@@ -56,6 +57,7 @@ __all__ = [
     "API_FIELD_MEASURE_DATA",
     "API_FIELD_VALUE",
     "API_FIELD_VALUES",
+    "API_REPORT_COMFORT_GRAPH",
     "API_REPORT_TRENDSUMMARY",
     "API_TELEMETRY_ACTUAL",
     "API_TELEMETRY_ENERGY",

--- a/custom_components/melcloudhome/api/models_ata.py
+++ b/custom_components/melcloudhome/api/models_ata.py
@@ -140,6 +140,7 @@ class AirToAirUnit:
     # reading. Cleared on the next successful poll. Diagnostic-only signal
     # for telling "endpoint failing for this unit" apart from "no data yet".
     outdoor_temp_last_error: str | None = None
+    outdoor_temp_last_error_at: datetime | None = None  # UTC-aware
     # Protection modes (from GET /context; null until ever configured on this unit)
     frost_protection: ProtectionModeState | None = None
     overheat_protection: ProtectionModeState | None = None

--- a/custom_components/melcloudhome/api/models_ata.py
+++ b/custom_components/melcloudhome/api/models_ata.py
@@ -135,6 +135,11 @@ class AirToAirUnit:
     # When the value was actually recorded by the unit. Idle units stop
     # uploading outdoor temperature, so this can lag hours behind (issue #171)
     outdoor_temp_recorded_at: datetime | None = None  # UTC-aware
+    # Set by the coordinator when the outdoor-temp poll itself raised (e.g. a
+    # real HTTP error), distinct from a successful poll finding no genuine
+    # reading. Cleared on the next successful poll. Diagnostic-only signal
+    # for telling "endpoint failing for this unit" apart from "no data yet".
+    outdoor_temp_last_error: str | None = None
     # Protection modes (from GET /context; null until ever configured on this unit)
     frost_protection: ProtectionModeState | None = None
     overheat_protection: ProtectionModeState | None = None

--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -2,6 +2,7 @@
 
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any
 
 from .const_atw import ATW_MODE_HEAT_ROOM_TEMP, ATW_STATUS_STOP
@@ -177,8 +178,13 @@ class AirToWaterUnit:
     set_temperature_zone2: float | None = None
     room_temperature_zone2: float | None = None
 
-    # Outdoor temperature (from settings response)
+    # Outdoor temperature. Live /context OutdoorTemperature can be silently
+    # wrong (issue #251) or absent, with no way to tell which from the value
+    # alone, so this is never parsed from settings - only ever set by the
+    # coordinator's comfort-graph poll, same as ATA's trendsummary-only value.
     outdoor_temperature: float | None = None  # °C
+    has_outdoor_temp_sensor: bool = False  # Runtime discovery flag
+    outdoor_temp_recorded_at: datetime | None = None  # UTC-aware
 
     # Holiday Mode & Frost Protection (read-only state)
     holiday_mode_enabled: bool = False
@@ -283,8 +289,6 @@ class AirToWaterUnit:
             ftc_model=int(settings.get("FTCModel", "3")),
             # Capabilities
             capabilities=capabilities,
-            # Outdoor temperature (included in settings response)
-            outdoor_temperature=_parse_float(settings.get("OutdoorTemperature")),
             # Holiday Mode & Frost Protection
             holiday_mode_enabled=holiday_enabled,
             frost_protection_enabled=frost_enabled,

--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -190,6 +190,7 @@ class AirToWaterUnit:
     # reading. Cleared on the next successful poll. Diagnostic-only signal
     # for telling "endpoint failing for this unit" apart from "no data yet".
     outdoor_temp_last_error: str | None = None
+    outdoor_temp_last_error_at: datetime | None = None  # UTC-aware
 
     # Holiday Mode & Frost Protection (read-only state)
     holiday_mode_enabled: bool = False

--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -185,6 +185,11 @@ class AirToWaterUnit:
     outdoor_temperature: float | None = None  # °C
     has_outdoor_temp_sensor: bool = False  # Runtime discovery flag
     outdoor_temp_recorded_at: datetime | None = None  # UTC-aware
+    # Set by the coordinator when the outdoor-temp poll itself raised (e.g. a
+    # real HTTP error), distinct from a successful poll finding no genuine
+    # reading. Cleared on the next successful poll. Diagnostic-only signal
+    # for telling "endpoint failing for this unit" apart from "no data yet".
+    outdoor_temp_last_error: str | None = None
 
     # Holiday Mode & Frost Protection (read-only state)
     holiday_mode_enabled: bool = False

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -636,6 +636,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 unit.outdoor_temperature = old_unit.outdoor_temperature
                 unit.outdoor_temp_recorded_at = old_unit.outdoor_temp_recorded_at
                 unit.outdoor_temp_last_error = old_unit.outdoor_temp_last_error
+                unit.outdoor_temp_last_error_at = old_unit.outdoor_temp_last_error_at
 
             if not self._should_poll_outdoor_temp(unit_id):
                 continue
@@ -646,6 +647,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 )
                 self._record_outdoor_temp_poll(unit_id)
                 unit.outdoor_temp_last_error = None
+                unit.outdoor_temp_last_error_at = None
 
                 if temp is not None:
                     unit.has_outdoor_temp_sensor = True
@@ -663,6 +665,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             except Exception as err:
                 self._record_outdoor_temp_poll(unit_id)
                 unit.outdoor_temp_last_error = f"{type(err).__name__}: {err}"
+                unit.outdoor_temp_last_error_at = datetime.now(UTC)
                 _LOGGER.debug(
                     "Failed to fetch %s for %s",
                     log_label,

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import inspect
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -216,115 +217,36 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
 
                 _LOGGER.debug(base_msg, *base_args)
 
-        # Update outdoor temperature for ATA devices (30 minute interval)
-        for building in context.buildings:
-            for unit in building.air_to_air_units:
-                unit_id = unit.id  # Capture for closures
-
-                # Preserve outdoor temp state from previous update
-                if unit_id in self._units:
-                    old_unit = self._units[unit_id]
-                    unit.has_outdoor_temp_sensor = old_unit.has_outdoor_temp_sensor
-                    unit.outdoor_temperature = old_unit.outdoor_temperature
-                    unit.outdoor_temp_recorded_at = old_unit.outdoor_temp_recorded_at
-
-                async def get_outdoor_temp(
-                    uid: str = unit_id,
-                ) -> tuple[float | None, datetime | None]:
-                    return await self.client.get_outdoor_temperature(uid)
-
-                # Poll outdoor temp if: never polled, or interval elapsed.
-                # Runs for both known-sensor and no-sensor units so idle-at-startup
-                # units recover automatically when the AC next runs.
-                if self._should_poll_outdoor_temp(unit_id):
-                    try:
-                        temp, recorded_at = await self._execute_with_retry(
-                            get_outdoor_temp,
-                            "outdoor temperature",
-                        )
-                        self._record_outdoor_temp_poll(unit_id)
-
-                        if temp is not None:
-                            unit.has_outdoor_temp_sensor = True
-                            unit.outdoor_temperature = temp
-                            unit.outdoor_temp_recorded_at = recorded_at
-                            _LOGGER.debug(
-                                "Outdoor temp for %s: %.1f°C (recorded %s)",
-                                unit.name,
-                                temp,
-                                recorded_at,
-                            )
-                        else:
-                            _LOGGER.debug(
-                                "No outdoor temp data for %s",
-                                unit.name,
-                            )
-                    except Exception:
-                        self._record_outdoor_temp_poll(unit_id)
-                        _LOGGER.debug(
-                            "Failed to fetch outdoor temp for %s",
-                            unit.name,
-                            exc_info=True,
-                        )
+        # Update outdoor temperature for ATA devices (30 minute interval).
+        # Runs for both known-sensor and no-sensor units so idle-at-startup
+        # units recover automatically when the AC next runs.
+        await self._poll_outdoor_temperature(
+            (
+                unit
+                for building in context.buildings
+                for unit in building.air_to_air_units
+            ),
+            self._units,
+            self.client.get_outdoor_temperature,
+            "outdoor temperature",
+        )
 
         # Update outdoor temperature for ATW devices via comfort-graph.
         # Live /context OutdoorTemperature can be silently wrong (issue #251)
         # or absent, with no way to tell which from the value alone, so this
         # never trusts it - comfort-graph is the sole source, same as ATA's
-        # trendsummary-only value above.
-        for building in context.buildings:
-            for atw_unit in building.air_to_water_units:
-                atw_unit_id = atw_unit.id  # Capture for closures
-
-                # Preserve outdoor temp state from previous update
-                if atw_unit_id in self._atw_units:
-                    old_atw_unit = self._atw_units[atw_unit_id]
-                    atw_unit.has_outdoor_temp_sensor = (
-                        old_atw_unit.has_outdoor_temp_sensor
-                    )
-                    atw_unit.outdoor_temperature = old_atw_unit.outdoor_temperature
-                    atw_unit.outdoor_temp_recorded_at = (
-                        old_atw_unit.outdoor_temp_recorded_at
-                    )
-
-                async def get_atw_outdoor_temp(
-                    uid: str = atw_unit_id,
-                ) -> tuple[float | None, datetime | None]:
-                    return await self.client.get_atw_outdoor_temperature(uid)
-
-                # Poll outdoor temp if: never polled, or interval elapsed.
-                # Shares _last_outdoor_temp_poll/_should_poll_outdoor_temp
-                # with ATA above - unit IDs are unique across device types.
-                if self._should_poll_outdoor_temp(atw_unit_id):
-                    try:
-                        temp, recorded_at = await self._execute_with_retry(
-                            get_atw_outdoor_temp,
-                            "ATW outdoor temperature",
-                        )
-                        self._record_outdoor_temp_poll(atw_unit_id)
-
-                        if temp is not None:
-                            atw_unit.has_outdoor_temp_sensor = True
-                            atw_unit.outdoor_temperature = temp
-                            atw_unit.outdoor_temp_recorded_at = recorded_at
-                            _LOGGER.debug(
-                                "ATW outdoor temp for %s: %.1f°C (recorded %s)",
-                                atw_unit.name,
-                                temp,
-                                recorded_at,
-                            )
-                        else:
-                            _LOGGER.debug(
-                                "No ATW outdoor temp data for %s",
-                                atw_unit.name,
-                            )
-                    except Exception:
-                        self._record_outdoor_temp_poll(atw_unit_id)
-                        _LOGGER.debug(
-                            "Failed to fetch ATW outdoor temp for %s",
-                            atw_unit.name,
-                            exc_info=True,
-                        )
+        # trendsummary-only value above. Shares _last_outdoor_temp_poll with
+        # ATA - unit IDs are unique across device types.
+        await self._poll_outdoor_temperature(
+            (
+                atw_unit
+                for building in context.buildings
+                for atw_unit in building.air_to_water_units
+            ),
+            self._atw_units,
+            self.client.get_atw_outdoor_temperature,
+            "ATW outdoor temperature",
+        )
 
         # Update caches for O(1) lookups
         self._rebuild_caches(context)
@@ -691,6 +613,60 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             _LOGGER.error("API error during %s: %s", operation_name, err)
             raise HomeAssistantError(f"API error: {err}") from err
 
+    async def _poll_outdoor_temperature(
+        self,
+        units: Iterable[AirToAirUnit | AirToWaterUnit],
+        cache: Mapping[str, AirToAirUnit | AirToWaterUnit],
+        get_temp: Callable[[str], Awaitable[tuple[float | None, datetime | None]]],
+        log_label: str,
+    ) -> None:
+        """Poll outdoor temperature for a set of units, shared by ATA and ATW.
+
+        Preserves the previous value across updates, polls only when
+        _should_poll_outdoor_temp allows it, and never resets to None on
+        failure - a failed poll just leaves whatever value (or None) was
+        already there until the next successful one.
+        """
+        for unit in units:
+            unit_id = unit.id
+
+            if unit_id in cache:
+                old_unit = cache[unit_id]
+                unit.has_outdoor_temp_sensor = old_unit.has_outdoor_temp_sensor
+                unit.outdoor_temperature = old_unit.outdoor_temperature
+                unit.outdoor_temp_recorded_at = old_unit.outdoor_temp_recorded_at
+
+            if not self._should_poll_outdoor_temp(unit_id):
+                continue
+
+            try:
+                temp, recorded_at = await self._execute_with_retry(
+                    functools.partial(get_temp, unit_id), log_label
+                )
+                self._record_outdoor_temp_poll(unit_id)
+
+                if temp is not None:
+                    unit.has_outdoor_temp_sensor = True
+                    unit.outdoor_temperature = temp
+                    unit.outdoor_temp_recorded_at = recorded_at
+                    _LOGGER.debug(
+                        "%s for %s: %.1f°C (recorded %s)",
+                        log_label,
+                        unit.name,
+                        temp,
+                        recorded_at,
+                    )
+                else:
+                    _LOGGER.debug("No %s data for %s", log_label, unit.name)
+            except Exception:
+                self._record_outdoor_temp_poll(unit_id)
+                _LOGGER.debug(
+                    "Failed to fetch %s for %s",
+                    log_label,
+                    unit.name,
+                    exc_info=True,
+                )
+
     def _should_poll_outdoor_temp(self, unit_id: str) -> bool:
         """Check if outdoor temp should be polled for a specific unit."""
         last_poll = self._last_outdoor_temp_poll.get(unit_id)
@@ -701,6 +677,14 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
     def _record_outdoor_temp_poll(self, unit_id: str) -> None:
         """Record that outdoor temp was polled for a unit."""
         self._last_outdoor_temp_poll[unit_id] = datetime.now(UTC)
+
+    def reset_outdoor_temp_polling(self) -> None:
+        """Clear outdoor temp poll history so the next refresh re-polls all units.
+
+        Public so tests can simulate the polling interval elapsing without
+        reaching into a private attribute.
+        """
+        self._last_outdoor_temp_poll.clear()
 
     # =================================================================
     # Air-to-Air (A2A) Control Methods - Delegate to ATAControlClient

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -267,6 +267,65 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                             exc_info=True,
                         )
 
+        # Update outdoor temperature for ATW devices via comfort-graph.
+        # Live /context OutdoorTemperature can be silently wrong (issue #251)
+        # or absent, with no way to tell which from the value alone, so this
+        # never trusts it - comfort-graph is the sole source, same as ATA's
+        # trendsummary-only value above.
+        for building in context.buildings:
+            for atw_unit in building.air_to_water_units:
+                atw_unit_id = atw_unit.id  # Capture for closures
+
+                # Preserve outdoor temp state from previous update
+                if atw_unit_id in self._atw_units:
+                    old_atw_unit = self._atw_units[atw_unit_id]
+                    atw_unit.has_outdoor_temp_sensor = (
+                        old_atw_unit.has_outdoor_temp_sensor
+                    )
+                    atw_unit.outdoor_temperature = old_atw_unit.outdoor_temperature
+                    atw_unit.outdoor_temp_recorded_at = (
+                        old_atw_unit.outdoor_temp_recorded_at
+                    )
+
+                async def get_atw_outdoor_temp(
+                    uid: str = atw_unit_id,
+                ) -> tuple[float | None, datetime | None]:
+                    return await self.client.get_atw_outdoor_temperature(uid)
+
+                # Poll outdoor temp if: never polled, or interval elapsed.
+                # Shares _last_outdoor_temp_poll/_should_poll_outdoor_temp
+                # with ATA above - unit IDs are unique across device types.
+                if self._should_poll_outdoor_temp(atw_unit_id):
+                    try:
+                        temp, recorded_at = await self._execute_with_retry(
+                            get_atw_outdoor_temp,
+                            "ATW outdoor temperature",
+                        )
+                        self._record_outdoor_temp_poll(atw_unit_id)
+
+                        if temp is not None:
+                            atw_unit.has_outdoor_temp_sensor = True
+                            atw_unit.outdoor_temperature = temp
+                            atw_unit.outdoor_temp_recorded_at = recorded_at
+                            _LOGGER.debug(
+                                "ATW outdoor temp for %s: %.1f°C (recorded %s)",
+                                atw_unit.name,
+                                temp,
+                                recorded_at,
+                            )
+                        else:
+                            _LOGGER.debug(
+                                "No ATW outdoor temp data for %s",
+                                atw_unit.name,
+                            )
+                    except Exception:
+                        self._record_outdoor_temp_poll(atw_unit_id)
+                        _LOGGER.debug(
+                            "Failed to fetch ATW outdoor temp for %s",
+                            atw_unit.name,
+                            exc_info=True,
+                        )
+
         # Update caches for O(1) lookups
         self._rebuild_caches(context)
         return context

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -635,6 +635,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 unit.has_outdoor_temp_sensor = old_unit.has_outdoor_temp_sensor
                 unit.outdoor_temperature = old_unit.outdoor_temperature
                 unit.outdoor_temp_recorded_at = old_unit.outdoor_temp_recorded_at
+                unit.outdoor_temp_last_error = old_unit.outdoor_temp_last_error
 
             if not self._should_poll_outdoor_temp(unit_id):
                 continue
@@ -644,6 +645,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                     functools.partial(get_temp, unit_id), log_label
                 )
                 self._record_outdoor_temp_poll(unit_id)
+                unit.outdoor_temp_last_error = None
 
                 if temp is not None:
                     unit.has_outdoor_temp_sensor = True
@@ -658,8 +660,9 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                     )
                 else:
                     _LOGGER.debug("No %s data for %s", log_label, unit.name)
-            except Exception:
+            except Exception as err:
                 self._record_outdoor_temp_poll(unit_id)
+                unit.outdoor_temp_last_error = f"{type(err).__name__}: {err}"
                 _LOGGER.debug(
                     "Failed to fetch %s for %s",
                     log_label,

--- a/custom_components/melcloudhome/diagnostics_ata.py
+++ b/custom_components/melcloudhome/diagnostics_ata.py
@@ -37,4 +37,9 @@ def serialize_ata_unit(unit: AirToAirUnit) -> dict[str, Any]:
             else None
         ),
         "outdoor_temp_last_error": unit.outdoor_temp_last_error,
+        "outdoor_temp_last_error_at": (
+            unit.outdoor_temp_last_error_at.isoformat()
+            if unit.outdoor_temp_last_error_at
+            else None
+        ),
     }

--- a/custom_components/melcloudhome/diagnostics_ata.py
+++ b/custom_components/melcloudhome/diagnostics_ata.py
@@ -29,4 +29,12 @@ def serialize_ata_unit(unit: AirToAirUnit) -> dict[str, Any]:
         "has_energy_consumed_meter": (
             unit.capabilities.has_energy_consumed_meter if unit.capabilities else None
         ),
+        "outdoor_temperature": unit.outdoor_temperature,
+        "has_outdoor_temp_sensor": unit.has_outdoor_temp_sensor,
+        "outdoor_temp_recorded_at": (
+            unit.outdoor_temp_recorded_at.isoformat()
+            if unit.outdoor_temp_recorded_at
+            else None
+        ),
+        "outdoor_temp_last_error": unit.outdoor_temp_last_error,
     }

--- a/custom_components/melcloudhome/diagnostics_ata.py
+++ b/custom_components/melcloudhome/diagnostics_ata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from .api.models_ata import AirToAirUnit
+from .diagnostics_shared import serialize_outdoor_temp_fields
 
 
 def serialize_ata_unit(unit: AirToAirUnit) -> dict[str, Any]:
@@ -30,16 +31,5 @@ def serialize_ata_unit(unit: AirToAirUnit) -> dict[str, Any]:
             unit.capabilities.has_energy_consumed_meter if unit.capabilities else None
         ),
         "outdoor_temperature": unit.outdoor_temperature,
-        "has_outdoor_temp_sensor": unit.has_outdoor_temp_sensor,
-        "outdoor_temp_recorded_at": (
-            unit.outdoor_temp_recorded_at.isoformat()
-            if unit.outdoor_temp_recorded_at
-            else None
-        ),
-        "outdoor_temp_last_error": unit.outdoor_temp_last_error,
-        "outdoor_temp_last_error_at": (
-            unit.outdoor_temp_last_error_at.isoformat()
-            if unit.outdoor_temp_last_error_at
-            else None
-        ),
+        **serialize_outdoor_temp_fields(unit),
     }

--- a/custom_components/melcloudhome/diagnostics_atw.py
+++ b/custom_components/melcloudhome/diagnostics_atw.py
@@ -42,4 +42,9 @@ def serialize_atw_unit(unit: AirToWaterUnit) -> dict[str, Any]:
             else None
         ),
         "outdoor_temp_last_error": unit.outdoor_temp_last_error,
+        "outdoor_temp_last_error_at": (
+            unit.outdoor_temp_last_error_at.isoformat()
+            if unit.outdoor_temp_last_error_at
+            else None
+        ),
     }

--- a/custom_components/melcloudhome/diagnostics_atw.py
+++ b/custom_components/melcloudhome/diagnostics_atw.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from .api.models_atw import AirToWaterUnit
+from .diagnostics_shared import serialize_outdoor_temp_fields
 
 
 def serialize_atw_unit(unit: AirToWaterUnit) -> dict[str, Any]:
@@ -35,16 +36,5 @@ def serialize_atw_unit(unit: AirToWaterUnit) -> dict[str, Any]:
         "forced_hot_water_mode": unit.forced_hot_water_mode,
         "has_zone2": unit.has_zone2,
         "outdoor_temperature": unit.outdoor_temperature,
-        "has_outdoor_temp_sensor": unit.has_outdoor_temp_sensor,
-        "outdoor_temp_recorded_at": (
-            unit.outdoor_temp_recorded_at.isoformat()
-            if unit.outdoor_temp_recorded_at
-            else None
-        ),
-        "outdoor_temp_last_error": unit.outdoor_temp_last_error,
-        "outdoor_temp_last_error_at": (
-            unit.outdoor_temp_last_error_at.isoformat()
-            if unit.outdoor_temp_last_error_at
-            else None
-        ),
+        **serialize_outdoor_temp_fields(unit),
     }

--- a/custom_components/melcloudhome/diagnostics_atw.py
+++ b/custom_components/melcloudhome/diagnostics_atw.py
@@ -35,4 +35,11 @@ def serialize_atw_unit(unit: AirToWaterUnit) -> dict[str, Any]:
         "forced_hot_water_mode": unit.forced_hot_water_mode,
         "has_zone2": unit.has_zone2,
         "outdoor_temperature": unit.outdoor_temperature,
+        "has_outdoor_temp_sensor": unit.has_outdoor_temp_sensor,
+        "outdoor_temp_recorded_at": (
+            unit.outdoor_temp_recorded_at.isoformat()
+            if unit.outdoor_temp_recorded_at
+            else None
+        ),
+        "outdoor_temp_last_error": unit.outdoor_temp_last_error,
     }

--- a/custom_components/melcloudhome/diagnostics_shared.py
+++ b/custom_components/melcloudhome/diagnostics_shared.py
@@ -1,0 +1,28 @@
+"""Shared diagnostics serialization helpers for ATA and ATW units."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .api.models_ata import AirToAirUnit
+from .api.models_atw import AirToWaterUnit
+
+
+def serialize_outdoor_temp_fields(
+    unit: AirToAirUnit | AirToWaterUnit,
+) -> dict[str, Any]:
+    """Serialize the outdoor-temp diagnostic fields shared by ATA and ATW units."""
+    return {
+        "has_outdoor_temp_sensor": unit.has_outdoor_temp_sensor,
+        "outdoor_temp_recorded_at": (
+            unit.outdoor_temp_recorded_at.isoformat()
+            if unit.outdoor_temp_recorded_at
+            else None
+        ),
+        "outdoor_temp_last_error": unit.outdoor_temp_last_error,
+        "outdoor_temp_last_error_at": (
+            unit.outdoor_temp_last_error_at.isoformat()
+            if unit.outdoor_temp_last_error_at
+            else None
+        ),
+    }

--- a/custom_components/melcloudhome/sensor_atw.py
+++ b/custom_components/melcloudhome/sensor_atw.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -57,6 +58,9 @@ class ATWSensorEntityDescription(SensorEntityDescription):  # type: ignore[misc]
     value_fn: Callable[[AirToWaterUnit], float | str | None]
     """Function to extract sensor value from unit data."""
 
+    attributes_fn: Callable[[AirToWaterUnit], dict[str, Any]] | None = None
+    """Optional function to extract extra state attributes from unit data."""
+
     should_create_fn: Callable[[AirToWaterUnit], bool] = lambda x: True
     """Whether to create the sensor at all.
 
@@ -95,7 +99,9 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.tank_water_temperature,
     ),
-    # Outdoor temperature. Always created; "unknown" until a reading arrives.
+    # Outdoor temperature - sourced from the comfort-graph report, never the
+    # live /context value (issue #251). Always created; "unknown" until a
+    # reading arrives.
     ATWSensorEntityDescription(
         key="outdoor_temperature",
         translation_key="outdoor_temperature",
@@ -103,6 +109,12 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.outdoor_temperature,
+        # last_reading surfaces staleness: units may not upload every poll.
+        attributes_fn=lambda unit: {
+            "last_reading": unit.outdoor_temp_recorded_at.isoformat()
+            if unit.outdoor_temp_recorded_at
+            else None
+        },
     ),
     # Operation status (3-way valve position - raw API values)
     ATWSensorEntityDescription(
@@ -305,6 +317,17 @@ class ATWSensor(CoordinatorEntity[CoordinatorProtocol], SensorEntity):  # type: 
             return None
 
         return self.entity_description.value_fn(device)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return extra state attributes."""
+        if self.entity_description.attributes_fn is None:
+            return None
+
+        device = self.coordinator.get_atw_device(self._unit_id)
+        if device is None:
+            return None
+        return self.entity_description.attributes_fn(device)
 
     @property
     def available(self) -> bool:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,7 +59,7 @@ graph LR
         UserContextAPI["GET /context<br/>(SHARED)"]
         ATAAPI["PUT /monitor/ataunit/{id}<br/>(ATA Control)"]
         ATWAPI["PUT /monitor/atwunit/{id}<br/>(ATW Control)"]
-        TelemetryAPI["GET /telemetry/...<br/>/report/v1/trendsummary<br/>(Energy/Telemetry)"]
+        TelemetryAPI["GET /telemetry/...<br/>/report/v1/trendsummary<br/>/report/v1/comfort-graph<br/>(Energy/Telemetry)"]
     end
     subgraph "MELCloud WebSocket<br/>ws.melcloudhome.com"
         WSHash["WS hash endpoint<br/>(Bearer → short-lived hash)"]
@@ -106,7 +106,7 @@ graph LR
 - **Single API client** provides unified interface to the MELCloud mobile API, plus proactive token refresh (60s pre-expiry buffer)
 - **Shared auth** — one OAuth session (access + refresh tokens) for all endpoints
 - **UserContext** (`/context`) returns both device types in one response
-- **Telemetry** is separate from state polling — `/telemetry/...` (30m energy, 60m flow/return) and `/report/v1/trendsummary` (30m ATA outdoor temp) each run on independent timers
+- **Telemetry** is separate from state polling — `/telemetry/...` (30m energy, 60m flow/return), `/report/v1/trendsummary` (30m ATA outdoor temp), and `/report/v1/comfort-graph` (30m ATW outdoor temp) each run on independent timers
 - **WebSocket listener** (default on) receives `unitStateChanged` deltas and triggers the debounced `/context` refresh — it never writes state and never sends commands; see [Real-Time WebSocket Updates](#real-time-websocket-updates-default-on)
 
 ---
@@ -330,6 +330,10 @@ sequenceDiagram
         APIClient->>Server: GET /report/v1/trendsummary
         Server-->>APIClient: outdoor temperature
     end
+    loop Every 30 min — ATW outdoor temp
+        APIClient->>Server: GET /report/v1/comfort-graph
+        Server-->>APIClient: outdoor temperature
+    end
     loop Every 60 min — ATW flow / return telemetry
         APIClient->>Server: GET /telemetry/telemetry/actual/{id}
         Server-->>APIClient: flow + return temperatures
@@ -352,7 +356,7 @@ sequenceDiagram
 **Coordinator Responsibilities (`MELCloudHomeCoordinator`):**
 
 - **State polling**: Drives the 60-second `/context` refresh loop; dispatches updates to all platforms.
-- **Independent telemetry timers**: Separate 30-minute energy timer, 30-minute ATA outdoor-temperature timer (via `/report/v1/trendsummary`), and 60-minute ATW flow/return telemetry timer.
+- **Independent telemetry timers**: Separate 30-minute energy timer, 30-minute ATA outdoor-temperature timer (via `/report/v1/trendsummary`), 30-minute ATW outdoor-temperature timer (via `/report/v1/comfort-graph` — the live `/context` value is never trusted, see issue #251), and 60-minute ATW flow/return telemetry timer.
 - **Re-auth ladder** (`_run_with_reauth`, guarded by `_reauth_lock`): retry-once → refresh_token → full login → `ConfigEntryAuthFailed` (triggers HA repair UI) if all fail. This is the single place in the integration that runs re-login on auth failure.
 - **WebSocket lifecycle**: `_async_setup_websocket` launches `MELCloudHomeWebSocket` as an entry-scoped background task when enabled (default on, `enable_websocket` option); `_on_ws_delta` feeds each delta into the same debounced refresh the control clients use. HA cancels the task on entry unload/reload.
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -146,7 +146,12 @@ For each heat pump system, the following entities are created:
 - **Tank Temperature**: `sensor.melcloudhome_{short_id}_tank_temperature`
 - **Outdoor Temperature**: `sensor.melcloudhome_{short_id}_outdoor_temperature`
   - Ambient temperature from the outdoor unit
-  - Available on all connected ATW devices; read from the regular polling response
+  - Created for every ATW unit; shows `unknown` until a reading arrives. Sourced
+    exclusively from the comfort-graph report, never the live polling response —
+    that value can be silently wrong or absent with no way to tell from the
+    value alone (issue #251)
+  - Attribute `last_reading`: timestamp of when the unit actually recorded the
+    value, for detecting stale data in automations (same pattern as ATA above)
 
 **Operation Status:**
 

--- a/tests/api/cassettes/test_get_atw_outdoor_temperature.yaml
+++ b/tests/api/cassettes/test_get_atw_outdoor_temperature.yaml
@@ -1,0 +1,746 @@
+interactions:
+- request:
+    body:
+      client_id: homemobile
+      code_challenge: GWTCg0JxHH_6o0UvYbKXQdvds2lmmWPgYusWJeR01Io
+      code_challenge_method: S256
+      redirect_uri: melcloudhome://
+      response_type: code
+      scope: openid profile email offline_access IdentityServerApi
+      state: oK1XfnZKChh7Sf_OFUA_iQ
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+    method: POST
+    uri: https://auth.melcloudhome.com/connect/par
+  response:
+    body:
+      string: '{"request_uri":"urn:ietf:params:oauth:request_uri:834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682","expires_in":600}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache, max-age=0
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '133'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 17 Aug 2026 07:44:40 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Kestrel
+      apigw-requestid:
+      - CPJMXjKyjoEEPWw=
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - auth.melcloudhome.com
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+    method: GET
+    uri: https://auth.melcloudhome.com/connect/authorize?client_id=homemobile&request_uri=urn:ietf:params:oauth:request_uri:834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682
+  response:
+    body: {}
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 17 Aug 2026 07:44:40 GMT
+      Location:
+      - https://auth.melcloudhome.com/Account/Login?ReturnUrl=%2Fconnect%2Fauthorize%2Fcallback%3Frequest_uri%3Durn%253Aietf%253Aparams%253Aoauth%253Arequest_uri%253A834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682%26client_id%3Dhomemobile
+      Server:
+      - Kestrel
+      apigw-requestid:
+      - CPJMYj4lDoEEPmw=
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - auth.melcloudhome.com
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+    method: GET
+    uri: https://auth.melcloudhome.com/Account/Login?ReturnUrl=/connect/authorize/callback?request_uri%3Durn%253Aietf%253Aparams%253Aoauth%253Arequest_uri%253A834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682%26client_id%3Dhomemobile
+  response:
+    body: {}
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 17 Aug 2026 07:44:40 GMT
+      Location:
+      - /ExternalLogin/Challenge?scheme=cognito-meu&returnUrl=%2Fconnect%2Fauthorize%2Fcallback%3Frequest_uri%3Durn%253Aietf%253Aparams%253Aoauth%253Arequest_uri%253A834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682%26client_id%3Dhomemobile
+      Server:
+      - Kestrel
+      apigw-requestid:
+      - CPJMYhOHjoEEPgQ=
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - auth.melcloudhome.com
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+    method: GET
+    uri: https://auth.melcloudhome.com/ExternalLogin/Challenge?scheme=cognito-meu&returnUrl=/connect/authorize/callback?request_uri%3Durn%253Aietf%253Aparams%253Aoauth%253Arequest_uri%253A834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682%26client_id%3Dhomemobile
+  response:
+    body: {}
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 17 Aug 2026 07:44:40 GMT
+      Location:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/oauth2/authorize?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https%3A%2F%2Fauth.melcloudhome.com%2Fsignin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - '***REDACTED***'
+      apigw-requestid:
+      - CPJMZglwDoEEPYw=
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - live-melcloudhome.auth.eu-west-1.amazoncognito.com
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+    method: GET
+    uri: https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/oauth2/authorize?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+  response:
+    body: {}
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 17 Aug 2026 07:44:40 GMT
+      Location:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/login?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+      Pragma:
+      - no-cache
+      Server:
+      - Server
+      Set-Cookie:
+      - '***REDACTED***'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - '0'
+      x-amz-cognito-request-id:
+      - d76397d7-c5b6-4e76-9f22-bd9921fa729f
+    status:
+      code: 302
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - live-melcloudhome.auth.eu-west-1.amazoncognito.com
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+      cookie:
+      - '***REDACTED***'
+    method: GET
+    uri: https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/login?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html lang=\"en\">\n<head><head>\n    <link href=\"https://d2uqej7bo24sqa.cloudfront.net/20240614193835/css/bootstrap.min.css\"
+        rel=\"stylesheet\"\n        media=\"screen\" />\n    <link href=\"https://d2uqej7bo24sqa.cloudfront.net/20240614193835/css/cognito-login.css\"
+        rel=\"stylesheet\"\n        media=\"screen\" />\n    <link href=\"https://d2uqej7bo24sqa.cloudfront.net/eu-west-1_gFEQiVmPM/3g4d5l5kivuqi7oia68gib7uso/20250401160518/assets/CSS/custom-css.css\"
+        rel=\"stylesheet\" media=\"screen\" />\n    <title>Signin</title>\n\n    <script
+        src=\"https://d2uqej7bo24sqa.cloudfront.net/20240614193835/js/amazon-cognito-advanced-security-data.min.js\"
+        ></script>\n    <script>\n    function getAdvancedSecurityData(formReference)
+        {\n        if (typeof AmazonCognitoAdvancedSecurityData === \"undefined\")
+        {\n            return true;\n        }\n\n        // UserpoolId is not available
+        on frontend for springboard. We do not use userPoolId\n        // anyway other
+        than put in context data. \n        var userPoolId = \"\";\n        var clientId
+        = getUrlParameter(\"client_id\");\n\n        var username = \"\";\n        var
+        usernameInput = document.getElementsByName(\"username\")[0];\n        if (usernameInput
+        && usernameInput.value) {\n            username = usernameInput.value;\n        }\n\n
+        \       var asfData = AmazonCognitoAdvancedSecurityData.getData(username,
+        userPoolId, clientId);\n        if (typeof asfData === \"undefined\") {\n
+        \           return true;\n        }\n\n        if (formReference && formReference.cognitoAsfData)
+        {\n            formReference.cognitoAsfData.value = asfData\n        }\n\n
+        \       return true;\n    }\n\n    function getUrlParameter(name) {\n        name
+        = name.replace(/[\\[]/, '\\\\[').replace(/[\\]]/, '\\\\]');\n        var regex
+        = new RegExp('[\\\\?&]' + name + '=([^&#]*)');\n        var results = regex.exec(location.search);\n
+        \       return results === null ? '' : decodeURIComponent(results[1].replace(/\\+/g,
+        ' '));\n    }\n\n    function onSubmit(evt, formRef) {\n        formRef.querySelector('button[type=\"submit\"]').disabled
+        = true;\n        if (!!formRef.submitted) {\n            evt.preventDefault();\n
+        \           return false;\n        } else {\n            formRef.submitted
+        = true;\n            return getAdvancedSecurityData(formRef);\n        }\n
+        \   }\n\n    function onSubmitLoginForm (formRef) {\n        formRef.querySelector('input[name=\"signInSubmitButton\"]').disabled
+        = true;\n        getAdvancedSecurityData(formRef)\n    }\n</script>\n\n    <meta
+        name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n</head></head>\n<body
+        spellcheck=\"false\">\n    <div class=\"container\">\n        <div class=\"modal-dialog\">\n
+        \           <div class=\"modal-content background-customizable modal-content-mobile
+        visible-xs visible-sm\">\n                <div><div>\n                    <div
+        class=\"banner-customizable\">\n                        <center>\n                            <img
+        alt=\"logo\" class=\"logo-customizable\" src=\"https://d2uqej7bo24sqa.cloudfront.net/eu-west-1_gFEQiVmPM/3g4d5l5kivuqi7oia68gib7uso/20250401160518/assets/images/image.jpg\"
+        />\n                        </center>\n                    </div>\n                </div></div>\n
+        \               <div class=\"modal-body\">\n                    <div><div>\n
+        \   \n</div></div>\n                    <div>\n                        <div><div>\n
+        \   \n</div></div>\n                        <div><div>\n    \n</div></div>\n
+        \                       <div>\n                            \n                            <div><div>\n
+        \   \n        <Span class=\"textDescription-customizable \">Sign in with your
+        email and password</Span>\n        <form action=\"/login?client_id=3g4d5l5kivuqi7oia68gib7uso&amp;redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&amp;response_type=code&amp;scope=openid
+        profile&amp;code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&amp;code_challenge_method=S256&amp;nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&amp;state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8\"
+        method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
+        onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-92ff8f2e54e8\"/>\n            <input type=\"hidden\"
+        name=\"_csrf\" value=\"aaaaaaaa-aaaa-aaaa-aaaa-92ff8f2e54e8\" />\n\n            \n\n
+        \           \n            <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
+        \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
+        type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
+        autocapitalize=\"none\" required value=\"\">\n                \n                \n
+        \           </div>\n\n            <label for=\"signInFormPassword\" class=\"label-customizable\">Password</label>\n
+        \           <div><input id=\"signInFormPassword\" name=\"password\" type=\"password\"
+        class=\"form-control inputField-customizable\"\n                   placeholder=\"Password\"\n
+        \                  required></div>\n            <input type=\"hidden\" class=\"form-control
+        inputField-customizable\" name=\"cognitoAsfData\"/>\n            <div>\n                <a
+        class=\"redirect-customizable\" href=\"/forgotPassword?client_id=3g4d5l5kivuqi7oia68gib7uso&amp;redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&amp;response_type=code&amp;scope=openid%20profile&amp;code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&amp;code_challenge_method=S256&amp;response_mode=form_post&amp;nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&amp;state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&amp;x-client-SKU=ID_NET8_0&amp;x-client-ver=7.1.2.0\">Forgot
+        your password?</a>\n            </div>\n            <input name=\"signInSubmitButton\"
+        type=\"Submit\" value=\"Sign in\"\n                   class=\"btn btn-primary
+        submitButton-customizable\" aria-label=\"submit\"/>\n            <br/>\n            \n
+        \       </form>\n    \n</div></div>\n                        </div>\n                    </div>\n
+        \               </div>\n            </div>\n\n            \n\n            <div
+        class=\"modal-content background-customizable modal-content-mobile visible-md
+        visible-lg\">\n                <div><div>\n                    <div class=\"banner-customizable\">\n
+        \                       <center>\n                            <img alt=\"logo\"
+        class=\"logo-customizable\" src=\"https://d2uqej7bo24sqa.cloudfront.net/eu-west-1_gFEQiVmPM/3g4d5l5kivuqi7oia68gib7uso/20250401160518/assets/images/image.jpg\"
+        />\n                        </center>\n                    </div>\n                </div></div>\n
+        \               <div class=\"modal-body\">\n                    <div><div>\n
+        \   \n</div></div>\n                    <div>\n                        <div>\n
+        \                           <div><div>\n    \n</div></div>\n                            <div><div>\n
+        \   \n</div></div>\n                        </div>\n                        <div>\n
+        \                           <div><div>\n    \n        <Span class=\"textDescription-customizable
+        \">Sign in with your email and password</Span>\n        <form action=\"/login?client_id=3g4d5l5kivuqi7oia68gib7uso&amp;redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&amp;response_type=code&amp;scope=openid
+        profile&amp;code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&amp;code_challenge_method=S256&amp;nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&amp;state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8\"
+        method=\"POST\" name=\"cognitoSignInForm\"\n              class=\"cognito-asf\"
+        onsubmit=\"onSubmitLoginForm(this);\"><input type=\"hidden\" name=\"_csrf\"
+        value=\"aaaaaaaa-aaaa-aaaa-aaaa-92ff8f2e54e8\"/>\n            <input type=\"hidden\"
+        name=\"_csrf\" value=\"aaaaaaaa-aaaa-aaaa-aaaa-92ff8f2e54e8\" />\n\n            \n\n
+        \           \n            <label for=\"signInFormUsername\" class=\"label-customizable\">Email</label>\n
+        \           <div>\n                <input id=\"signInFormUsername\" name=\"username\"
+        type=\"text\" class=\"form-control inputField-customizable\"\n                   placeholder=\"***REDACTED_EMAIL***\"
+        autocapitalize=\"none\" required value=\"\">\n                \n                \n
+        \           </div>\n\n            <label for=\"signInFormPassword\" class=\"label-customizable\">Password</label>\n
+        \           <div><input id=\"signInFormPassword\" name=\"password\" type=\"password\"
+        class=\"form-control inputField-customizable\"\n                   placeholder=\"Password\"\n
+        \                  required></div>\n            <input type=\"hidden\" class=\"form-control
+        inputField-customizable\" name=\"cognitoAsfData\"/>\n            <div>\n                <a
+        class=\"redirect-customizable\" href=\"/forgotPassword?client_id=3g4d5l5kivuqi7oia68gib7uso&amp;redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&amp;response_type=code&amp;scope=openid%20profile&amp;code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&amp;code_challenge_method=S256&amp;response_mode=form_post&amp;nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&amp;state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&amp;x-client-SKU=ID_NET8_0&amp;x-client-ver=7.1.2.0\">Forgot
+        your password?</a>\n            </div>\n            <input name=\"signInSubmitButton\"
+        type=\"Submit\" value=\"Sign in\"\n                   class=\"btn btn-primary
+        submitButton-customizable\" aria-label=\"submit\"/>\n            <br/>\n            \n
+        \       </form>\n    \n</div></div>\n                        </div>\n                    </div>\n
+        \               </div>\n            </div>\n        </div>\n    </div>\n    <script>\n
+        \   document.addEventListener(\"DOMContentLoaded\", function () {\n        var
+        inputs = document.querySelectorAll(\"input\");\n\n        inputs.forEach((input)
+        => {\n            input.addEventListener(\"input\", function () {\n                var
+        name = this.name;\n                var value = this.value;\n                var
+        matchingInputs = document.querySelectorAll(`input[name=\"${name}\"]`);\n\n
+        \               matchingInputs.forEach((match) => {\n                    if
+        (match !== this) {\n                        match.value = value;\n                    }\n
+        \               });\n            });\n        });\n    });\n</script>\n</body>\n\n</html>\n"
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Language:
+      - en-US
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Mon, 17 Aug 2026 07:44:40 GMT
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - Server
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - '0'
+      x-amz-cognito-request-id:
+      - b4da907f-5cbc-40d1-a95f-07fda55f3e4a
+    status:
+      code: 200
+      message: ''
+- request:
+    body:
+      _csrf: '***REDACTED***'
+      cognitoAsfData: ''
+      password: '***REDACTED***'
+      username: '***REDACTED_EMAIL***'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '127'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - live-melcloudhome.auth.eu-west-1.amazoncognito.com
+      Origin:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com
+      Referer:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/login?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+      User-Agent:
+      - Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15
+        (KHTML, like Gecko) Mobile/22F76
+      cookie:
+      - '***REDACTED***'
+    method: POST
+    uri: https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/login?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+  response:
+    body: {}
+    headers:
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 17 Aug 2026 07:44:40 GMT
+      Location:
+      - https://auth.melcloudhome.com/signin-oidc-meu?code=3fcdb3fd-4b89-46c5-afa8-6429c18b30d6&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8
+      Pragma:
+      - no-cache
+      Server:
+      - Server
+      Set-Cookie:
+      - '***REDACTED***'
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - '0'
+      x-amz-cognito-request-id:
+      - 3e5c3fd2-2293-49f4-87e1-03a6c01e3425
+    status:
+      code: 302
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - auth.melcloudhome.com
+      Origin:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com
+      Referer:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/login?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+      User-Agent:
+      - Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15
+        (KHTML, like Gecko) Mobile/22F76
+      cookie:
+      - '***REDACTED***'
+    method: GET
+    uri: https://auth.melcloudhome.com/signin-oidc-meu?code=3fcdb3fd-4b89-46c5-afa8-6429c18b30d6&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8
+  response:
+    body: {}
+    headers:
+      Cache-Control:
+      - no-cache,no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 17 Aug 2026 07:44:41 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Location:
+      - /ExternalLogin/Callback
+      Pragma:
+      - no-cache
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - '***REDACTED***'
+      apigw-requestid:
+      - CPJMfisDDoEEPyA=
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - auth.melcloudhome.com
+      Origin:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com
+      Referer:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/login?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+      User-Agent:
+      - Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15
+        (KHTML, like Gecko) Mobile/22F76
+      cookie:
+      - '***REDACTED***'
+    method: GET
+    uri: https://auth.melcloudhome.com/ExternalLogin/Callback
+  response:
+    body: {}
+    headers:
+      Cache-Control:
+      - no-cache,no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 17 Aug 2026 07:44:41 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Location:
+      - /Redirect?RedirectUri=%2Fconnect%2Fauthorize%2Fcallback%3Frequest_uri%3Durn%253Aietf%253Aparams%253Aoauth%253Arequest_uri%253A834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682%26client_id%3Dhomemobile
+      Pragma:
+      - no-cache
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - '***REDACTED***'
+      apigw-requestid:
+      - CPJMhiy2joEEPkw=
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Host:
+      - auth.melcloudhome.com
+      Origin:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com
+      Referer:
+      - https://live-melcloudhome.auth.eu-west-1.amazoncognito.com/login?client_id=3g4d5l5kivuqi7oia68gib7uso&redirect_uri=https://auth.melcloudhome.com/signin-oidc-meu&response_type=code&scope=openid%20profile&code_challenge=PAk7Oczk7UGflEwjs7OOrHT7Md9w_viOd4561QpA44M&code_challenge_method=S256&response_mode=form_post&nonce=639225494804186515.MDI4YjNhZjctMWUwNC00ODM2LWFiNTYtMWQyYmVkZWMxYmY5N2E1N2VmZTItZjA2Ny00YjU4LTllN2MtN2Y0ZTYxYmYyMDMz&state=CfDJ8I9HYxO_M3FJmqyQy6voCjJ7JxeI9851IvWlLFNvghG_v3CB5bfb0U9hJgui2VifbRkrU1uBDU13vSSGSCpgoPHeaYL2o-I5jDtsYMpimJg9bvJpHaJemVnsYUVCBlROLrBqHj8dOg6e5lrrdrekTfh52X2T-BGDZrY6ctDFx1n87c_LAIadp11pETHxhB__vzjm2AU3DMaDdt0RQq5JBnPXRESl4EyslIvA1MrNpf_D7hdKAiisCk_Cgm4hDrw37xmDvotEocMO8I6buMj-nlMydZ7kMQCSsLjcPvLamI_j7llsfz2AgBptJ7YBy44IrMKfpUDWckRHauaiyZMXgbSvyhrMqn7aJ5Kto-oS85jYCMhQ-9tTwJyBP6ByQMq1P-g3VSQ7c6YFO3NQFme-3OpuDujvSczaXNhBgD5v14Sk043gFgeiivS0aaiHSeOVm2SSTKh-k4rQABV5coWWINDzmVQ5wmB-VL2gMDAkI-Ttnxl4OGxLXBGjpE2IagcuNhn9lfhrWHI29wKBctB7EGus8-TDS4vLorxoA6ZOsdKNyN_rXf-dRtgoB8tArUOl0Nonu3Za182iyDA_xFqJtBFFAVBZGY0Vf1myx3vqNYH6P8CEJ34XN0E6VL7jXIxeRMqQj9ON7r4TVOGKxbXR0apT_8sFcIsH1yFz5plyBms8&x-client-SKU=ID_NET8_0&x-client-ver=7.1.2.0
+      User-Agent:
+      - Mozilla/5.0 (iPhone; CPU iPhone OS 18_5 like Mac OS X) AppleWebKit/605.1.15
+        (KHTML, like Gecko) Mobile/22F76
+      cookie:
+      - '***REDACTED***'
+    method: GET
+    uri: https://auth.melcloudhome.com/Redirect?RedirectUri=/connect/authorize/callback?request_uri%3Durn%253Aietf%253Aparams%253Aoauth%253Arequest_uri%253A834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682%26client_id%3Dhomemobile
+  response:
+    body:
+      string: "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n    <meta charset=\"utf-8\"
+        />\n    <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">\n    <meta
+        name=\"viewport\" content=\"width=device-width, initial-scale=1.0, shrink-to-fit=no\"
+        />\n\n    <title>MELCloud Home</title>\n\n    <link rel=\"stylesheet\" href=\"/lib/bootstrap/dist/css/bootstrap.min.css\"
+        />\n    <link rel=\"stylesheet\" href=\"/lib/bootstrap4-glyphicons/css/bootstrap-glyphicons.min.css\"
+        />\n    <link rel=\"stylesheet\" href=\"/css/site.css\" />\n    <link rel=\"stylesheet\"
+        href=\"/css/layout.css\" />\n\n    \n</head>\n<body>\n    \n<header class=\"gs18-Header
+        gs18-Header--MinInteraction gs18-Header--NoSearch\" role=\"banner\" data-js-gs18-header>\n
+        \   <div class=\"gs18-Header__Inner\" style=\"height:85px\">\n        <a href=\"\"
+        style=\"position:absolute;\"><img src=\"/logo_with_name.png\" style=\"height:85px;\"
+        alt=\"MITSUBISHI ELECTRIC\"></a>\n        <nav class=\"gs18-HeaderNav\" id=\"navMenu\">\n
+        \               <ul class=\"gs18-HeaderNav__Menu\" style=\"width:100%\">\n
+        \                   <li class=\"nav-item dropdown gs18-HeaderNav__Item\" style=\"color:black
+        !important;\">\n                    <a href=\"#\" class=\"nav-link dropdown-toggle
+        gs18-HeaderNav__Text\" data-toggle=\"dropdown\">***REDACTED_EMAIL*** <b class=\"caret\"></b></a>\n\n
+        \                   <div class=\"dropdown-menu\">\n                        <a
+        class=\"dropdown-item\" href=\"/Account/Logout\">Logout</a>\n                    </div>\n
+        \               </li>\n            </ul>\n        </nav>\n    </div>\n</header>\n
+        \  \n    <div class=\"container body-container\">\n        \n<div class=\"redirect-page\">\n
+        \   <div class=\"lead\">\n        <p>Redirecting to MelCloud Home...</p>\n
+        \   </div>\n</div>\n\n<meta http-equiv=\"refresh\" content=\"0;url=/connect/authorize/callback?request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3A834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682&amp;client_id=homemobile\"
+        data-url=\"/connect/authorize/callback?request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3A834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682&amp;client_id=homemobile\">\n<script
+        src=\"/js/signin-redirect.js\"></script>\n\n    </div>\n\n    <script src=\"/lib/jquery/dist/jquery.slim.min.js\"></script>\n
+        \   <script src=\"/lib/bootstrap/dist/js/bootstrap.bundle.min.js\"></script>\n\n
+        \   \n</body>\n</html>\n"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2277'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Mon, 17 Aug 2026 07:44:41 GMT
+      Server:
+      - Kestrel
+      apigw-requestid:
+      - CPJMijj9DoEEPMA=
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+      cookie:
+      - '***REDACTED***'
+    method: GET
+    uri: https://auth.melcloudhome.com/connect/authorize/callback?request_uri=urn:ietf:params:oauth:request_uri:834F2F5631F78D6717C4C8591DDBEF9214C5B02CA0E05803488D21FFD699F682&client_id=homemobile
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-store, no-cache, max-age=0
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Mon, 17 Aug 2026 07:44:41 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Location:
+      - melcloudhome://?code=787CF8680064FA8C969494DEFB6B952C52218B2D18DB3624321B7494242548D7-1&scope=openid%20profile%20email%20offline_access%20IdentityServerApi&state=oK1XfnZKChh7Sf_OFUA_iQ&session_state=6znQ85138hW0jgTe9OIEVdPtvGoHUATfG1BHTj-lrqY.E40832F276C3E4BF2E22007984CFA8AA&iss=https%3A%2F%2Fauth.melcloudhome.com
+      Pragma:
+      - no-cache
+      Server:
+      - Kestrel
+      Set-Cookie:
+      - '***REDACTED***'
+      apigw-requestid:
+      - CPJMijzODoEEPYA=
+    status:
+      code: 302
+      message: Found
+- request:
+    body:
+      client_id: homemobile
+      code: '***REDACTED***'
+      code_verifier: '***REDACTED***'
+      grant_type: authorization_code
+      redirect_uri: melcloudhome://
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+      cookie:
+      - '***REDACTED***'
+    method: POST
+    uri: https://auth.melcloudhome.com/connect/token
+  response:
+    body:
+      string: '{"id_token":"***REDACTED***","access_token":"***REDACTED***","expires_in":3600,"token_type":"Bearer","refresh_token":"***REDACTED***","scope":"openid
+        profile email offline_access IdentityServerApi"}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache, max-age=0
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2205'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 17 Aug 2026 07:44:41 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Kestrel
+      apigw-requestid:
+      - CPJMjiDwDoEEPtw=
+    status:
+      code: 200
+      message: OK
+- request:
+    body:
+      client_id: homemobile
+      grant_type: refresh_token
+      refresh_token: '***REDACTED***'
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+      cookie:
+      - '***REDACTED***'
+    method: POST
+    uri: https://auth.melcloudhome.com/connect/token
+  response:
+    body:
+      string: '{"id_token":"***REDACTED***","access_token":"***REDACTED***","expires_in":3600,"token_type":"Bearer","refresh_token":"***REDACTED***","scope":"openid
+        profile email offline_access IdentityServerApi"}'
+    headers:
+      Cache-Control:
+      - no-store, no-cache, max-age=0
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2205'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Mon, 17 Aug 2026 07:44:41 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Kestrel
+      apigw-requestid:
+      - CPJMlj8wjoEEPmw=
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+      authorization:
+      - '***REDACTED***'
+    method: GET
+    uri: https://mobile.bff.melcloudhome.com/context
+  response:
+    body:
+      string: '{"id":"aaaaaaaa-aaaa-aaaa-aaaa-e02c4382eb85","firstname":"***REDACTED***","lastname":"***REDACTED***","email":"***REDACTED_EMAIL***","language":"en","country":"GB","numberOfDevicesAllowed":10,"numberOfBuildingsAllowed":2,"numberOfGuestUsersAllowedPerUnit":5,"numberOfGuestDevicesAllowed":10,"buildings":[],"guestBuildings":[{"id":"aaaaaaaa-aaaa-aaaa-aaaa-f90937ac0297","name":"***REDACTED_BUILDING***","timezone":"Europe/London","airToAirUnits":[{"unitSettings":null,"schedule":[],"scheduleEnabled":true,"connectedInterfaceIdentifier":"***REDACTED_MAC***","capabilities":{"isMultiSplitSystem":true,"isLegacyDevice":false,"hasStandby":true,"hasCoolOperationMode":true,"hasHeatOperationMode":true,"hasAutoOperationMode":true,"hasDryOperationMode":true,"hasAutomaticFanSpeed":true,"hasAirDirection":true,"hasSwing":true,"hasExtendedTemperatureRange":true,"hasEnergyConsumedMeter":true,"numberOfFanSpeeds":5,"minTempCoolDry":16,"maxTempCoolDry":31,"minTempHeat":10,"maxTempHeat":31,"minTempAutomatic":16,"maxTempAutomatic":31,"hasDemandSideControl":true,"hasHalfDegreeIncrements":true,"supportsWideVane":false},"frostProtection":{"active":false,"enabled":true,"min":10,"max":12},"overheatProtection":{"active":false,"enabled":false,"min":35,"max":37},"holidayMode":{"enabled":false,"startDate":"2026-07-28T07:44:00.966","endDate":"2026-07-28T07:44:00","active":false},"connectedInterfaceType":"fourthGenWifi","systemId":null,"id":"aaaaaaaa-aaaa-aaaa-aaaa-4c6fd61ac825","givenDisplayName":"***REDACTED_DEVICE***","displayIcon":"DiningRoom","settings":[{"name":"RoomTemperature","value":"20.5"},{"name":"Power","value":"True"},{"name":"OperationMode","value":"Cool"},{"name":"ActualFanSpeed","value":"Two"},{"name":"SetFanSpeed","value":"Auto"},{"name":"VaneHorizontalDirection","value":"Swing"},{"name":"VaneVerticalDirection","value":"Auto"},{"name":"InStandbyMode","value":"False"},{"name":"SetTemperature","value":"21"},{"name":"IsInError","value":"False"},{"name":"ErrorCode","value":""}],"timeZone":"Europe/London","rssi":-76,"isConnected":true,"isInError":false},{"unitSettings":null,"schedule":[],"scheduleEnabled":false,"connectedInterfaceIdentifier":"***REDACTED_MAC***","capabilities":{"isMultiSplitSystem":true,"isLegacyDevice":false,"hasStandby":true,"hasCoolOperationMode":true,"hasHeatOperationMode":true,"hasAutoOperationMode":true,"hasDryOperationMode":true,"hasAutomaticFanSpeed":true,"hasAirDirection":true,"hasSwing":true,"hasExtendedTemperatureRange":true,"hasEnergyConsumedMeter":true,"numberOfFanSpeeds":5,"minTempCoolDry":16,"maxTempCoolDry":31,"minTempHeat":10,"maxTempHeat":31,"minTempAutomatic":16,"maxTempAutomatic":31,"hasDemandSideControl":true,"hasHalfDegreeIncrements":true,"supportsWideVane":false},"frostProtection":{"active":false,"enabled":true,"min":10,"max":12},"overheatProtection":{"active":false,"enabled":true,"min":35,"max":37},"holidayMode":null,"connectedInterfaceType":"fourthGenWifi","systemId":null,"id":"aaaaaaaa-aaaa-aaaa-aaaa-40e80e68f338","givenDisplayName":"***REDACTED_DEVICE***","displayIcon":"LivingRoom","settings":[{"name":"RoomTemperature","value":"21"},{"name":"Power","value":"True"},{"name":"OperationMode","value":"Cool"},{"name":"ActualFanSpeed","value":"Two"},{"name":"SetFanSpeed","value":"Auto"},{"name":"VaneHorizontalDirection","value":"Centre"},{"name":"VaneVerticalDirection","value":"Auto"},{"name":"InStandbyMode","value":"False"},{"name":"SetTemperature","value":"20.5"},{"name":"IsInError","value":"False"},{"name":"ErrorCode","value":""}],"timeZone":"Europe/London","rssi":-55,"isConnected":true,"isInError":false},{"unitSettings":null,"schedule":[],"scheduleEnabled":false,"connectedInterfaceIdentifier":"***REDACTED_MAC***","capabilities":{"isMultiSplitSystem":true,"isLegacyDevice":false,"hasStandby":true,"hasCoolOperationMode":true,"hasHeatOperationMode":true,"hasAutoOperationMode":true,"hasDryOperationMode":true,"hasAutomaticFanSpeed":true,"hasAirDirection":true,"hasSwing":true,"hasExtendedTemperatureRange":true,"hasEnergyConsumedMeter":true,"numberOfFanSpeeds":5,"minTempCoolDry":16,"maxTempCoolDry":31,"minTempHeat":10,"maxTempHeat":31,"minTempAutomatic":16,"maxTempAutomatic":31,"hasDemandSideControl":true,"hasHalfDegreeIncrements":true,"supportsWideVane":false},"frostProtection":{"active":false,"enabled":true,"min":10,"max":12},"overheatProtection":null,"holidayMode":null,"connectedInterfaceType":"fourthGenWifi","systemId":null,"id":"aaaaaaaa-aaaa-aaaa-aaaa-e3325d1bcce7","givenDisplayName":"***REDACTED_DEVICE***","displayIcon":"GuestBedroom","settings":[{"name":"RoomTemperature","value":"20"},{"name":"Power","value":"True"},{"name":"OperationMode","value":"Cool"},{"name":"ActualFanSpeed","value":"One"},{"name":"SetFanSpeed","value":"Auto"},{"name":"VaneHorizontalDirection","value":"Swing"},{"name":"VaneVerticalDirection","value":"Auto"},{"name":"InStandbyMode","value":"False"},{"name":"SetTemperature","value":"21"},{"name":"IsInError","value":"False"},{"name":"ErrorCode","value":""}],"timeZone":"Europe/London","rssi":-60,"isConnected":true,"isInError":false},{"unitSettings":null,"schedule":[],"scheduleEnabled":true,"connectedInterfaceIdentifier":"***REDACTED_MAC***","capabilities":{"isMultiSplitSystem":false,"isLegacyDevice":false,"hasStandby":true,"hasCoolOperationMode":true,"hasHeatOperationMode":true,"hasAutoOperationMode":true,"hasDryOperationMode":true,"hasAutomaticFanSpeed":true,"hasAirDirection":false,"hasSwing":false,"hasExtendedTemperatureRange":true,"hasEnergyConsumedMeter":true,"numberOfFanSpeeds":3,"minTempCoolDry":19,"maxTempCoolDry":30,"minTempHeat":10,"maxTempHeat":28,"minTempAutomatic":19,"maxTempAutomatic":28,"hasDemandSideControl":false,"hasHalfDegreeIncrements":true,"supportsWideVane":false},"frostProtection":{"active":false,"enabled":true,"min":10,"max":12},"overheatProtection":null,"holidayMode":null,"connectedInterfaceType":"melCloudWiFi","systemId":null,"id":"aaaaaaaa-aaaa-aaaa-aaaa-3e40b123aa57","givenDisplayName":"***REDACTED_DEVICE***","displayIcon":"GuestBedroom","settings":[{"name":"RoomTemperature","value":"18"},{"name":"Power","value":"True"},{"name":"OperationMode","value":"Cool"},{"name":"ActualFanSpeed","value":"Four"},{"name":"SetFanSpeed","value":"Three"},{"name":"VaneHorizontalDirection","value":"Auto"},{"name":"VaneVerticalDirection","value":"Auto"},{"name":"InStandbyMode","value":"False"},{"name":"SetTemperature","value":"19"},{"name":"IsInError","value":"False"},{"name":"ErrorCode","value":""}],"timeZone":"Europe/London","rssi":-33,"isConnected":true,"isInError":false},{"unitSettings":null,"schedule":[],"scheduleEnabled":true,"connectedInterfaceIdentifier":"***REDACTED_MAC***","capabilities":{"isMultiSplitSystem":false,"isLegacyDevice":false,"hasStandby":true,"hasCoolOperationMode":true,"hasHeatOperationMode":true,"hasAutoOperationMode":true,"hasDryOperationMode":true,"hasAutomaticFanSpeed":true,"hasAirDirection":false,"hasSwing":false,"hasExtendedTemperatureRange":true,"hasEnergyConsumedMeter":true,"numberOfFanSpeeds":3,"minTempCoolDry":19,"maxTempCoolDry":30,"minTempHeat":10,"maxTempHeat":28,"minTempAutomatic":19,"maxTempAutomatic":28,"hasDemandSideControl":false,"hasHalfDegreeIncrements":true,"supportsWideVane":false},"frostProtection":{"active":false,"enabled":true,"min":10,"max":12},"overheatProtection":null,"holidayMode":null,"connectedInterfaceType":"melCloudWiFi","systemId":null,"id":"aaaaaaaa-aaaa-aaaa-aaaa-c0e1b9ce1d4f","givenDisplayName":"***REDACTED_DEVICE***","displayIcon":"Bedroom","settings":[{"name":"RoomTemperature","value":"18.5"},{"name":"Power","value":"True"},{"name":"OperationMode","value":"Cool"},{"name":"ActualFanSpeed","value":"Two"},{"name":"SetFanSpeed","value":"Auto"},{"name":"VaneHorizontalDirection","value":"Auto"},{"name":"VaneVerticalDirection","value":"Auto"},{"name":"InStandbyMode","value":"False"},{"name":"SetTemperature","value":"19"},{"name":"IsInError","value":"False"},{"name":"ErrorCode","value":""}],"timeZone":"Europe/London","rssi":-62,"isConnected":true,"isInError":false},{"unitSettings":null,"schedule":[],"scheduleEnabled":true,"connectedInterfaceIdentifier":"***REDACTED_MAC***","capabilities":{"isMultiSplitSystem":false,"isLegacyDevice":false,"hasStandby":true,"hasCoolOperationMode":true,"hasHeatOperationMode":true,"hasAutoOperationMode":true,"hasDryOperationMode":true,"hasAutomaticFanSpeed":true,"hasAirDirection":false,"hasSwing":false,"hasExtendedTemperatureRange":true,"hasEnergyConsumedMeter":true,"numberOfFanSpeeds":3,"minTempCoolDry":19,"maxTempCoolDry":30,"minTempHeat":10,"maxTempHeat":28,"minTempAutomatic":19,"maxTempAutomatic":28,"hasDemandSideControl":false,"hasHalfDegreeIncrements":true,"supportsWideVane":false},"frostProtection":{"active":false,"enabled":true,"min":10,"max":12},"overheatProtection":null,"holidayMode":null,"connectedInterfaceType":"melCloudWiFi","systemId":null,"id":"aaaaaaaa-aaaa-aaaa-aaaa-dace463c9e6f","givenDisplayName":"***REDACTED_DEVICE***","displayIcon":"Bedroom","settings":[{"name":"RoomTemperature","value":"18.5"},{"name":"Power","value":"True"},{"name":"OperationMode","value":"Cool"},{"name":"ActualFanSpeed","value":"Two"},{"name":"SetFanSpeed","value":"Auto"},{"name":"VaneHorizontalDirection","value":"Auto"},{"name":"VaneVerticalDirection","value":"Auto"},{"name":"InStandbyMode","value":"False"},{"name":"SetTemperature","value":"19"},{"name":"IsInError","value":"False"},{"name":"ErrorCode","value":""}],"timeZone":"Europe/London","rssi":-56,"isConnected":true,"isInError":false}],"airToWaterUnits":[]},{"id":"aaaaaaaa-aaaa-aaaa-aaaa-1915aa4cdb6d","name":"***REDACTED_BUILDING***","timezone":"Europe/Stockholm","airToAirUnits":[],"airToWaterUnits":[{"macAddress":"***REDACTED_MAC***","ftcModel":"ftC7","schedule":[],"scheduleEnabled":true,"frostProtection":{"zone1Active":false,"zone2Active":false,"enabled":false,"min":10,"max":12},"overheatProtection":null,"holidayMode":null,"capabilities":{"maxImportPower":0,"maxHeatOutput":0,"temperatureUnit":"","hasHotWater":true,"immersionHeaterCapacity":0,"minSetTankTemperature":40,"maxSetTankTemperature":60,"minSetTemperature":10,"maxSetTemperature":30,"temperatureIncrement":0.5,"temperatureIncrementOverride":"2","hasHalfDegrees":true,"hasZone2":false,"hasDualRoomTemperature":false,"hasThermostatZone1":true,"hasThermostatZone2":true,"hasHeatZone1":true,"hasHeatZone2":true,"hasMeasuredEnergyConsumption":false,"hasMeasuredEnergyProduction":false,"hasEstimatedEnergyConsumption":true,"hasEstimatedEnergyProduction":true,"ftcModel":5,"refridgerentAddress":0,"hasDemandSideControl":true,"hasWirelessRemote":true,"hasBoiler":false,"systemMaxFlowTemperature":null},"id":"aaaaaaaa-aaaa-aaaa-aaaa-6b6529f39911","givenDisplayName":"***REDACTED_DEVICE***","displayIcon":"Basement","settings":[{"name":"Power","value":"True"},{"name":"InStandbyMode","value":"False"},{"name":"OperationMode","value":"Stop"},{"name":"HasZone2","value":"None"},{"name":"OperationModeZone1","value":"HeatRoomTemperature"},{"name":"RoomTemperatureZone1","value":"23"},{"name":"SetTemperatureZone1","value":"18"},{"name":"ProhibitHotWater","value":"False"},{"name":"TankWaterTemperature","value":"58"},{"name":"SetTankWaterTemperature","value":"50"},{"name":"HasCoolingMode","value":"False"},{"name":"ForcedHotWaterMode","value":"False"},{"name":"IsInError","value":"False"},{"name":"ErrorCode","value":""},{"name":"OutdoorTemperature","value":"0"}],"timeZone":"Europe/Stockholm","rssi":-73,"isConnected":true,"isInError":false}]}],"scenes":[]}'
+    headers:
+      Apigw-Requestid:
+      - CPJMmhgOjoEEPeg=
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '11427'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Mon, 17 Aug 2026 07:44:41 GMT
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - MonitorAndControl.App.Mobile/52 CFNetwork/3860.400.51 Darwin/25.3.0
+      authorization:
+      - '***REDACTED***'
+    method: GET
+    uri: https://mobile.bff.melcloudhome.com/report/v1/comfort-graph?unitId=aaaaaaaa-aaaa-aaaa-aaaa-6b6529f39911&period=Hourly&from=2026-08-16T09:30:00.0000000&to=2026-08-17T09:30:00.0000000
+  response:
+    body:
+      string: '[{"reportPeriod":0,"datasets":[{"id":"set_tank_water_temperature","label":"REPORT.INTEMP_REPORT.DATASET.LABELS.SET_TANK_TEMPERATURE","data":[{"x":"2026-08-17T08:57:11","y":50},{"x":"2026-08-17T09:00:00","y":50},{"x":"2026-08-17T09:30:00","y":50}],"borderColor":"#EEDD11","backgroundColor":"#EEDD11","yAxisId":"yTemp","pointRadius":0,"lineTension":0,"borderWidth":2,"stepped":true,"spanGaps":false,"displayIcon":true,"fill":false,"hidden":true},{"id":"tank_water_temperature","label":"REPORT.INTEMP_REPORT.DATASET.LABELS.TANK_TEMPERATURE","data":[{"x":"2026-08-16T00:27:12","y":44.5},{"x":"2026-08-16T00:28:12","y":44},{"x":"2026-08-16T00:29:13","y":43},{"x":"2026-08-16T00:30:12","y":42.5},{"x":"2026-08-16T00:31:12","y":41.5},{"x":"2026-08-16T00:32:12","y":40},{"x":"2026-08-16T00:33:13","y":38.5},{"x":"2026-08-16T00:34:12","y":37.5},{"x":"2026-08-16T00:36:13","y":37},{"x":"2026-08-16T00:37:12","y":37.5},{"x":"2026-08-16T00:39:11","y":38},{"x":"2026-08-16T00:40:11","y":38.5},{"x":"2026-08-16T00:41:11","y":39.5},{"x":"2026-08-16T00:42:11","y":40},{"x":"2026-08-16T00:43:11","y":40.5},{"x":"2026-08-16T00:44:11","y":41},{"x":"2026-08-16T00:45:11","y":42},{"x":"2026-08-16T00:46:11","y":42.5},{"x":"2026-08-16T00:47:12","y":43},{"x":"2026-08-16T00:48:12","y":43.5},{"x":"2026-08-16T00:49:12","y":44},{"x":"2026-08-16T00:50:12","y":44.5},{"x":"2026-08-16T00:51:12","y":45},{"x":"2026-08-16T00:52:12","y":46},{"x":"2026-08-16T00:53:12","y":46.5},{"x":"2026-08-16T00:54:12","y":47},{"x":"2026-08-16T00:55:11","y":47.5},{"x":"2026-08-16T00:56:12","y":48},{"x":"2026-08-16T00:57:11","y":48.5},{"x":"2026-08-16T00:58:12","y":49},{"x":"2026-08-16T00:59:12","y":49.5},{"x":"2026-08-16T01:00:00","y":49.5},{"x":"2026-08-16T01:00:11","y":50},{"x":"2026-08-16T01:02:12","y":50.5},{"x":"2026-08-16T01:03:11","y":51.5},{"x":"2026-08-16T01:13:11","y":50.5},{"x":"2026-08-16T02:00:00","y":50.5},{"x":"2026-08-16T02:26:12","y":50},{"x":"2026-08-16T03:00:00","y":50},{"x":"2026-08-16T04:00:00","y":50},{"x":"2026-08-16T04:08:11","y":49.5},{"x":"2026-08-16T05:00:00","y":49.5},{"x":"2026-08-16T06:00:00","y":49.5},{"x":"2026-08-16T06:07:11","y":49},{"x":"2026-08-16T06:08:12","y":49.5},{"x":"2026-08-16T06:09:11","y":49},{"x":"2026-08-16T07:00:00","y":49},{"x":"2026-08-16T08:00:00","y":49},{"x":"2026-08-16T08:07:12","y":48.5},{"x":"2026-08-16T09:00:00","y":48.5},{"x":"2026-08-16T10:00:00","y":48.5},{"x":"2026-08-16T10:02:12","y":48},{"x":"2026-08-16T11:00:00","y":48},{"x":"2026-08-16T11:54:11","y":47.5},{"x":"2026-08-16T12:00:00","y":47.5},{"x":"2026-08-16T13:00:00","y":47.5},{"x":"2026-08-16T13:40:10","y":47},{"x":"2026-08-16T14:00:00","y":47},{"x":"2026-08-16T14:29:11","y":46.5},{"x":"2026-08-16T14:54:11","y":46},{"x":"2026-08-16T15:00:00","y":46},{"x":"2026-08-16T15:18:11","y":45.5},{"x":"2026-08-16T15:21:11","y":45},{"x":"2026-08-16T15:50:11","y":44.5},{"x":"2026-08-16T16:00:00","y":44.5},{"x":"2026-08-16T16:51:11","y":44},{"x":"2026-08-16T16:53:11","y":43.5},{"x":"2026-08-16T16:54:11","y":43},{"x":"2026-08-16T16:55:11","y":42.5},{"x":"2026-08-16T16:56:11","y":41.5},{"x":"2026-08-16T16:57:11","y":40.5},{"x":"2026-08-16T16:58:12","y":39},{"x":"2026-08-16T16:59:11","y":38.5},{"x":"2026-08-16T17:00:00","y":38.5},{"x":"2026-08-16T17:01:11","y":39},{"x":"2026-08-16T17:02:10","y":39.5},{"x":"2026-08-16T17:03:11","y":40},{"x":"2026-08-16T17:04:12","y":40.5},{"x":"2026-08-16T17:05:12","y":41.5},{"x":"2026-08-16T17:06:10","y":42},{"x":"2026-08-16T17:07:11","y":42.5},{"x":"2026-08-16T17:08:11","y":43},{"x":"2026-08-16T17:09:11","y":43.5},{"x":"2026-08-16T17:10:10","y":44},{"x":"2026-08-16T17:11:11","y":45},{"x":"2026-08-16T17:12:11","y":45.5},{"x":"2026-08-16T17:14:11","y":46},{"x":"2026-08-16T17:15:10","y":47},{"x":"2026-08-16T17:16:11","y":47.5},{"x":"2026-08-16T17:17:10","y":48},{"x":"2026-08-16T17:18:10","y":48.5},{"x":"2026-08-16T17:19:11","y":49},{"x":"2026-08-16T17:21:10","y":49.5},{"x":"2026-08-16T17:22:11","y":50},{"x":"2026-08-16T17:24:10","y":50.5},{"x":"2026-08-16T17:25:11","y":51.5},{"x":"2026-08-16T17:32:11","y":50.5},{"x":"2026-08-16T18:00:00","y":50.5},{"x":"2026-08-16T18:52:11","y":50},{"x":"2026-08-16T19:00:00","y":50},{"x":"2026-08-16T20:00:00","y":50},{"x":"2026-08-16T20:27:11","y":49.5},{"x":"2026-08-16T21:00:00","y":49.5},{"x":"2026-08-16T22:00:00","y":49.5},{"x":"2026-08-16T22:06:11","y":49},{"x":"2026-08-16T23:00:00","y":49},{"x":"2026-08-16T23:25:12","y":48.5},{"x":"2026-08-17T00:00:00","y":48.5},{"x":"2026-08-17T01:00:00","y":48.5},{"x":"2026-08-17T01:14:11","y":48},{"x":"2026-08-17T02:00:00","y":48},{"x":"2026-08-17T02:45:11","y":47.5},{"x":"2026-08-17T03:00:00","y":47.5},{"x":"2026-08-17T04:00:00","y":47.5},{"x":"2026-08-17T04:02:12","y":47},{"x":"2026-08-17T04:04:12","y":46.5},{"x":"2026-08-17T04:05:13","y":45},{"x":"2026-08-17T04:06:11","y":44},{"x":"2026-08-17T04:07:12","y":43},{"x":"2026-08-17T04:10:12","y":44},{"x":"2026-08-17T04:11:11","y":44.5},{"x":"2026-08-17T04:12:11","y":45.5},{"x":"2026-08-17T04:13:11","y":47},{"x":"2026-08-17T04:14:11","y":48},{"x":"2026-08-17T04:15:11","y":48.5},{"x":"2026-08-17T04:16:11","y":49.5},{"x":"2026-08-17T04:17:10","y":50.5},{"x":"2026-08-17T04:19:10","y":51.5},{"x":"2026-08-17T04:20:11","y":52},{"x":"2026-08-17T04:21:11","y":53},{"x":"2026-08-17T04:23:11","y":53.5},{"x":"2026-08-17T04:24:11","y":54.5},{"x":"2026-08-17T04:25:11","y":55},{"x":"2026-08-17T04:28:11","y":55.5},{"x":"2026-08-17T04:34:10","y":56},{"x":"2026-08-17T04:36:11","y":57},{"x":"2026-08-17T04:38:10","y":57.5},{"x":"2026-08-17T04:40:10","y":58},{"x":"2026-08-17T04:42:10","y":59},{"x":"2026-08-17T04:45:11","y":59.5},{"x":"2026-08-17T04:47:11","y":60},{"x":"2026-08-17T04:48:12","y":61},{"x":"2026-08-17T04:51:11","y":61.5},{"x":"2026-08-17T05:00:00","y":61.5},{"x":"2026-08-17T05:27:11","y":61},{"x":"2026-08-17T05:28:11","y":61.5},{"x":"2026-08-17T05:29:11","y":61},{"x":"2026-08-17T06:00:00","y":61},{"x":"2026-08-17T06:46:11","y":60},{"x":"2026-08-17T07:00:00","y":60},{"x":"2026-08-17T08:00:00","y":60},{"x":"2026-08-17T08:14:11","y":59.5},{"x":"2026-08-17T08:57:11","y":59.5},{"x":"2026-08-17T09:00:00","y":59.5},{"x":"2026-08-17T09:05:23","y":59},{"x":"2026-08-17T09:30:00","y":59}],"borderColor":"#7a720f","backgroundColor":"#7a720f","yAxisId":"yTemp","pointRadius":0,"lineTension":0,"borderWidth":2,"spanGaps":false,"displayIcon":true,"fill":true,"hidden":true},{"id":"set_temperature_zone1","label":"REPORT.INTEMP_REPORT.DATASET.LABELS.SET_TEMPERATURE_ZONE1","data":[{"x":"2026-08-16T00:33:13","y":17.5},{"x":"2026-08-16T01:00:00","y":17.5},{"x":"2026-08-16T01:04:12","y":18},{"x":"2026-08-16T02:00:00","y":18},{"x":"2026-08-16T03:00:00","y":18},{"x":"2026-08-16T04:00:00","y":18},{"x":"2026-08-16T05:00:00","y":18},{"x":"2026-08-16T06:00:00","y":18},{"x":"2026-08-16T06:01:12","y":21},{"x":"2026-08-16T07:00:00","y":21},{"x":"2026-08-16T08:00:00","y":21},{"x":"2026-08-16T09:00:00","y":21},{"x":"2026-08-16T10:00:00","y":21},{"x":"2026-08-16T11:00:00","y":21},{"x":"2026-08-16T12:00:00","y":21},{"x":"2026-08-16T13:00:00","y":21},{"x":"2026-08-16T14:00:00","y":21},{"x":"2026-08-16T15:00:00","y":21},{"x":"2026-08-16T16:00:00","y":21},{"x":"2026-08-16T17:00:00","y":21},{"x":"2026-08-16T18:00:00","y":21},{"x":"2026-08-16T19:00:00","y":21},{"x":"2026-08-16T19:30:11","y":20},{"x":"2026-08-16T19:46:11","y":21},{"x":"2026-08-16T19:50:11","y":20},{"x":"2026-08-16T20:00:00","y":20},{"x":"2026-08-16T20:15:10","y":21},{"x":"2026-08-16T20:21:11","y":20},{"x":"2026-08-16T20:33:11","y":21},{"x":"2026-08-16T21:00:00","y":21},{"x":"2026-08-16T21:45:11","y":20},{"x":"2026-08-16T22:00:00","y":20},{"x":"2026-08-16T22:01:11","y":21},{"x":"2026-08-16T22:06:11","y":18},{"x":"2026-08-16T23:00:00","y":18},{"x":"2026-08-17T00:00:00","y":18},{"x":"2026-08-17T01:00:00","y":18},{"x":"2026-08-17T02:00:00","y":18},{"x":"2026-08-17T03:00:00","y":18},{"x":"2026-08-17T04:00:00","y":18},{"x":"2026-08-17T05:00:00","y":18},{"x":"2026-08-17T06:00:00","y":18},{"x":"2026-08-17T06:01:12","y":20},{"x":"2026-08-17T06:15:12","y":21},{"x":"2026-08-17T06:31:11","y":18},{"x":"2026-08-17T07:00:00","y":18},{"x":"2026-08-17T08:00:00","y":18},{"x":"2026-08-17T08:57:11","y":18},{"x":"2026-08-17T09:00:00","y":18},{"x":"2026-08-17T09:30:00","y":18}],"borderColor":"#36BC6A","backgroundColor":"#36BC6A","yAxisId":"yTemp","pointRadius":0,"lineTension":0,"borderWidth":2,"stepped":true,"spanGaps":false,"displayIcon":true,"fill":false,"hidden":false},{"id":"room_temperature_zone1","label":"REPORT.INTEMP_REPORT.DATASET.LABELS.ROOM_TEMPERATURE_ZONE1","data":[{"x":"2026-08-16T00:23:11","y":24.5},{"x":"2026-08-16T01:00:00","y":24.5},{"x":"2026-08-16T02:00:00","y":24.5},{"x":"2026-08-16T03:00:00","y":24.5},{"x":"2026-08-16T03:22:12","y":24},{"x":"2026-08-16T03:25:12","y":24.5},{"x":"2026-08-16T03:31:12","y":24},{"x":"2026-08-16T04:00:00","y":24},{"x":"2026-08-16T05:00:00","y":24},{"x":"2026-08-16T06:00:00","y":24},{"x":"2026-08-16T07:00:00","y":24},{"x":"2026-08-16T07:26:11","y":23.5},{"x":"2026-08-16T08:00:00","y":23.5},{"x":"2026-08-16T09:00:00","y":23.5},{"x":"2026-08-16T10:00:00","y":23.5},{"x":"2026-08-16T11:00:00","y":23.5},{"x":"2026-08-16T12:00:00","y":23.5},{"x":"2026-08-16T13:00:00","y":23.5},{"x":"2026-08-16T14:00:00","y":23.5},{"x":"2026-08-16T15:00:00","y":23.5},{"x":"2026-08-16T16:00:00","y":23.5},{"x":"2026-08-16T17:00:00","y":23.5},{"x":"2026-08-16T17:32:11","y":24},{"x":"2026-08-16T18:00:00","y":24},{"x":"2026-08-16T19:00:00","y":24},{"x":"2026-08-16T20:00:00","y":24},{"x":"2026-08-16T21:00:00","y":24},{"x":"2026-08-16T22:00:00","y":24},{"x":"2026-08-16T23:00:00","y":24},{"x":"2026-08-17T00:00:00","y":24},{"x":"2026-08-17T00:15:11","y":23.5},{"x":"2026-08-17T00:20:11","y":24},{"x":"2026-08-17T00:23:11","y":23.5},{"x":"2026-08-17T01:00:00","y":23.5},{"x":"2026-08-17T02:00:00","y":23.5},{"x":"2026-08-17T03:00:00","y":23.5},{"x":"2026-08-17T04:00:00","y":23.5},{"x":"2026-08-17T05:00:00","y":23.5},{"x":"2026-08-17T06:00:00","y":23.5},{"x":"2026-08-17T06:27:11","y":23},{"x":"2026-08-17T07:00:00","y":23},{"x":"2026-08-17T08:00:00","y":23},{"x":"2026-08-17T08:57:11","y":23},{"x":"2026-08-17T09:00:00","y":23},{"x":"2026-08-17T09:30:00","y":23}],"borderColor":"#F1995D","backgroundColor":"#F1995D","yAxisId":"yTemp","pointRadius":0,"lineTension":0,"borderWidth":2,"spanGaps":false,"displayIcon":true,"fill":true,"hidden":false},{"id":"outside_temperature","label":"REPORT.TREND_SUMMARY_REPORT.DATASET.LABELS.OUTDOOR_TEMPERATURE","data":[{"x":"2026-08-16T00:28:12","y":16},{"x":"2026-08-16T01:00:00","y":16},{"x":"2026-08-16T02:00:00","y":16},{"x":"2026-08-16T03:00:00","y":16},{"x":"2026-08-16T03:42:12","y":15},{"x":"2026-08-16T03:45:12","y":16},{"x":"2026-08-16T03:46:12","y":15},{"x":"2026-08-16T04:00:00","y":15},{"x":"2026-08-16T05:00:00","y":15},{"x":"2026-08-16T06:00:00","y":15},{"x":"2026-08-16T06:14:11","y":16},{"x":"2026-08-16T06:15:11","y":15},{"x":"2026-08-16T06:16:12","y":16},{"x":"2026-08-16T06:18:12","y":15},{"x":"2026-08-16T06:19:12","y":16},{"x":"2026-08-16T07:00:00","y":16},{"x":"2026-08-16T08:00:00","y":16},{"x":"2026-08-16T08:05:25","y":17},{"x":"2026-08-16T08:12:11","y":16},{"x":"2026-08-16T08:34:12","y":17},{"x":"2026-08-16T09:00:00","y":17},{"x":"2026-08-16T09:35:12","y":18},{"x":"2026-08-16T09:49:11","y":17},{"x":"2026-08-16T10:00:00","y":17},{"x":"2026-08-16T10:04:12","y":18},{"x":"2026-08-16T11:00:00","y":18},{"x":"2026-08-16T11:16:10","y":17},{"x":"2026-08-16T11:18:11","y":18},{"x":"2026-08-16T11:19:12","y":17},{"x":"2026-08-16T11:47:11","y":18},{"x":"2026-08-16T11:48:10","y":17},{"x":"2026-08-16T11:49:11","y":18},{"x":"2026-08-16T11:50:10","y":17},{"x":"2026-08-16T11:51:11","y":18},{"x":"2026-08-16T12:00:00","y":18},{"x":"2026-08-16T12:23:11","y":19},{"x":"2026-08-16T12:32:10","y":18},{"x":"2026-08-16T12:48:10","y":19},{"x":"2026-08-16T13:00:00","y":19},{"x":"2026-08-16T13:00:11","y":18},{"x":"2026-08-16T13:05:19","y":19},{"x":"2026-08-16T13:07:11","y":18},{"x":"2026-08-16T13:08:10","y":19},{"x":"2026-08-16T14:00:00","y":19},{"x":"2026-08-16T14:12:10","y":20},{"x":"2026-08-16T14:50:10","y":21},{"x":"2026-08-16T14:54:11","y":20},{"x":"2026-08-16T15:00:00","y":20},{"x":"2026-08-16T15:17:11","y":21},{"x":"2026-08-16T15:21:11","y":20},{"x":"2026-08-16T15:27:11","y":21},{"x":"2026-08-16T15:33:12","y":20},{"x":"2026-08-16T16:00:00","y":20},{"x":"2026-08-16T16:53:11","y":19},{"x":"2026-08-16T17:00:00","y":19},{"x":"2026-08-16T17:28:11","y":20},{"x":"2026-08-16T17:36:11","y":21},{"x":"2026-08-16T17:45:11","y":20},{"x":"2026-08-16T17:54:11","y":21},{"x":"2026-08-16T18:00:00","y":21},{"x":"2026-08-16T18:11:11","y":20},{"x":"2026-08-16T18:57:12","y":19},{"x":"2026-08-16T18:58:11","y":20},{"x":"2026-08-16T19:00:00","y":20},{"x":"2026-08-16T19:03:11","y":19},{"x":"2026-08-16T19:04:11","y":20},{"x":"2026-08-16T19:05:12","y":19},{"x":"2026-08-16T20:00:00","y":19},{"x":"2026-08-16T20:29:11","y":18},{"x":"2026-08-16T21:00:00","y":18},{"x":"2026-08-16T22:00:00","y":18},{"x":"2026-08-16T22:45:11","y":17},{"x":"2026-08-16T22:46:11","y":18},{"x":"2026-08-16T22:47:11","y":17},{"x":"2026-08-16T23:00:00","y":17},{"x":"2026-08-17T00:00:00","y":17},{"x":"2026-08-17T01:00:00","y":17},{"x":"2026-08-17T02:00:00","y":17},{"x":"2026-08-17T02:00:11","y":16},{"x":"2026-08-17T03:00:00","y":16},{"x":"2026-08-17T03:46:10","y":15},{"x":"2026-08-17T03:48:10","y":16},{"x":"2026-08-17T04:00:00","y":16},{"x":"2026-08-17T04:01:11","y":15},{"x":"2026-08-17T04:08:11","y":14},{"x":"2026-08-17T04:09:11","y":15},{"x":"2026-08-17T04:10:12","y":14},{"x":"2026-08-17T04:53:12","y":15},{"x":"2026-08-17T05:00:00","y":15},{"x":"2026-08-17T05:09:11","y":16},{"x":"2026-08-17T05:10:11","y":15},{"x":"2026-08-17T05:17:11","y":16},{"x":"2026-08-17T05:40:11","y":15},{"x":"2026-08-17T05:43:12","y":16},{"x":"2026-08-17T05:46:12","y":15},{"x":"2026-08-17T05:47:11","y":16},{"x":"2026-08-17T05:48:12","y":15},{"x":"2026-08-17T05:50:12","y":16},{"x":"2026-08-17T06:00:00","y":16},{"x":"2026-08-17T06:01:12","y":15},{"x":"2026-08-17T06:02:11","y":16},{"x":"2026-08-17T06:03:11","y":15},{"x":"2026-08-17T06:14:12","y":16},{"x":"2026-08-17T06:15:12","y":15},{"x":"2026-08-17T06:16:12","y":16},{"x":"2026-08-17T06:17:12","y":15},{"x":"2026-08-17T07:00:00","y":15},{"x":"2026-08-17T07:04:11","y":16},{"x":"2026-08-17T07:05:13","y":15},{"x":"2026-08-17T07:07:11","y":16},{"x":"2026-08-17T07:09:11","y":15},{"x":"2026-08-17T07:16:12","y":16},{"x":"2026-08-17T07:18:12","y":15},{"x":"2026-08-17T07:19:12","y":16},{"x":"2026-08-17T07:20:12","y":15},{"x":"2026-08-17T07:23:11","y":16},{"x":"2026-08-17T07:26:10","y":15},{"x":"2026-08-17T07:27:11","y":16},{"x":"2026-08-17T07:28:10","y":15},{"x":"2026-08-17T07:37:10","y":16},{"x":"2026-08-17T07:38:10","y":15},{"x":"2026-08-17T07:40:11","y":16},{"x":"2026-08-17T07:41:11","y":15},{"x":"2026-08-17T07:44:11","y":16},{"x":"2026-08-17T07:45:11","y":15},{"x":"2026-08-17T07:46:11","y":16},{"x":"2026-08-17T07:47:11","y":15},{"x":"2026-08-17T07:48:11","y":16},{"x":"2026-08-17T07:50:12","y":15},{"x":"2026-08-17T07:51:11","y":16},{"x":"2026-08-17T08:00:00","y":16},{"x":"2026-08-17T08:19:12","y":15},{"x":"2026-08-17T08:20:12","y":16},{"x":"2026-08-17T08:21:11","y":15},{"x":"2026-08-17T08:28:10","y":16},{"x":"2026-08-17T08:57:11","y":16},{"x":"2026-08-17T09:00:00","y":16},{"x":"2026-08-17T09:30:00","y":16}],"borderColor":"#6A8FBF","backgroundColor":"#6A8FBF","yAxisId":"yTemp","pointRadius":0,"lineTension":0,"borderWidth":2,"spanGaps":false,"displayIcon":true,"fill":false,"hidden":false}],"annotations":[{"type":"box","xMin":"2026-08-16T00:24:12","xMax":"2026-08-16T01:03:11","backgroundColor":"rgba(244,215,177,
+        0.5)","borderWidth":0,"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.HOT_WATER"},{"type":"box","xMin":"2026-08-16T01:58:12","xMax":"2026-08-16T02:02:11","backgroundColor":"rgba(241,153,93,
+        0.5)","borderWidth":0,"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.HEATING"},{"type":"box","xMin":"2026-08-16T02:10:12","xMax":"2026-08-16T02:15:13","backgroundColor":"rgba(241,153,93,
+        0.5)","borderWidth":0,"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.HEATING"},{"type":"box","xMin":"2026-08-16T16:51:11","xMax":"2026-08-16T17:24:10","backgroundColor":"rgba(244,215,177,
+        0.5)","borderWidth":0,"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.HOT_WATER"},{"type":"box","xMin":"2026-08-17T03:59:12","xMax":"2026-08-17T04:51:11","backgroundColor":"rgba(245,183,161,
+        0.5)","borderWidth":0,"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.LEGIONELLA"},{"type":"box","xMin":"2026-07-29T10:23:57.991+02:00","xMax":"2026-07-29T10:51:04.015+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-07-28T18:20:29.314+02:00","xMax":"2026-07-28T18:34:13.813+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-07-08T14:30:34.582+02:00","xMax":"2026-07-08T19:51:56.908+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-07-08T00:17:21.316+02:00","xMax":"2026-07-08T00:58:42.94+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-07-07T13:03:47.402+02:00","xMax":"2026-07-07T13:59:09.198+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-07-02T00:11:33.092+02:00","xMax":"2026-07-02T01:06:30.575+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-06-04T19:07:21.373+02:00","xMax":"2026-06-04T21:19:28.192+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-05-29T00:27:01.89+02:00","xMax":"2026-05-29T12:50:28.944+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-05-16T02:30:55.402+02:00","xMax":"2026-05-16T03:01:56.36+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-05-15T21:51:10.333+02:00","xMax":"2026-05-15T21:51:18.956+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-05-15T21:51:07.176+02:00","xMax":"2026-05-15T21:51:08.782+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-05-13T18:03:05.872+02:00","xMax":"2026-05-13T18:03:14.389+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-05-13T18:03:02.656+02:00","xMax":"2026-05-13T18:03:04.284+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0},{"type":"box","xMin":"2026-04-09T19:10:44.007+02:00","xMax":"2026-04-09T19:10:54.51+02:00","backgroundColor":"rgba(169,169,169,
+        1)","borderWidth":0}],"annotationLegends":[{"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.HOT_WATER","backgroundColor":"rgba(244,215,177,
+        0.5)","hasData":true},{"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.HEATING","backgroundColor":"rgba(241,153,93,
+        0.5)","hasData":true},{"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.COOLING","backgroundColor":"rgba(205,241,255,
+        0.5)","hasData":false},{"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.FREEZE_STAT","backgroundColor":"rgba(199,221,238,
+        0.5)","hasData":false},{"label":"REPORT.COMFORT_GRAPH.OVERLAY_KEY.LEGIONELLA","backgroundColor":"rgba(245,183,161,
+        0.5)","hasData":true}],"previousTriggers":[{"trigger":"2026-08-17T08:57:11","value":50,"measure":"set_tank_water_temperature"},{"trigger":"2026-08-16T00:27:12","value":44.5,"measure":"tank_water_temperature"},{"trigger":"2026-08-16T00:33:13","value":17.5,"measure":"set_temperature_zone1"},{"trigger":"2026-08-16T00:23:11","value":24.5,"measure":"room_temperature_zone1"},{"trigger":"2026-08-16T00:28:12","value":16,"measure":"outside_temperature"}],"timeUnit":"minute","stepSize":15,"from":"2026-08-16T00:00:00","to":"2026-08-17T09:30:00"}]'
+    headers:
+      Apigw-Requestid:
+      - CPJMoj4tjoEEPwA=
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '19584'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 Aug 2026 07:44:44 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/api/test_atw_models.py
+++ b/tests/api/test_atw_models.py
@@ -455,6 +455,11 @@ class TestEdgeCases:
         unit = AirToWaterUnit.from_dict(ATW_UNIT_IDLE)
         assert unit.outdoor_temp_recorded_at is None
 
+    def test_outdoor_temp_last_error_at_defaults_none(self) -> None:
+        """outdoor_temp_last_error_at is set by the coordinator, not from_dict."""
+        unit = AirToWaterUnit.from_dict(ATW_UNIT_IDLE)
+        assert unit.outdoor_temp_last_error_at is None
+
     def test_empty_string_converts_to_none(self) -> None:
         """Test that empty strings are converted to None."""
         # ErrorCode is empty string in IDLE fixture

--- a/tests/api/test_atw_models.py
+++ b/tests/api/test_atw_models.py
@@ -424,10 +424,14 @@ class TestEdgeCases:
         assert unit.power is False  # Default
         assert unit.operation_status == "Stop"  # Default
 
-    def test_outdoor_temperature_parsed_from_settings(self) -> None:
-        """Test outdoor temperature is parsed from settings array."""
+    def test_outdoor_temperature_never_parsed_from_live_settings(self) -> None:
+        """Live OutdoorTemperature can be silently wrong with no way to tell
+        from the value alone (issue #251), so from_dict never trusts it -
+        outdoor_temperature is populated only by the coordinator's
+        comfort-graph poll, same as ATA's trendsummary-only outdoor temp.
+        """
         unit = AirToWaterUnit.from_dict(ATW_UNIT_IDLE)
-        assert unit.outdoor_temperature == 18.0
+        assert unit.outdoor_temperature is None
 
     def test_outdoor_temperature_none_when_missing(self) -> None:
         """Test outdoor temperature defaults to None when not in settings."""
@@ -439,6 +443,17 @@ class TestEdgeCases:
         }
         unit = AirToWaterUnit.from_dict(unit_data)
         assert unit.outdoor_temperature is None
+
+    def test_has_outdoor_temp_sensor_defaults_false(self) -> None:
+        """has_outdoor_temp_sensor is a runtime discovery flag set by the
+        coordinator after a successful comfort-graph poll, not by from_dict."""
+        unit = AirToWaterUnit.from_dict(ATW_UNIT_IDLE)
+        assert unit.has_outdoor_temp_sensor is False
+
+    def test_outdoor_temp_recorded_at_defaults_none(self) -> None:
+        """outdoor_temp_recorded_at is set by the coordinator, not from_dict."""
+        unit = AirToWaterUnit.from_dict(ATW_UNIT_IDLE)
+        assert unit.outdoor_temp_recorded_at is None
 
     def test_empty_string_converts_to_none(self) -> None:
         """Test that empty strings are converted to None."""

--- a/tests/api/test_atw_outdoor_temperature_vcr.py
+++ b/tests/api/test_atw_outdoor_temperature_vcr.py
@@ -1,0 +1,55 @@
+"""VCR tests for ATW outdoor temperature via the comfort-graph report API.
+
+Unlike ATA (whose live /context OutdoorTemperature is always absent), ATW's
+live value can be present but silently wrong with no way to tell from the
+value alone (issue #251) — so ATW always queries the comfort-graph report
+instead of trusting the live value.
+
+Recording VCR cassettes:
+1. Set credentials: export MELCLOUD_USER=email MELCLOUD_PASSWORD=password
+2. Delete existing cassette: rm tests/api/cassettes/test_get_atw_outdoor_temperature*.yaml
+3. Run test: pytest tests/api/test_atw_outdoor_temperature_vcr.py -v
+4. Cassette will be recorded automatically
+
+Reference: docs/testing-best-practices.md
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import pytest
+from freezegun import freeze_time
+
+if TYPE_CHECKING:
+    from custom_components.melcloudhome.api.client import MELCloudHomeClient
+
+
+@freeze_time("2026-08-17 09:30:00", real_asyncio=True)
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_get_atw_outdoor_temperature(
+    authenticated_client: "MELCloudHomeClient",
+) -> None:
+    """Test fetching outdoor temperature for ATW unit via comfort-graph."""
+    context = await authenticated_client.get_user_context()
+
+    unit = None
+    for building in context.buildings:
+        for atw_unit in building.air_to_water_units:
+            unit = atw_unit
+            break
+        if unit:
+            break
+
+    if not unit:
+        pytest.skip("No ATW units found")
+
+    assert unit is not None  # Type narrowing
+    temp, recorded_at = await authenticated_client.get_atw_outdoor_temperature(unit.id)
+
+    # Verify response - either float or None (both valid)
+    if temp is not None:
+        assert isinstance(temp, float)
+        assert -50.0 <= temp <= 50.0  # Reasonable temperature range
+        assert recorded_at is None or isinstance(recorded_at, datetime)
+    # else: None is valid (no genuine reading in the lookback window)

--- a/tests/api/test_outdoor_temperature_client.py
+++ b/tests/api/test_outdoor_temperature_client.py
@@ -234,14 +234,70 @@ async def test_get_outdoor_temperature_api_returns_none(mocker):
 
 
 @pytest.mark.asyncio
-async def test_get_outdoor_temperature_exception_handling(mocker):
-    """Test exception handling returns None and logs debug."""
+async def test_get_outdoor_temperature_propagates_exceptions(mocker):
+    """Errors propagate to the caller rather than being swallowed to (None,
+    None) - the coordinator needs to see them to distinguish "endpoint
+    failing" from "no genuine reading yet" (both would otherwise look
+    identical, undermining any diagnostic signal for issue #251-style bugs).
+    The coordinator's own per-unit exception isolation (_poll_outdoor_temperature)
+    is what keeps this from destabilizing the overall update.
+    """
     client = MELCloudHomeClient()
 
-    # Mock _api_request to raise an exception
-    mocker.patch.object(client, "_api_request", side_effect=Exception("API error"))
+    mocker.patch.object(client, "_api_request", side_effect=ValueError("API error"))
 
-    result = await client.get_outdoor_temperature("test-unit-id")
+    with pytest.raises(ValueError, match="API error"):
+        await client.get_outdoor_temperature("test-unit-id")
 
-    # Should return (None, None) on exception, not raise
-    assert result == (None, None)
+
+@freeze_time("2026-08-17 09:30:00", real_asyncio=True)
+@pytest.mark.asyncio
+async def test_get_atw_outdoor_temperature_calls_api_correctly(mocker):
+    """Test that get_atw_outdoor_temperature queries Hourly with a 24h window."""
+    client = MELCloudHomeClient()
+
+    mock_request = mocker.patch.object(
+        client,
+        "_api_request",
+        return_value={
+            "datasets": [
+                {
+                    "label": "REPORT.TREND_SUMMARY_REPORT.DATASET.LABELS.OUTDOOR_TEMPERATURE",
+                    "data": [{"x": "2026-08-17T09:00:23", "y": 16.0}],
+                }
+            ]
+        },
+    )
+
+    result = await client.get_atw_outdoor_temperature("test-atw-unit-id")
+
+    mock_request.assert_called_once()
+    call_args = mock_request.call_args
+    assert call_args[0][0] == "GET"
+    assert call_args[0][1] == "/report/v1/comfort-graph"
+
+    params = call_args[1]["params"]
+    assert params["unitId"] == "test-atw-unit-id"
+    assert params["period"] == "Hourly"
+    to_dt = datetime.strptime(params["to"], "%Y-%m-%dT%H:%M:%S.0000000").replace(
+        tzinfo=UTC
+    )
+    from_dt = datetime.strptime(params["from"], "%Y-%m-%dT%H:%M:%S.0000000").replace(
+        tzinfo=UTC
+    )
+    assert to_dt == datetime(2026, 8, 17, 9, 30, 0, tzinfo=UTC)
+    # 24h window: comfort-graph's Hourly period hard-fails past ~4 days back
+    assert to_dt - from_dt == timedelta(hours=24)
+
+    assert result == (16.0, datetime(2026, 8, 17, 9, 0, 23, tzinfo=UTC))
+
+
+@pytest.mark.asyncio
+async def test_get_atw_outdoor_temperature_propagates_exceptions(mocker):
+    """Same propagation contract as get_outdoor_temperature - see that test."""
+    client = MELCloudHomeClient()
+
+    mocker.patch.object(client, "_api_request", side_effect=ValueError("API error"))
+
+    with pytest.raises(ValueError, match="API error"):
+        await client.get_atw_outdoor_temperature("test-atw-unit-id")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -122,7 +122,7 @@ def create_mock_atw_unit(
     energy_consumed: float | None = None,
     energy_produced: float | None = None,
     cop: float | None = None,
-    outdoor_temperature: float | None = 15.0,
+    outdoor_temperature: float | None = None,
 ) -> "AirToWaterUnit":
     """Create a mock AirToWaterUnit for testing.
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@ These fixtures require pytest-homeassistant-custom-component.
 import asyncio
 import json
 from collections.abc import Callable
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
@@ -123,6 +124,9 @@ def create_mock_atw_unit(
     energy_produced: float | None = None,
     cop: float | None = None,
     outdoor_temperature: float | None = None,
+    has_outdoor_temp_sensor: bool = False,
+    outdoor_temp_recorded_at: datetime | None = None,
+    outdoor_temp_last_error: str | None = None,
 ) -> "AirToWaterUnit":
     """Create a mock AirToWaterUnit for testing.
 
@@ -166,6 +170,9 @@ def create_mock_atw_unit(
         energy_produced=energy_produced,
         cop=cop,
         outdoor_temperature=outdoor_temperature,
+        has_outdoor_temp_sensor=has_outdoor_temp_sensor,
+        outdoor_temp_recorded_at=outdoor_temp_recorded_at,
+        outdoor_temp_last_error=outdoor_temp_last_error,
         capabilities=AirToWaterCapabilities(
             has_zone2=has_zone2,
             has_heat_zone2=has_zone2,

--- a/tests/integration/test_atw_outdoor_temperature_sensor.py
+++ b/tests/integration/test_atw_outdoor_temperature_sensor.py
@@ -46,6 +46,8 @@ async def test_atw_outdoor_temperature_sensor_shows_polled_value(
     assert state is not None
     assert state.state == "16.0"
     assert state.attributes["last_reading"] == "2026-08-17T08:57:11+00:00"
+    assert state.attributes["unit_of_measurement"] == "°C"
+    assert state.attributes["device_class"] == "temperature"
 
 
 async def test_atw_outdoor_temperature_unknown_when_poll_returns_none(
@@ -91,10 +93,8 @@ async def test_atw_outdoor_temperature_updates_on_coordinator_refresh(
     mock_client.get_atw_outdoor_temperature = AsyncMock(
         return_value=(14.0, datetime(2026, 8, 17, 9, 27, 11, tzinfo=UTC))
     )
-    # _last_outdoor_temp_poll has no public reset interface; direct access is
-    # the only way to simulate the polling interval elapsing in tests.
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    coordinator._last_outdoor_temp_poll.clear()
+    coordinator.reset_outdoor_temp_polling()
 
     await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
     await hass.async_block_till_done()

--- a/tests/integration/test_atw_outdoor_temperature_sensor.py
+++ b/tests/integration/test_atw_outdoor_temperature_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.core import HomeAssistant
 from custom_components.melcloudhome.const import DOMAIN
 
 from .conftest import (
+    TEST_ATW_UNIT_ID,
     create_mock_atw_building,
     create_mock_atw_unit,
     create_mock_atw_user_context,
@@ -102,3 +103,67 @@ async def test_atw_outdoor_temperature_updates_on_coordinator_refresh(
     state = hass.states.get(ENTITY_ID)
     assert state.state == "14.0"
     assert state.attributes["last_reading"] == "2026-08-17T09:27:11+00:00"
+
+
+async def test_atw_outdoor_temp_last_error_recorded_on_poll_failure(
+    hass: HomeAssistant,
+) -> None:
+    """A real error (e.g. comfort-graph 500) is distinguishable from "no
+    genuine reading yet" - both must not look identical, or there's no way
+    to diagnose "does this device support comfort-graph at all" (see #251
+    follow-up discussion)."""
+    mock_unit = create_mock_atw_unit()
+    mock_context = create_mock_atw_user_context(
+        [create_mock_atw_building(units=[mock_unit])]
+    )
+
+    def configure(client: Any) -> None:
+        client.get_atw_outdoor_temperature = AsyncMock(
+            side_effect=ValueError("MELCloud service unavailable (HTTP 500)")
+        )
+
+    entry, _ = await setup_atw_integration_custom(
+        hass, mock_context, configure_client=configure
+    )
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    unit = coordinator.get_atw_device(TEST_ATW_UNIT_ID)
+    assert unit is not None
+    assert unit.outdoor_temp_last_error is not None
+    assert "500" in unit.outdoor_temp_last_error
+    # Sensor still shows unknown, not an error state - failures never surface
+    # as anything other than "no value yet" to the end user.
+    assert hass.states.get(ENTITY_ID).state == "unknown"
+
+
+async def test_atw_outdoor_temp_last_error_cleared_on_next_success(
+    hass: HomeAssistant,
+) -> None:
+    """A recorded error clears once the poll succeeds again."""
+    mock_unit = create_mock_atw_unit()
+    mock_context = create_mock_atw_user_context(
+        [create_mock_atw_building(units=[mock_unit])]
+    )
+
+    def configure(client: Any) -> None:
+        client.get_atw_outdoor_temperature = AsyncMock(
+            side_effect=ValueError("MELCloud service unavailable (HTTP 500)")
+        )
+
+    entry, mock_client = await setup_atw_integration_custom(
+        hass, mock_context, configure_client=configure
+    )
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    assert (
+        coordinator.get_atw_device(TEST_ATW_UNIT_ID).outdoor_temp_last_error is not None
+    )
+
+    mock_client.get_atw_outdoor_temperature = AsyncMock(
+        return_value=(16.0, datetime(2026, 8, 17, 8, 57, 11, tzinfo=UTC))
+    )
+    coordinator.reset_outdoor_temp_polling()
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+    await hass.async_block_till_done()
+
+    assert coordinator.get_atw_device(TEST_ATW_UNIT_ID).outdoor_temp_last_error is None

--- a/tests/integration/test_atw_outdoor_temperature_sensor.py
+++ b/tests/integration/test_atw_outdoor_temperature_sensor.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock
 
+from freezegun import freeze_time
 from homeassistant.core import HomeAssistant
 
 from custom_components.melcloudhome.const import DOMAIN
@@ -105,6 +106,7 @@ async def test_atw_outdoor_temperature_updates_on_coordinator_refresh(
     assert state.attributes["last_reading"] == "2026-08-17T09:27:11+00:00"
 
 
+@freeze_time("2026-08-17 09:30:00", real_asyncio=True)
 async def test_atw_outdoor_temp_last_error_recorded_on_poll_failure(
     hass: HomeAssistant,
 ) -> None:
@@ -131,6 +133,7 @@ async def test_atw_outdoor_temp_last_error_recorded_on_poll_failure(
     assert unit is not None
     assert unit.outdoor_temp_last_error is not None
     assert "500" in unit.outdoor_temp_last_error
+    assert unit.outdoor_temp_last_error_at == datetime(2026, 8, 17, 9, 30, tzinfo=UTC)
     # Sensor still shows unknown, not an error state - failures never surface
     # as anything other than "no value yet" to the end user.
     assert hass.states.get(ENTITY_ID).state == "unknown"
@@ -155,9 +158,9 @@ async def test_atw_outdoor_temp_last_error_cleared_on_next_success(
     )
 
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    assert (
-        coordinator.get_atw_device(TEST_ATW_UNIT_ID).outdoor_temp_last_error is not None
-    )
+    unit = coordinator.get_atw_device(TEST_ATW_UNIT_ID)
+    assert unit.outdoor_temp_last_error is not None
+    assert unit.outdoor_temp_last_error_at is not None
 
     mock_client.get_atw_outdoor_temperature = AsyncMock(
         return_value=(16.0, datetime(2026, 8, 17, 8, 57, 11, tzinfo=UTC))
@@ -166,4 +169,6 @@ async def test_atw_outdoor_temp_last_error_cleared_on_next_success(
     await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
     await hass.async_block_till_done()
 
-    assert coordinator.get_atw_device(TEST_ATW_UNIT_ID).outdoor_temp_last_error is None
+    unit = coordinator.get_atw_device(TEST_ATW_UNIT_ID)
+    assert unit.outdoor_temp_last_error is None
+    assert unit.outdoor_temp_last_error_at is None

--- a/tests/integration/test_atw_outdoor_temperature_sensor.py
+++ b/tests/integration/test_atw_outdoor_temperature_sensor.py
@@ -1,0 +1,104 @@
+"""Integration tests for ATW outdoor temperature sensor.
+
+ATW's live /context OutdoorTemperature can be silently wrong (issue #251) or
+absent, with no way to tell which from the value alone, so outdoor
+temperature is sourced exclusively from the coordinator's comfort-graph poll -
+mirroring how ATA's outdoor temperature is sourced exclusively from
+trendsummary. See tests/integration/test_outdoor_temperature_sensor.py for
+the ATA equivalent this mirrors.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.melcloudhome.const import DOMAIN
+
+from .conftest import (
+    create_mock_atw_building,
+    create_mock_atw_unit,
+    create_mock_atw_user_context,
+    setup_atw_integration_custom,
+)
+
+ENTITY_ID = "sensor.melcloudhome_0efc_9abc_outdoor_temperature"
+
+
+async def test_atw_outdoor_temperature_sensor_shows_polled_value(
+    hass: HomeAssistant,
+) -> None:
+    """Sensor shows the comfort-graph poll result, not any live-context value."""
+    mock_unit = create_mock_atw_unit()
+    mock_context = create_mock_atw_user_context(
+        [create_mock_atw_building(units=[mock_unit])]
+    )
+
+    def configure(client: Any) -> None:
+        client.get_atw_outdoor_temperature = AsyncMock(
+            return_value=(16.0, datetime(2026, 8, 17, 8, 57, 11, tzinfo=UTC))
+        )
+
+    await setup_atw_integration_custom(hass, mock_context, configure_client=configure)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "16.0"
+    assert state.attributes["last_reading"] == "2026-08-17T08:57:11+00:00"
+
+
+async def test_atw_outdoor_temperature_unknown_when_poll_returns_none(
+    hass: HomeAssistant,
+) -> None:
+    """Sensor is always created; shows 'unknown' when the poll finds nothing,
+    never a stale/wrong live-context value."""
+    mock_unit = create_mock_atw_unit()
+    mock_context = create_mock_atw_user_context(
+        [create_mock_atw_building(units=[mock_unit])]
+    )
+
+    def configure(client: Any) -> None:
+        client.get_atw_outdoor_temperature = AsyncMock(return_value=(None, None))
+
+    await setup_atw_integration_custom(hass, mock_context, configure_client=configure)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "unknown"
+
+
+async def test_atw_outdoor_temperature_updates_on_coordinator_refresh(
+    hass: HomeAssistant,
+) -> None:
+    """Value updates when the coordinator's next poll returns a new reading."""
+    mock_unit = create_mock_atw_unit()
+    mock_context = create_mock_atw_user_context(
+        [create_mock_atw_building(units=[mock_unit])]
+    )
+
+    def configure(client: Any) -> None:
+        client.get_atw_outdoor_temperature = AsyncMock(
+            return_value=(16.0, datetime(2026, 8, 17, 8, 57, 11, tzinfo=UTC))
+        )
+
+    entry, mock_client = await setup_atw_integration_custom(
+        hass, mock_context, configure_client=configure
+    )
+
+    assert hass.states.get(ENTITY_ID).state == "16.0"
+
+    mock_client.get_atw_outdoor_temperature = AsyncMock(
+        return_value=(14.0, datetime(2026, 8, 17, 9, 27, 11, tzinfo=UTC))
+    )
+    # _last_outdoor_temp_poll has no public reset interface; direct access is
+    # the only way to simulate the polling interval elapsing in tests.
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator._last_outdoor_temp_poll.clear()
+
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == "14.0"
+    assert state.attributes["last_reading"] == "2026-08-17T09:27:11+00:00"

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -8,6 +8,7 @@ Run with: make test-integration
 """
 
 import json
+from datetime import datetime
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
@@ -25,7 +26,11 @@ from .conftest import (
     create_mock_ata_building,
     create_mock_ata_unit,
     create_mock_ata_user_context,
+    create_mock_atw_building,
+    create_mock_atw_unit,
+    create_mock_atw_user_context,
     setup_ata_integration_custom,
+    setup_atw_integration_custom,
     wire_connected_ws,
     ws_text_frame,
 )
@@ -232,3 +237,46 @@ async def test_diagnostics_redacts_tokens(hass: HomeAssistant) -> None:
         assert "mock-access-token-abc123" not in blob
         assert "mock-refresh-token-xyz789" not in blob
         assert "9999999999.0" not in blob
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_includes_atw_outdoor_temp_source_fields(
+    hass: HomeAssistant,
+) -> None:
+    """Diagnostics must distinguish "comfort-graph never worked for this
+    unit" from "no reading yet" from "polled fine, no error" - otherwise a
+    user's diagnostics dump can't tell those apart (see #251 follow-up:
+    there's no static way to know upfront whether a device supports the
+    comfort-graph endpoint, so this is the reactive signal)."""
+    # Pre-set fields represent the last known-good reading; the mocked poll
+    # below then fails, so the coordinator sets outdoor_temp_last_error for
+    # real without touching the other three (same behaviour as a real device
+    # that last reported fine and is now erroring).
+    unit = create_mock_atw_unit(
+        outdoor_temperature=16.0,
+        has_outdoor_temp_sensor=True,
+        outdoor_temp_recorded_at=datetime(2026, 8, 17, 8, 57, 11),
+    )
+    mock_context = create_mock_atw_user_context(
+        [create_mock_atw_building(units=[unit])]
+    )
+
+    def configure(client):
+        client.get_atw_outdoor_temperature = AsyncMock(
+            side_effect=ValueError("MELCloud service unavailable (HTTP 500)")
+        )
+
+    entry, _ = await setup_atw_integration_custom(
+        hass, mock_context, configure_client=configure
+    )
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    atw_unit = diagnostics["user_context"]["buildings"][0]["atw_units"][0]
+
+    assert atw_unit["outdoor_temperature"] == 16.0
+    assert atw_unit["has_outdoor_temp_sensor"] is True
+    assert atw_unit["outdoor_temp_recorded_at"] == "2026-08-17T08:57:11"
+    assert (
+        atw_unit["outdoor_temp_last_error"]
+        == "ValueError: MELCloud service unavailable (HTTP 500)"
+    )

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -280,3 +280,4 @@ async def test_diagnostics_includes_atw_outdoor_temp_source_fields(
         atw_unit["outdoor_temp_last_error"]
         == "ValueError: MELCloud service unavailable (HTTP 500)"
     )
+    assert atw_unit["outdoor_temp_last_error_at"] is not None

--- a/tests/integration/test_outdoor_temperature_sensor.py
+++ b/tests/integration/test_outdoor_temperature_sensor.py
@@ -216,10 +216,8 @@ async def test_outdoor_temperature_all_units_polled_on_refresh(
         side_effect=mock_get_outdoor_temp_updated
     )
 
-    # _last_outdoor_temp_poll has no public reset interface; direct access is the
-    # only way to simulate the 30-minute polling interval elapsing in tests.
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    coordinator._last_outdoor_temp_poll.clear()
+    coordinator.reset_outdoor_temp_polling()
 
     await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
     await hass.async_block_till_done()
@@ -254,8 +252,6 @@ async def test_idle_unit_reprobed_after_polling_interval(
     # Outdoor temp entities use should_create_fn at setup time and are not
     # dynamically added on coordinator updates — the coordinator model is the
     # only observable outcome of a re-probe short of an entry reload.
-    # _last_outdoor_temp_poll has no public reset API; direct access is the
-    # only way to simulate the 30-minute interval elapsing in tests.
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     unit = coordinator.get_ata_device(LIVING_ROOM_ID)
@@ -266,7 +262,7 @@ async def test_idle_unit_reprobed_after_polling_interval(
     mock_client.get_outdoor_temperature = AsyncMock(
         return_value=(15.0, datetime(2026, 2, 7, 12, 0, 0, tzinfo=UTC))
     )
-    coordinator._last_outdoor_temp_poll.clear()
+    coordinator.reset_outdoor_temp_polling()
 
     await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
     await hass.async_block_till_done()

--- a/tests/integration/test_sensor_atw.py
+++ b/tests/integration/test_sensor_atw.py
@@ -306,37 +306,13 @@ async def test_atw_energy_sensors_have_correct_device_class(
         assert cop.attributes.get("unit_of_measurement") is None
 
 
-@pytest.mark.asyncio
-async def test_atw_outdoor_temperature_sensor_created(hass: HomeAssistant) -> None:
-    """Test ATW outdoor temperature sensor is created from settings response."""
-    mock_unit = create_mock_atw_unit(outdoor_temperature=12.5)
-    mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
-    )
-    await setup_atw_integration_custom(hass, mock_context)
-
-    state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
-    assert state is not None
-    assert float(state.state) == 12.5
-    assert state.attributes["unit_of_measurement"] == "°C"
-    assert state.attributes["device_class"] == "temperature"
-
-
-@pytest.mark.asyncio
-async def test_atw_outdoor_temperature_created_but_unknown_when_none(
-    hass: HomeAssistant,
-) -> None:
-    """ATW outdoor temp sensor is always created; a unit not reporting it shows
-    'unknown', not dropped."""
-    mock_unit = create_mock_atw_unit(outdoor_temperature=None)
-    mock_context = create_mock_atw_user_context(
-        [create_mock_atw_building(units=[mock_unit])]
-    )
-    await setup_atw_integration_custom(hass, mock_context)
-
-    state = hass.states.get("sensor.melcloudhome_0efc_9abc_outdoor_temperature")
-    assert state is not None
-    assert state.state == "unknown"
+# Outdoor temperature sensor creation/unknown-state coverage lives in
+# tests/integration/test_atw_outdoor_temperature_sensor.py, which mocks the
+# actual comfort-graph poll (client.get_atw_outdoor_temperature) - the sole
+# source of this value since issue #251. The tests formerly here predated
+# that fix and passed only because their unmocked poll silently failed,
+# leaving create_mock_atw_unit's directly-set value untouched; they never
+# exercised real behaviour.
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Live `/context` `OutdoorTemperature` can read a silently wrong value on ATW units (issue #251), with no way to tell it's wrong from the value alone. This sources ATW outdoor temperature exclusively from the comfort-graph report instead, mirroring how ATA already relies solely on trendsummary rather than trusting its own live value.

## Key changes

- New `client.get_atw_outdoor_temperature()` querying `/report/v1/comfort-graph` (Hourly, 24h window — the endpoint hard-fails past ~4 days back)
- `AirToWaterUnit` no longer parses `OutdoorTemperature` from settings; adds `has_outdoor_temp_sensor` / `outdoor_temp_recorded_at`, matching `AirToAirUnit`
- New coordinator polling loop for ATW outdoor temp, sharing ATA's polling-interval bookkeeping via an extracted `_poll_outdoor_temperature` helper (also de-duplicates the two near-identical client methods into `_get_report_outdoor_temperature`)
- `outdoor_temperature` sensor gains a `last_reading` attribute, matching ATA
- New `reset_outdoor_temp_polling()` public coordinator method, replacing private-attribute test access
- Outdoor-temp poll errors now propagate instead of being swallowed, and are recorded on the unit (`outdoor_temp_last_error` / `outdoor_temp_last_error_at`) and surfaced in diagnostics for both ATA and ATW (deduped into a shared `diagnostics_shared.serialize_outdoor_temp_fields()`) — there's no way to know upfront whether a given device supports comfort-graph, so this is the reactive signal for telling "endpoint failing" apart from "no reading yet"
- Docs (`entities.md`, `architecture.md`) updated to describe the new behaviour

## Test plan

- [x] New VCR test recorded against the real reporter's device (comfort-graph response)
- [x] New unit tests for client methods, model fields, and coordinator polling/error-recording
- [x] New integration tests for sensor behaviour, `last_reading`, error recording/clearing, and diagnostics fields
- [x] Full API + integration suites green, `make pre-commit` clean
- [x] Live-verified against the real reporter's device in a fresh dev HA instance — sensor showed a genuine `19.0°C` via comfort-graph instead of the stuck `0`

Closes #251