### PR TITLE
fix(diagnostics): redact real device/building names from entity_id keys

### DIFF
--- a/custom_components/melcloudhome/diagnostics.py
+++ b/custom_components/melcloudhome/diagnostics.py
@@ -3,18 +3,14 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    area_registry as ar,
-    device_registry as dr,
-    entity_registry as er,
-)
-from homeassistant.util import slugify
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import DOMAIN
 from .coordinator import MELCloudHomeCoordinator
@@ -23,55 +19,38 @@ from .diagnostics_atw import serialize_atw_unit
 
 TO_REDACT = {CONF_EMAIL, CONF_PASSWORD, "access_token", "refresh_token", "token_expiry"}
 
-
-def _real_name_slugs(
-    entity: er.RegistryEntry,
-    device: dr.DeviceEntry | None,
-    area_reg: ar.AreaRegistry,
-) -> dict[str, str]:
-    """Map each real-name slug that could leak into this entity_id to the
-    stable registry id to hash for its placeholder - the area's id when the
-    match is area-sourced (shared by every device in that area, so sibling
-    devices redact to the same placeholder), the device's id otherwise.
-
-    Never matches against `device.name` - that's always the harmless
-    `melcloudhome_xxxx_yyyy` short id, not a real name (see docs/entities.md).
-    """
-    slugs: dict[str, str] = {}
-    if device is not None and device.name_by_user:
-        slug = slugify(device.name_by_user)
-        if slug:
-            slugs[slug] = device.id
-
-    area_id = entity.area_id or (device.area_id if device else None)
-    if area_id and (area := area_reg.async_get_area(area_id)) and area.name:
-        slug = slugify(area.name)
-        if slug:
-            slugs[slug] = area.id
-
-    return slugs
+_ENTITY_ID_PREFIX = re.compile(r"^(.+)_(?=melcloudhome_)")
 
 
-def _redact_entity_id(entity_id: str, real_name_slugs: dict[str, str]) -> str:
-    """Strip any real-name-derived slug out of an entity_id, if present.
+def _redact_entity_id(
+    entity_id: str, device_id: str | None, area_id: str | None
+) -> str:
+    """Redact any real-name prefix baked into an entity_id, whatever put it there.
 
