### PR TITLE
fix(mock): add /report/v1/comfort-graph route for ATW outdoor temperature

### DIFF
--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -1312,10 +1312,12 @@ class MockMELCloudServer:
 
         if not unit_id:
             return web.json_response({"error": "unitId required"}, status=400)
+        if unit_id not in self.atw_states:
+            return web.json_response({"error": "unit not found"}, status=404)
 
         from_time, to_time = self._parse_report_window(request)
 
-        outdoor_temp = self.atw_states.get(unit_id, {}).get("outdoor_temperature", 10.0)
+        outdoor_temp = self.atw_states[unit_id].get("outdoor_temperature", 10.0)
 
         datapoints = []
         current = from_time.replace(second=26)

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -1195,16 +1195,12 @@ class MockMELCloudServer:
             charset="utf-8",
         )
 
-    async def get_trend_summary(self, request: web.Request) -> web.Response:
-        """GET /report/v1/trendsummary - Temperature trend data."""
-        unit_id = request.query.get("unitId")
+    @staticmethod
+    def _parse_report_window(request: web.Request) -> tuple[datetime, datetime]:
+        """Parse the "from"/"to" query params shared by trendsummary and comfort-graph."""
         to_param = request.query.get("to", "")
         from_param = request.query.get("from", "")
 
-        if not unit_id:
-            return web.json_response({"error": "unitId required"}, status=400)
-
-        # Parse timestamps
         if to_param:
             to_time = datetime.fromisoformat(to_param.replace(".0000000", ""))
         else:
@@ -1214,6 +1210,17 @@ class MockMELCloudServer:
             from_time = datetime.fromisoformat(from_param.replace(".0000000", ""))
         else:
             from_time = to_time - timedelta(hours=1)
+
+        return from_time, to_time
+
+    async def get_trend_summary(self, request: web.Request) -> web.Response:
+        """GET /report/v1/trendsummary - Temperature trend data."""
+        unit_id = request.query.get("unitId")
+
+        if not unit_id:
+            return web.json_response({"error": "unitId required"}, status=400)
+
+        from_time, to_time = self._parse_report_window(request)
 
         # Generate datapoints (every 10 minutes). Like the real API, genuine
         # readings carry arbitrary seconds (here :26) while synthetic points
@@ -1302,21 +1309,11 @@ class MockMELCloudServer:
         get_atw_outdoor_temperature only reads OUTDOOR_TEMPERATURE.
         """
         unit_id = request.query.get("unitId")
-        to_param = request.query.get("to", "")
-        from_param = request.query.get("from", "")
 
         if not unit_id:
             return web.json_response({"error": "unitId required"}, status=400)
 
-        if to_param:
-            to_time = datetime.fromisoformat(to_param.replace(".0000000", ""))
-        else:
-            to_time = datetime.now()
-
-        if from_param:
-            from_time = datetime.fromisoformat(from_param.replace(".0000000", ""))
-        else:
-            from_time = to_time - timedelta(hours=1)
+        from_time, to_time = self._parse_report_window(request)
 
         outdoor_temp = self.atw_states.get(unit_id, {}).get("outdoor_temperature", 10.0)
 

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -416,6 +416,9 @@ class MockMELCloudServer:
         trendsummary_route = app.router.add_get(
             "/report/v1/trendsummary", self.get_trend_summary
         )
+        comfort_graph_route = app.router.add_get(
+            "/report/v1/comfort-graph", self.get_comfort_graph
+        )
 
         # WebSocket endpoints (not added to CORS — native ws handshake, no CORS preflight)
         app.router.add_get("/ws/token", self.handle_ws_token)
@@ -440,6 +443,7 @@ class MockMELCloudServer:
             telemetry_route,
             energy_route,
             trendsummary_route,
+            comfort_graph_route,
         ]:
             cors.add(route)
 
@@ -1283,6 +1287,52 @@ class MockMELCloudServer:
                     "isNonInteractive": False,
                 }
             )
+
+        return web.Response(
+            text=json.dumps({"datasets": datasets, "annotations": []}),
+            content_type="text/plain",
+            charset="utf-8",
+        )
+
+    async def get_comfort_graph(self, request: web.Request) -> web.Response:
+        """GET /report/v1/comfort-graph - ATW outdoor temperature data.
+
+        Only models the OUTDOOR_TEMPERATURE dataset — the real endpoint also
+        returns zone/tank temperature datasets and annotations, but
+        get_atw_outdoor_temperature only reads OUTDOOR_TEMPERATURE.
+        """
+        unit_id = request.query.get("unitId")
+        to_param = request.query.get("to", "")
+        from_param = request.query.get("from", "")
+
+        if not unit_id:
+            return web.json_response({"error": "unitId required"}, status=400)
+
+        if to_param:
+            to_time = datetime.fromisoformat(to_param.replace(".0000000", ""))
+        else:
+            to_time = datetime.now()
+
+        if from_param:
+            from_time = datetime.fromisoformat(from_param.replace(".0000000", ""))
+        else:
+            from_time = to_time - timedelta(hours=1)
+
+        outdoor_temp = self.atw_states.get(unit_id, {}).get("outdoor_temperature", 10.0)
+
+        datapoints = []
+        current = from_time.replace(second=26)
+        while current <= to_time:
+            datapoints.append({"x": current.isoformat(), "y": outdoor_temp})
+            current += timedelta(minutes=10)
+        datapoints.append({"x": to_time.isoformat(), "y": outdoor_temp})  # to-echo
+
+        datasets = [
+            {
+                "label": "REPORT.TREND_SUMMARY_REPORT.DATASET.LABELS.OUTDOOR_TEMPERATURE",
+                "data": datapoints,
+            }
+        ]
 
         return web.Response(
             text=json.dumps({"datasets": datasets, "annotations": []}),


### PR DESCRIPTION
## Summary

- #257 added `get_atw_outdoor_temperature()`, which queries `/report/v1/comfort-graph`, but the mock server only ever registered `/report/v1/trendsummary`.
- Local dev testing (`make dev-up`) of ATW outdoor temperature was silently broken since #257 merged — every poll 404'd against the mock and populated `outdoor_temp_last_error` instead of a value.
- Docker integration tests didn't catch this because they mock `MELCloudHomeClient` directly at the API boundary, bypassing the mock server's HTTP layer entirely.

## Key changes

- `tools/mock_melcloud_server.py`: registers `/report/v1/comfort-graph` and adds `get_comfort_graph`, modeled on the existing `get_trend_summary` handler. Only models the `OUTDOOR_TEMPERATURE` dataset (the only one the client reads), sourced from each ATW unit's stored `outdoor_temperature`.

## Test plan

- [x] Rebuilt the mock Docker image and verified end-to-end: a real `MELCloudHomeClient` login + `get_atw_outdoor_temperature()` call against the live mock now returns the unit's configured temperature with a genuine reading timestamp (previously 404'd)
- [x] `tests/api/` full suite (379 passed)
- [x] `tests/integration/` full suite via Docker (206 passed)
- [x] `make pre-commit` clean