### PR TITLE
Release v2.4.2-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.4.2] - 2026-08-18
+
+### Fixed
+
+- Heat pump (ATW) outdoor temperature could get stuck at an incorrect value (e.g. a value of 0) with no way to tell it was wrong. It's now read from the same source as the MELCloud Home app's Reports → Comfort graph, which doesn't have this problem. (#251)
+- Air conditioning (ATA) outdoor temperature could occasionally fail to update because the underlying request looked back over a week of history, which could trigger an error from the MELCloud API. It now looks back 48 hours instead, which is more reliable - the trade-off is that a unit idle for more than 48 hours (rather than 7 days) will show outdoor temperature as "unknown" until it's used again.
+
+
 ## [2.4.1] - 2026-08-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@
 
 Home Assistant custom integration for **MELCloud Home**.
 
-## What's New in v2.4.1
+## What's New in v2.4.2
 
-**Entity names now follow your Home Assistant language.** Sensor and binary sensor names (WiFi signal, Room temperature, Frost protection, Holiday mode, and others) previously always displayed in English regardless of your Home Assistant language setting - they're now translated correctly. Identified and diagnosed by [@Jan-Arild-Blekken](https://github.com/Jan-Arild-Blekken).
-
-**New devices going forward will get entity IDs that match their translated name** for a few diagnostic sensors, including the COP sensor and the minimum/maximum frost and overheat protection sensors. This doesn't affect any of your existing entities.
-
-Norwegian (nb) translations added (thanks @Jan-Arild-Blekken).
+**More reliable outdoor temperature readings.** Heat pump (ATW) outdoor temperature could get stuck at an incorrect value with no way to tell it was wrong - it's now read from the same source as the MELCloud Home app's Reports → Comfort graph. Air conditioning (ATA) outdoor temperature could occasionally fail to update because of an error from the MELCloud API; it's now more reliable, at the cost of showing "unknown" a bit sooner for units left idle for more than 2 days.
 
 See [CHANGELOG.md](CHANGELOG.md) for full history.
 

--- a/custom_components/melcloudhome/manifest.json
+++ b/custom_components/melcloudhome/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.melcloudhome"
   ],
   "requirements": [],
-  "version": "2.4.1"
+  "version": "2.4.2"
 }


### PR DESCRIPTION
## Summary

Beta release for community testing of the ATW outdoor temperature fixes:

- ATW outdoor temperature now sourced from the comfort-graph report instead of the unreliable live value (#257, closes #251)
- ATA outdoor temperature's trendsummary lookback shrunk from 7 days to 48h to avoid a genuine 500 from the MELCloud API (#258)

Version bump only — no code changes.

## Test plan

- [ ] Merge this PR
- [ ] Tag `v2.4.2-beta.1` and push to trigger the release workflow
- [ ] Invite beta testers, verify against real ATW hardware