-    Real running installs never hit this in the device-name-by-user case -
-    `_clear_friendly_device_names` (see __init__.py) clears it before setup -
-    but entity_id is set once and never recomputed, so a legacy or
-    manually-recreated entity_id (HA's "Recreate entity IDs" action, see
-    ADR-013) can still have a real name baked in permanently. The area-name
-    case has no equivalent mitigation and can leak on every normal setup.
+    Every entity_id this integration generates is exactly
+    `{domain}.[prefix_]melcloudhome_{shortid}_{suffix}` - "melcloudhome_" is a
+    hardcoded, never-real-name-derived marker, so any non-empty prefix before
+    it is some real name by construction. Deliberately doesn't enumerate
+    *why* (device `name_by_user`, an assigned area, a legacy/manually-
+    recreated entity_id - see ADR-013 - or any future mechanism): two
+    independent real ones were already found reactively via live testing, so
+    a structural check catches whatever comes next too, not just those two.
+
+    Hashes the area id when available (shared by every device in that area,
+    so sibling devices redact to the same placeholder), the device id
+    otherwise - never the leaked name itself, which is exactly what we're
+    trying to keep unguessable (a real building/room name is low-entropy
+    enough to dictionary-attack a hash of the name itself, unlike a UUID).
     """
     domain, _, object_id = entity_id.partition(".")
-    for slug, hash_source_id in real_name_slugs.items():
-        placeholder = (
-            f"redacted_device_{hashlib.sha256(hash_source_id.encode()).hexdigest()[:8]}"
-        )
-        if object_id == slug:
-            return f"{domain}.{placeholder}"
-        if object_id.startswith(f"{slug}_"):
-            return f"{domain}.{placeholder}{object_id[len(slug) :]}"
-    return entity_id
+    match = _ENTITY_ID_PREFIX.match(object_id)
+    if not match or device_id is None:
+        return entity_id
+    hash_source = area_id or device_id
+    placeholder = (
+        f"redacted_device_{hashlib.sha256(hash_source.encode()).hexdigest()[:8]}"
+    )
+    return f"{domain}.{placeholder}_{object_id[match.end() :]}"
 
 
 async def async_get_config_entry_diagnostics(
@@ -85,11 +64,10 @@ async def async_get_config_entry_diagnostics(
     # Get all entities for this config entry
     entity_reg = er.async_get(hass)
     device_reg = dr.async_get(hass)
-    area_reg = ar.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
 
-    # Collect entity states, redacting any real-name-derived segment out of
-    # the entity_id key itself (see _redact_entity_id / _real_name_slugs).
+    # Collect entity states, redacting any real-name prefix out of the
+    # entity_id key itself (see _redact_entity_id).
     entity_data = {}
     for entity in entities:
         if state := hass.states.get(entity.entity_id):
@@ -98,8 +76,9 @@ async def async_get_config_entry_diagnostics(
             device = (
                 device_reg.async_get(entity.device_id) if entity.device_id else None
             )
-            slugs = _real_name_slugs(entity, device, area_reg)
-            entity_data[_redact_entity_id(entity.entity_id, slugs)] = {
+            area_id = entity.area_id or (device.area_id if device else None)
+            redacted_id = _redact_entity_id(entity.entity_id, entity.device_id, area_id)
+            entity_data[redacted_id] = {
                 "state": state.state,
                 "attributes": attrs,
             }

--- a/custom_components/melcloudhome/diagnostics.py
+++ b/custom_components/melcloudhome/diagnostics.py
@@ -25,23 +25,10 @@ _ENTITY_ID_PREFIX = re.compile(r"^(.+)_(?=melcloudhome_)")
 def _redact_entity_id(
     entity_id: str, device_id: str | None, area_id: str | None
 ) -> str:
-    """Redact any real-name prefix baked into an entity_id, whatever put it there.
-
-    Every entity_id this integration generates is exactly
-    `{domain}.[prefix_]melcloudhome_{shortid}_{suffix}` - "melcloudhome_" is a
-    hardcoded, never-real-name-derived marker, so any non-empty prefix before
-    it is some real name by construction. Deliberately doesn't enumerate
-    *why* (device `name_by_user`, an assigned area, a legacy/manually-
-    recreated entity_id - see ADR-013 - or any future mechanism): two
-    independent real ones were already found reactively via live testing, so
-    a structural check catches whatever comes next too, not just those two.
-
-    Hashes the area id when available (shared by every device in that area,
-    so sibling devices redact to the same placeholder), the device id
-    otherwise - never the leaked name itself, which is exactly what we're
-    trying to keep unguessable (a real building/room name is low-entropy
-    enough to dictionary-attack a hash of the name itself, unlike a UUID).
-    """
+    """Redact any real-name prefix before the never-name-derived "melcloudhome_"
+    marker, regardless of what put it there. Hashes area_id over device_id when
+    available so sibling devices share a placeholder; hashes an id rather than
+    the name itself since a real name is guessable via dictionary attack."""
     domain, _, object_id = entity_id.partition(".")
     match = _ENTITY_ID_PREFIX.match(object_id)
     if not match or device_id is None:

--- a/custom_components/melcloudhome/diagnostics.py
+++ b/custom_components/melcloudhome/diagnostics.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util import slugify
 
 from .const import DOMAIN
 from .coordinator import MELCloudHomeCoordinator
@@ -16,6 +18,42 @@ from .diagnostics_ata import serialize_ata_unit
 from .diagnostics_atw import serialize_atw_unit
 
 TO_REDACT = {CONF_EMAIL, CONF_PASSWORD, "access_token", "refresh_token", "token_expiry"}
+
+
+def _redact_entity_id(entity_id: str, device: dr.DeviceEntry | None) -> str:
+    """Strip a device-name-derived slug out of an entity_id, if present.
+
+    Real running installs never actually hit this: `_clear_friendly_device_names`
+    (see __init__.py) clears `name_by_user` before entities are created, so
+    entity_id is always generated from the stable UUID-based `device.name`, not
+    the real building/room name. But entity_id is set once and never
+    recomputed, so a legacy or manually-recreated entity (HA's "Recreate
+    entity IDs" action regenerates from whatever `name_by_user` is set to at
+    the time - see ADR-013's "Entity ID recreation risk") can still have the
+    friendly name baked into its entity_id permanently. Diagnostics must not
+    forward that.
+
+    Only `name_by_user` is checked, not `device.name` - the latter is always
+    the harmless `melcloudhome_xxxx_yyyy` short id and matches every normal
+    entity_id by design (see docs/entities.md), so matching against it too
+    would strip that useful short id from every entity, not just leaked ones.
+    """
+    if device is None or not device.name_by_user:
+        return entity_id
+    slug = slugify(device.name_by_user)
+    if not slug:
+        return entity_id
+    domain, _, object_id = entity_id.partition(".")
+    # Hash the device registry ID, not the name - the name is exactly what
+    # we're trying to keep unguessable.
+    placeholder = (
+        f"redacted_device_{hashlib.sha256(device.id.encode()).hexdigest()[:8]}"
+    )
+    if object_id == slug:
+        return f"{domain}.{placeholder}"
+    if object_id.startswith(f"{slug}_"):
+        return f"{domain}.{placeholder}{object_id[len(slug) :]}"
+    return entity_id
 
 
 async def async_get_config_entry_diagnostics(
@@ -28,15 +66,20 @@ async def async_get_config_entry_diagnostics(
 
     # Get all entities for this config entry
     entity_reg = er.async_get(hass)
+    device_reg = dr.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
 
-    # Collect entity states
+    # Collect entity states, redacting any device-name-derived segment out of
+    # the entity_id key itself (see _redact_entity_id).
     entity_data = {}
     for entity in entities:
         if state := hass.states.get(entity.entity_id):
             attrs = dict(state.attributes)
             attrs.pop("friendly_name", None)
-            entity_data[entity.entity_id] = {
+            device = (
+                device_reg.async_get(entity.device_id) if entity.device_id else None
+            )
+            entity_data[_redact_entity_id(entity.entity_id, device)] = {
                 "state": state.state,
                 "attributes": attrs,
             }

--- a/custom_components/melcloudhome/diagnostics.py
+++ b/custom_components/melcloudhome/diagnostics.py
@@ -9,7 +9,11 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.util import slugify
 
 from .const import DOMAIN
@@ -20,39 +24,53 @@ from .diagnostics_atw import serialize_atw_unit
 TO_REDACT = {CONF_EMAIL, CONF_PASSWORD, "access_token", "refresh_token", "token_expiry"}
 
 
-def _redact_entity_id(entity_id: str, device: dr.DeviceEntry | None) -> str:
-    """Strip a device-name-derived slug out of an entity_id, if present.
+def _real_name_slugs(
+    entity: er.RegistryEntry,
+    device: dr.DeviceEntry | None,
+    area_reg: ar.AreaRegistry,
+) -> dict[str, str]:
+    """Map each real-name slug that could leak into this entity_id to the
+    stable registry id to hash for its placeholder - the area's id when the
+    match is area-sourced (shared by every device in that area, so sibling
+    devices redact to the same placeholder), the device's id otherwise.
 
-    Real running installs never actually hit this: `_clear_friendly_device_names`
-    (see __init__.py) clears `name_by_user` before entities are created, so
-    entity_id is always generated from the stable UUID-based `device.name`, not
-    the real building/room name. But entity_id is set once and never
-    recomputed, so a legacy or manually-recreated entity (HA's "Recreate
-    entity IDs" action regenerates from whatever `name_by_user` is set to at
-    the time - see ADR-013's "Entity ID recreation risk") can still have the
-    friendly name baked into its entity_id permanently. Diagnostics must not
-    forward that.
-
-    Only `name_by_user` is checked, not `device.name` - the latter is always
-    the harmless `melcloudhome_xxxx_yyyy` short id and matches every normal
-    entity_id by design (see docs/entities.md), so matching against it too
-    would strip that useful short id from every entity, not just leaked ones.
+    Never matches against `device.name` - that's always the harmless
+    `melcloudhome_xxxx_yyyy` short id, not a real name (see docs/entities.md).
     """
-    if device is None or not device.name_by_user:
-        return entity_id
-    slug = slugify(device.name_by_user)
-    if not slug:
-        return entity_id
+    slugs: dict[str, str] = {}
+    if device is not None and device.name_by_user:
+        slug = slugify(device.name_by_user)
+        if slug:
+            slugs[slug] = device.id
+
+    area_id = entity.area_id or (device.area_id if device else None)
+    if area_id and (area := area_reg.async_get_area(area_id)) and area.name:
+        slug = slugify(area.name)
+        if slug:
+            slugs[slug] = area.id
+
+    return slugs
+
+
+def _redact_entity_id(entity_id: str, real_name_slugs: dict[str, str]) -> str:
+    """Strip any real-name-derived slug out of an entity_id, if present.
+
+    Real running installs never hit this in the device-name-by-user case -
+    `_clear_friendly_device_names` (see __init__.py) clears it before setup -
+    but entity_id is set once and never recomputed, so a legacy or
+    manually-recreated entity_id (HA's "Recreate entity IDs" action, see
+    ADR-013) can still have a real name baked in permanently. The area-name
+    case has no equivalent mitigation and can leak on every normal setup.
+    """
     domain, _, object_id = entity_id.partition(".")
-    # Hash the device registry ID, not the name - the name is exactly what
-    # we're trying to keep unguessable.
-    placeholder = (
-        f"redacted_device_{hashlib.sha256(device.id.encode()).hexdigest()[:8]}"
-    )
-    if object_id == slug:
-        return f"{domain}.{placeholder}"
-    if object_id.startswith(f"{slug}_"):
-        return f"{domain}.{placeholder}{object_id[len(slug) :]}"
+    for slug, hash_source_id in real_name_slugs.items():
+        placeholder = (
+            f"redacted_device_{hashlib.sha256(hash_source_id.encode()).hexdigest()[:8]}"
+        )
+        if object_id == slug:
+            return f"{domain}.{placeholder}"
+        if object_id.startswith(f"{slug}_"):
+            return f"{domain}.{placeholder}{object_id[len(slug) :]}"
     return entity_id
 
 
@@ -67,10 +85,11 @@ async def async_get_config_entry_diagnostics(
     # Get all entities for this config entry
     entity_reg = er.async_get(hass)
     device_reg = dr.async_get(hass)
+    area_reg = ar.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
 
-    # Collect entity states, redacting any device-name-derived segment out of
-    # the entity_id key itself (see _redact_entity_id).
+    # Collect entity states, redacting any real-name-derived segment out of
+    # the entity_id key itself (see _redact_entity_id / _real_name_slugs).
     entity_data = {}
     for entity in entities:
         if state := hass.states.get(entity.entity_id):
@@ -79,7 +98,8 @@ async def async_get_config_entry_diagnostics(
             device = (
                 device_reg.async_get(entity.device_id) if entity.device_id else None
             )
-            entity_data[_redact_entity_id(entity.entity_id, device)] = {
+            slugs = _real_name_slugs(entity, device, area_reg)
+            entity_data[_redact_entity_id(entity.entity_id, slugs)] = {
                 "state": state.state,
                 "attributes": attrs,
             }

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -14,7 +14,11 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 import pytest
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+)
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.melcloudhome.const import DOMAIN
@@ -244,15 +248,7 @@ async def test_diagnostics_redacts_tokens(hass: HomeAssistant) -> None:
 async def test_diagnostics_includes_atw_outdoor_temp_source_fields(
     hass: HomeAssistant,
 ) -> None:
-    """Diagnostics must distinguish "comfort-graph never worked for this
-    unit" from "no reading yet" from "polled fine, no error" - otherwise a
-    user's diagnostics dump can't tell those apart (see #251 follow-up:
-    there's no static way to know upfront whether a device supports the
-    comfort-graph endpoint, so this is the reactive signal)."""
-    # Pre-set fields represent the last known-good reading; the mocked poll
-    # below then fails, so the coordinator sets outdoor_temp_last_error for
-    # real without touching the other three (same behaviour as a real device
-    # that last reported fine and is now erroring).
+    """Diagnostics distinguishes a last-good reading from a fresh poll error."""
     unit = create_mock_atw_unit(
         outdoor_temperature=16.0,
         has_outdoor_temp_sensor=True,
@@ -288,20 +284,7 @@ async def test_diagnostics_includes_atw_outdoor_temp_source_fields(
 async def test_diagnostics_redacts_device_name_from_entity_id_key(
     hass: HomeAssistant,
 ) -> None:
-    """Regression: a device-name-derived entity_id segment must never leak
-    the real device name into a diagnostics dump's entity dict *keys*.
-
-    Structured fields (building name, unit name) are already redacted, but
-    the entity_id itself is also derived from the device name for
-    has_entity_name entities (HA prepends `device.name_by_user or device.name`
-    - see entity_registry._async_get_full_entity_name). Under normal setup
-    this integration clears name_by_user before entities are created
-    (`_clear_friendly_device_names`) specifically to keep it out of entity_id,
-    but a legacy/manually-recreated entity_id (see ADR-013's "Entity ID
-    recreation risk") can still end up with the friendly name baked in
-    permanently, since entity_id is never recomputed once registered. This
-    simulates that leaked entity directly against the entity registry.
-    """
+    """A legacy/recreated entity_id with the real device name baked in gets redacted."""
     unit_id = "11112222-3333-4444-5555-666677778888"
     unit = create_mock_ata_unit(unit_id=unit_id, name="Bathroom")
     mock_context = create_mock_ata_user_context(
@@ -316,8 +299,6 @@ async def test_diagnostics_redacts_device_name_from_entity_id_key(
     device_reg = dr.async_get(hass)
     device = device_reg.async_get_device(identifiers={(DOMAIN, unit_id)})
     assert device is not None
-    # Sanity check: the real friendly-name mechanism set this, matching the
-    # slug baked into the leaked entity_id below.
     assert device.name_by_user == "Test Cottage Bathroom"
 
     entity_reg = er.async_get(hass)
@@ -345,12 +326,64 @@ async def test_diagnostics_redacts_device_name_from_entity_id_key(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_redacts_area_name_from_entity_id_key(
+    hass: HomeAssistant,
+) -> None:
+    """A leaked entity_id matching only the (shorter) area slug, not the
+    longer name_by_user slug, still gets redacted - this integration always
+    sets name_by_user to "{building} {unit}", so a leaked entity_id using
+    just the area/building name alone (the real-world case found live
+    2026-08-19) would slip past a name_by_user-only check."""
+    unit_id = "aaaa1111-2222-3333-4444-555566667777"
+    unit = create_mock_ata_unit(unit_id=unit_id, name="Bathroom")
+    mock_context = create_mock_ata_user_context(
+        [
+            create_mock_ata_building(
+                building_id="building-2", name="Test Building", units=[unit]
+            )
+        ]
+    )
+    entry, _ = await setup_ata_integration_custom(hass, mock_context)
+
+    device_reg = dr.async_get(hass)
+    device = device_reg.async_get_device(identifiers={(DOMAIN, unit_id)})
+    assert device is not None
+    assert device.name_by_user == "Test Building Bathroom"
+
+    area_reg = ar.async_get(hass)
+    area = area_reg.async_get_or_create("Test Building")
+    device_reg.async_update_device(device.id, area_id=area.id)
+    device = device_reg.async_get_device(identifiers={(DOMAIN, unit_id)})
+    assert device is not None and device.area_id == area.id
+
+    entity_reg = er.async_get(hass)
+    leaked = entity_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{unit_id}_leaked_sensor",
+        suggested_object_id="test_building_leaked_sensor",
+        device_id=device.id,
+        config_entry=entry,
+    )
+    hass.states.async_set(leaked.entity_id, "42")
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    entities = diagnostics["entities"]
+
+    assert leaked.entity_id not in entities
+    blob = json.dumps(entities)
+    assert "test_building" not in blob
+
+    redacted_keys = [k for k in entities if k.endswith("_leaked_sensor")]
+    assert len(redacted_keys) == 1
+    assert redacted_keys[0].startswith("sensor.redacted_device_")
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_single_device_type_entity_ids_unaffected(
     hass: HomeAssistant,
 ) -> None:
-    """Regression: single-device accounts have no device-name prefix in their
-    entity_ids at all (see docs/entities.md) - the redaction pass must be a
-    no-op here, not accidentally mangle the stable short-id entity IDs."""
+    """Single-device accounts have no name prefix to redact - must be a no-op."""
     mock_context = create_mock_ata_user_context()
     entry, _ = await setup_ata_integration_custom(hass, mock_context)
 

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -280,6 +280,40 @@ async def test_diagnostics_includes_atw_outdoor_temp_source_fields(
     assert atw_unit["outdoor_temp_last_error_at"] is not None
 
 
+def _assert_leak_redacted(
+    entities: dict, leaked_entity_id: str, raw_substring: str
+) -> None:
+    """Shared assertion for the leak-redaction tests below."""
+    assert leaked_entity_id not in entities
+    assert raw_substring not in json.dumps(entities)
+
+    redacted_keys = [k for k in entities if k.endswith("_leaked_sensor")]
+    assert len(redacted_keys) == 1
+    assert redacted_keys[0].startswith("sensor.redacted_device_")
+
+
+async def _register_leaked_entity(
+    hass: HomeAssistant, entry, unit_id: str, device_id: str, prefix: str
+):
+    """Register an entity whose object_id has `prefix` baked in before the
+    real `melcloudhome_{shortid}_...` object_id this integration always
+    generates - matching the actual shape of every real leak observed live
+    (e.g. `mollebacksgatan_10_melcloudhome_ec56_6442_outdoor_temperature`),
+    not an arbitrary made-up suffix."""
+    short_id = f"{unit_id[:4]}_{unit_id[-4:]}"
+    entity_reg = er.async_get(hass)
+    leaked = entity_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{unit_id}_leaked_sensor",
+        suggested_object_id=f"{prefix}_melcloudhome_{short_id}_leaked_sensor",
+        device_id=device_id,
+        config_entry=entry,
+    )
+    hass.states.async_set(leaked.entity_id, "42")
+    return leaked
+
+
 @pytest.mark.asyncio
 async def test_diagnostics_redacts_device_name_from_entity_id_key(
     hass: HomeAssistant,
@@ -301,28 +335,12 @@ async def test_diagnostics_redacts_device_name_from_entity_id_key(
     assert device is not None
     assert device.name_by_user == "Test Cottage Bathroom"
 
-    entity_reg = er.async_get(hass)
-    leaked = entity_reg.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        f"{unit_id}_leaked_sensor",
-        suggested_object_id="test_cottage_bathroom_leaked_sensor",
-        device_id=device.id,
-        config_entry=entry,
+    leaked = await _register_leaked_entity(
+        hass, entry, unit_id, device.id, "test_cottage_bathroom"
     )
-    hass.states.async_set(leaked.entity_id, "42")
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
-    entities = diagnostics["entities"]
-
-    assert leaked.entity_id not in entities
-    blob = json.dumps(entities)
-    assert "test_cottage" not in blob
-    assert "bathroom" not in blob
-
-    redacted_keys = [k for k in entities if k.endswith("_leaked_sensor")]
-    assert len(redacted_keys) == 1
-    assert redacted_keys[0].startswith("sensor.redacted_device_")
+    _assert_leak_redacted(diagnostics["entities"], leaked.entity_id, "test_cottage")
 
 
 @pytest.mark.asyncio
@@ -356,27 +374,49 @@ async def test_diagnostics_redacts_area_name_from_entity_id_key(
     device = device_reg.async_get_device(identifiers={(DOMAIN, unit_id)})
     assert device is not None and device.area_id == area.id
 
-    entity_reg = er.async_get(hass)
-    leaked = entity_reg.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        f"{unit_id}_leaked_sensor",
-        suggested_object_id="test_building_leaked_sensor",
-        device_id=device.id,
-        config_entry=entry,
+    leaked = await _register_leaked_entity(
+        hass, entry, unit_id, device.id, "test_building"
     )
-    hass.states.async_set(leaked.entity_id, "42")
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
-    entities = diagnostics["entities"]
+    _assert_leak_redacted(diagnostics["entities"], leaked.entity_id, "test_building")
 
-    assert leaked.entity_id not in entities
-    blob = json.dumps(entities)
-    assert "test_building" not in blob
 
-    redacted_keys = [k for k in entities if k.endswith("_leaked_sensor")]
-    assert len(redacted_keys) == 1
-    assert redacted_keys[0].startswith("sensor.redacted_device_")
+@pytest.mark.asyncio
+async def test_diagnostics_redacts_unknown_mechanism_leak(hass: HomeAssistant) -> None:
+    """The whole point of the structural (regex) redaction: it doesn't need
+    to know *why* a name leaked. A device with no `name_by_user` and no area
+    assigned still gets an arbitrary leaked prefix redacted - simulating a
+    mechanism neither of the two tests above cover (e.g. a future HA
+    behavior, or a naming scheme from a much older integration version)."""
+    unit_id = "cccc9999-8888-7777-6666-555544443333"
+    unit = create_mock_ata_unit(unit_id=unit_id, name="Landing")
+    mock_context = create_mock_ata_user_context(
+        [
+            create_mock_ata_building(
+                building_id="building-3", name="No Area Building", units=[unit]
+            )
+        ]
+    )
+    entry, _ = await setup_ata_integration_custom(hass, mock_context)
+
+    device_reg = dr.async_get(hass)
+    device = device_reg.async_get_device(identifiers={(DOMAIN, unit_id)})
+    assert device is not None
+    # Clear name_by_user and any auto-suggested area - neither known
+    # mechanism is in play here, only the arbitrary leaked prefix below.
+    device_reg.async_update_device(device.id, name_by_user=None, area_id=None)
+    device = device_reg.async_get_device(identifiers={(DOMAIN, unit_id)})
+    assert device is not None and not device.name_by_user and not device.area_id
+
+    leaked = await _register_leaked_entity(
+        hass, entry, unit_id, device.id, "some_ancient_naming_scheme"
+    )
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    _assert_leak_redacted(
+        diagnostics["entities"], leaked.entity_id, "some_ancient_naming_scheme"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_diagnostics.py
+++ b/tests/integration/test_diagnostics.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, PropertyMock, patch
 import pytest
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.melcloudhome.const import DOMAIN
@@ -281,3 +282,81 @@ async def test_diagnostics_includes_atw_outdoor_temp_source_fields(
         == "ValueError: MELCloud service unavailable (HTTP 500)"
     )
     assert atw_unit["outdoor_temp_last_error_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_redacts_device_name_from_entity_id_key(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: a device-name-derived entity_id segment must never leak
+    the real device name into a diagnostics dump's entity dict *keys*.
+
+    Structured fields (building name, unit name) are already redacted, but
+    the entity_id itself is also derived from the device name for
+    has_entity_name entities (HA prepends `device.name_by_user or device.name`
+    - see entity_registry._async_get_full_entity_name). Under normal setup
+    this integration clears name_by_user before entities are created
+    (`_clear_friendly_device_names`) specifically to keep it out of entity_id,
+    but a legacy/manually-recreated entity_id (see ADR-013's "Entity ID
+    recreation risk") can still end up with the friendly name baked in
+    permanently, since entity_id is never recomputed once registered. This
+    simulates that leaked entity directly against the entity registry.
+    """
+    unit_id = "11112222-3333-4444-5555-666677778888"
+    unit = create_mock_ata_unit(unit_id=unit_id, name="Bathroom")
+    mock_context = create_mock_ata_user_context(
+        [
+            create_mock_ata_building(
+                building_id="building-1", name="Test Cottage", units=[unit]
+            )
+        ]
+    )
+    entry, _ = await setup_ata_integration_custom(hass, mock_context)
+
+    device_reg = dr.async_get(hass)
+    device = device_reg.async_get_device(identifiers={(DOMAIN, unit_id)})
+    assert device is not None
+    # Sanity check: the real friendly-name mechanism set this, matching the
+    # slug baked into the leaked entity_id below.
+    assert device.name_by_user == "Test Cottage Bathroom"
+
+    entity_reg = er.async_get(hass)
+    leaked = entity_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{unit_id}_leaked_sensor",
+        suggested_object_id="test_cottage_bathroom_leaked_sensor",
+        device_id=device.id,
+        config_entry=entry,
+    )
+    hass.states.async_set(leaked.entity_id, "42")
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    entities = diagnostics["entities"]
+
+    assert leaked.entity_id not in entities
+    blob = json.dumps(entities)
+    assert "test_cottage" not in blob
+    assert "bathroom" not in blob
+
+    redacted_keys = [k for k in entities if k.endswith("_leaked_sensor")]
+    assert len(redacted_keys) == 1
+    assert redacted_keys[0].startswith("sensor.redacted_device_")
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_single_device_type_entity_ids_unaffected(
+    hass: HomeAssistant,
+) -> None:
+    """Regression: single-device accounts have no device-name prefix in their
+    entity_ids at all (see docs/entities.md) - the redaction pass must be a
+    no-op here, not accidentally mangle the stable short-id entity IDs."""
+    mock_context = create_mock_ata_user_context()
+    entry, _ = await setup_ata_integration_custom(hass, mock_context)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+    entities = diagnostics["entities"]
+
+    assert "climate.melcloudhome_a1b2_9abc_climate" in entities
+    assert "sensor.melcloudhome_a1b2_9abc_room_temperature" in entities
+    assert not any("redacted_device_" in key for key in entities)


### PR DESCRIPTION
## Summary

Diagnostics dumps correctly redact structured fields (building names, credentials), but entity_id *keys* could still leak a real building/device name into a dump a user attaches to a bug report.

Every entity_id this integration generates is `{domain}.[prefix_]melcloudhome_{shortid}_{suffix}` — `melcloudhome_` is a hardcoded marker that's never itself real-name-derived, so any non-empty prefix before it is a real name leak, however it got there.

## Key changes

- `_redact_entity_id()` matches the `melcloudhome_` marker and redacts anything before it to `redacted_device_<hash>`.
- Hashes a stable registry id (area id when available so devices sharing an area redact consistently, device id otherwise) — never the leaked name itself, which is low-entropy enough to dictionary-attack.

## Test plan

- [x] New tests cover a `name_by_user` leak, an area-name leak, and an arbitrary leak from neither (proving the check doesn't depend on knowing the cause)
- [x] Full `tests/integration/` suite (210 passed), `make pre-commit` clean
- [x] Live-verified against a real production account with mixed legacy naming (some entities per device leaked, others clean)