### PR TITLE
perf(coordinator): defer first energy/telemetry fetch off the setup path

### DIFF
--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import functools
 import inspect
 import logging
@@ -79,6 +80,8 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         self._cancel_energy_updates: CALLBACK_TYPE | None = None
         # SPIKE: Telemetry tracking cancellation callback
         self._cancel_telemetry_updates: CALLBACK_TYPE | None = None
+        # First energy/telemetry fetch runs off the setup path (ADR-021)
+        self._startup_fetch_task: asyncio.Task[None] | None = None
         # Real-time WebSocket listener (default-on accelerator — issue #174)
         self._websocket: MELCloudHomeWebSocket | None = None
         self._ws_task: asyncio.Task[None] | None = None
@@ -330,27 +333,6 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         await self.energy_tracker.async_setup()
         await self.energy_tracker_atw.async_setup()
 
-        # Perform initial energy fetch for both ATA and ATW units in parallel
-        # Use return_exceptions=True to ensure one failure doesn't block the other
-        await asyncio.gather(
-            self._fetch_and_update_tracker(
-                "ATA energy",
-                self.energy_tracker.async_update_energy_data,
-                self.energy_tracker.update_unit_energy_data,
-                self._units,
-            ),
-            self._fetch_and_update_tracker(
-                "ATW energy",
-                self.energy_tracker_atw.async_update_energy_data,
-                self.energy_tracker_atw.update_unit_energy_data,
-                self._atw_units,
-            ),
-            return_exceptions=True,
-        )
-
-        # Notify listeners once after both energy fetches complete
-        self.async_update_listeners()
-
         # Schedule periodic energy updates (30 minutes)
         async def _update_energy_with_listeners(now):
             """Update energy and notify listeners."""
@@ -376,17 +358,6 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         # Setup telemetry tracker
         await self.telemetry_tracker.async_setup()
 
-        # Perform initial telemetry fetch
-        await self._fetch_and_update_tracker(
-            "telemetry",
-            self.telemetry_tracker.async_update_telemetry_data,
-            self.telemetry_tracker.update_unit_telemetry_data,
-            self._atw_units,
-        )
-
-        # Notify listeners after telemetry fetch
-        self.async_update_listeners()
-
         # Schedule periodic telemetry updates (60 minutes)
         async def _update_telemetry_with_listeners(now):
             """Update telemetry and notify listeners."""
@@ -401,8 +372,49 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         )
         _LOGGER.info("Telemetry polling scheduled (every 60 minutes)")
 
+        # The first energy/telemetry fetch is ~22 sequential paced requests
+        # (ADR-021). Run it in the background so entity creation isn't
+        # blocked on it; the periodic timers above are already registered,
+        # so a failure here self-heals at the next tick.
+        self._startup_fetch_task = self.hass.async_create_background_task(
+            self._run_startup_fetch(), name=f"{DOMAIN}-startup-fetch"
+        )
+
         # Start the real-time WebSocket listener unless opted out
         self._async_setup_websocket()
+
+    async def _run_startup_fetch(self) -> None:
+        """Run the first energy + telemetry fetch off the setup path.
+
+        Deferred out of async_setup (ADR-021) so ~22 sequential paced
+        requests don't block entity creation on every restart. The periodic
+        timers are registered eagerly in async_setup, so if this is
+        cancelled or fails, polling still recovers at the next tick.
+        """
+        await asyncio.gather(
+            self._fetch_and_update_tracker(
+                "ATA energy",
+                self.energy_tracker.async_update_energy_data,
+                self.energy_tracker.update_unit_energy_data,
+                self._units,
+            ),
+            self._fetch_and_update_tracker(
+                "ATW energy",
+                self.energy_tracker_atw.async_update_energy_data,
+                self.energy_tracker_atw.update_unit_energy_data,
+                self._atw_units,
+            ),
+            return_exceptions=True,
+        )
+        await self._fetch_and_update_tracker(
+            "telemetry",
+            self.telemetry_tracker.async_update_telemetry_data,
+            self.telemetry_tracker.update_unit_telemetry_data,
+            self._atw_units,
+        )
+        # One notification once everything has settled, rather than two
+        # progressive refreshes the user can't act on differently.
+        self.async_update_listeners()
 
     def _websocket_enabled(self) -> bool:
         """Whether the WebSocket accelerator should run (default on)."""
@@ -493,6 +505,15 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             # socket errors out first (e.g. when the client closes below).
             self._websocket.stop()
             self._ws_task = None
+        if self._startup_fetch_task is not None and not self._startup_fetch_task.done():
+            self._startup_fetch_task.cancel()
+            # Awaited, not just cancelled: HA's own background-task cleanup
+            # runs in _async_process_on_unload, AFTER async_unload_entry has
+            # already called this method and closed the client. Without this
+            # await, an in-flight request would have the session closed
+            # underneath it.
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._startup_fetch_task
         await self.client.close()
 
     def get_ata_device(self, unit_id: str) -> AirToAirUnit | None:

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -372,12 +372,9 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         )
         _LOGGER.info("Telemetry polling scheduled (every 60 minutes)")
 
-        # The first energy/telemetry fetch is ~22 sequential paced requests
-        # (ADR-021). Run it in the background so entity creation isn't
-        # blocked on it; the periodic timers above are already registered,
-        # so a failure here self-heals at the next tick.
-        self._startup_fetch_task = self.hass.async_create_background_task(
-            self._run_startup_fetch(), name=f"{DOMAIN}-startup-fetch"
+        # Deferred off the setup path — see _run_startup_fetch (ADR-021).
+        self._startup_fetch_task = self._config_entry.async_create_background_task(
+            self.hass, self._run_startup_fetch(), name=f"{DOMAIN}-startup-fetch"
         )
 
         # Start the real-time WebSocket listener unless opted out
@@ -508,10 +505,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         if self._startup_fetch_task is not None and not self._startup_fetch_task.done():
             self._startup_fetch_task.cancel()
             # Awaited, not just cancelled: HA's own background-task cleanup
-            # runs in _async_process_on_unload, AFTER async_unload_entry has
-            # already called this method and closed the client. Without this
-            # await, an in-flight request would have the session closed
-            # underneath it.
+            # runs after async_unload_entry has closed the client (ADR-021).
             with contextlib.suppress(asyncio.CancelledError):
                 await self._startup_fetch_task
         await self.client.close()

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -504,6 +504,10 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             self._ws_task = None
         if self._startup_fetch_task is not None and not self._startup_fetch_task.done():
             self._startup_fetch_task.cancel()
+            # Logged because suppressing CancelledError below is otherwise
+            # silent: without this, a reload mid-fetch leaves a truncated
+            # "Initial ... fetch completed" sequence with no stated reason.
+            _LOGGER.debug("Startup fetch cancelled before completion (entry unload)")
             # Awaited, not just cancelled: HA's own background-task cleanup
             # runs after async_unload_entry has closed the client (ADR-021).
             with contextlib.suppress(asyncio.CancelledError):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -406,6 +406,29 @@ graph TD
 
 ---
 
+## Setup Lifecycle: Fresh Install vs Restart
+
+Both paths run the same `async_setup_entry`, but they diverge in what already exists on disk, and that divergence is where most setup-related behaviour differences come from.
+
+**Shared sequence** (`__init__.py`): build client → `restore_tokens` → `coordinator.async_config_entry_first_refresh()` (`/context`, plus outdoor-temp polling) → `coordinator.async_setup()` (tracker `Store` loads, periodic timer registration, deferred fetch task) → seed `known_device_ids` → `_clear_friendly_device_names` → `async_forward_entry_setups` → `_restore_device_names`.
+
+Entities are created at `async_forward_entry_setups`. Only `/context` blocks that; energy and telemetry are fetched afterwards in a background task (ADR-021).
+
+| | Fresh install | Restart |
+|---|---|---|
+| States before setup runs | none | HA's entity registry writes `unavailable` + `restored: True` for every known entity, so the full list appears greyed out before our code runs |
+| Entity IDs | allocated now from the UUID scheme | read from the registry, hence stable |
+| Tracker `Store`s | empty, no file | cumulative totals and hour values restored, then the retention/corrupt-value cleanup pass runs |
+| Energy baseline | `_is_first_initialization` is true, so `_initialize_unit_tracking` marks returned hours *seen* without adding them to the cumulative — historical data must not inflate the meter. Cumulative starts at 0.0 and the first real increment lands on the *next* poll | false — normal delta accounting resumes from the restored cumulative |
+| Statistics zero point | set from the first valid float | read from the recorder database |
+| Device names | UUID-based | user's saved names restored |
+| Auth | full login | tokens restored from `entry.data` |
+| Outdoor temp | polls every unit (nothing to gate on) | polls every unit *again* — `_last_outdoor_temp_poll` is in-memory only, so the 30-minute gate is defeated by every restart |
+
+**The transient `unknown` is not symmetric between the two.** On a fresh install it replaces *no entities at all* for the duration of the first fetch, which is strictly better. On a restart it inserts an extra state: `unavailable (restored)` → `unknown` → value, where previously the entity went straight from `restored` to a real value because the fetch had completed before platform setup. Restart is therefore the only path that pays a cost, and `RestoreEntity` support — showing the last-known value rather than `unknown` — is what would remove it. See [ADR-021](decisions/021-deferred-startup-fetch.md) and [ADR-020](decisions/020-unknown-for-missing-readings.md).
+
+---
+
 ## Multi-Device Architecture
 
 Showing the facade pattern and model relationships. Facade pattern provides device-type-specific control via `client.ata` and `client.atw`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -356,7 +356,7 @@ sequenceDiagram
 **Coordinator Responsibilities (`MELCloudHomeCoordinator`):**
 
 - **State polling**: Drives the 60-second `/context` refresh loop; dispatches updates to all platforms.
-- **Independent telemetry timers**: Separate 30-minute energy timer, 30-minute ATA outdoor-temperature timer (via `/report/v1/trendsummary`), 30-minute ATW outdoor-temperature timer (via `/report/v1/comfort-graph` — the live `/context` value is never trusted, see issue #251), and 60-minute ATW flow/return telemetry timer.
+- **Independent telemetry timers**: Separate 30-minute energy timer, 30-minute ATA outdoor-temperature timer (via `/report/v1/trendsummary`), 30-minute ATW outdoor-temperature timer (via `/report/v1/comfort-graph` — the live `/context` value is never trusted, see issue #251), and 60-minute ATW flow/return telemetry timer. The timers are registered during setup, but the *first* energy/telemetry fetch runs in a background task rather than blocking entity creation on ~22 sequential paced requests (ADR-021) — so entities appear immediately after a restart, with those sensors briefly reading `unknown` until the fetch completes.
 - **Re-auth ladder** (`_run_with_reauth`, guarded by `_reauth_lock`): retry-once → refresh_token → full login → `ConfigEntryAuthFailed` (triggers HA repair UI) if all fail. This is the single place in the integration that runs re-login on auth failure.
 - **WebSocket lifecycle**: `_async_setup_websocket` launches `MELCloudHomeWebSocket` as an entry-scoped background task when enabled (default on, `enable_websocket` option); `_on_ws_delta` feeds each delta into the same debounced refresh the control clients use. HA cancels the task on entry unload/reload.
 

--- a/docs/decisions/021-deferred-startup-fetch.md
+++ b/docs/decisions/021-deferred-startup-fetch.md
@@ -1,0 +1,114 @@
+# ADR-021: Defer the First Energy/Telemetry Fetch Off the Setup Path
+
+**Status:** Accepted
+**Date:** 2026-08-19
+**Related:** [ADR-020](020-unknown-for-missing-readings.md) (defines the `unknown` state this decision makes transiently observable after a restart, without changing its meaning)
+
+## Context
+
+Traced against the dev mock server on 2026-08-18: every restart fired 31
+sequential HTTP requests before any entity existed — 1× `/context`, 6×
+`trendsummary`, 2× `comfort-graph`, 10× telemetry-energy, 12×
+telemetry-actual, on a 6 ATA + 2 ATW fixture. It scales linearly with device
+count, and `RequestPacer` enforces a 0.5s minimum gap between requests
+(`api/pacing.py:11`), so the wall-clock floor is structural rather than mock
+latency — roughly 66 seconds in that trace.
+
+None of it was optional, because `async_setup_entry` awaited
+`coordinator.async_config_entry_first_refresh()` (`__init__.py:294`) and
+`coordinator.async_setup()` (`:306`) in full before
+`async_forward_entry_setups` (`:352`). No entity of any kind existed until
+all 31 requests had completed.
+
+### The rejected alternative: jitter for fleet desynchronization
+
+The investigation that found this originally proposed a different fix:
+delay the first fetch by `random.uniform(0, 60)` so that many installs
+restarting around the same time — say after a release announcement — would
+not leave their periodic 30/60-minute timers synchronized against
+MELCloud's backend.
+
+**Rejected, because the premise is unevidenced and the arithmetic doesn't
+work.** Recorded here so it isn't rediscovered and rebuilt:
+
+- `_TrackTimeInterval._schedule_timer` (`helpers/event.py`) schedules via
+  `loop.call_at(loop.time() + seconds)`. Timer phase is anchored to
+  registration time, and nothing in this system anchors to a wall clock —
+  no cron, no `async_track_time_change`, no shared boundary. Fleet-wide
+  phase spread therefore already equals restart-time spread, which for
+  manual HACS updates is hours to days.
+- Even granting the premise, 60 seconds of jitter on a 1800-second period
+  is a 3.3% nudge — noise on a distribution already hours wide.
+- There is no evidence MELCloud rate-limits at a layer where cross-install
+  timing would matter. Each install has its own account and token. The 500s
+  that prompted the investigation came with **zero 429s** in the same
+  window, and trace to the ATW telemetry endpoint's own reliability.
+
+Adding jitter would also have required moving the `async_track_time_interval`
+registrations into the delayed task, since a timer registered eagerly keeps
+its restart-anchored phase regardless of when the first fetch runs. That
+move is a robustness downgrade in its own right — see Decision.
+
+## Decision
+
+**The first energy and telemetry fetch runs in a background task**
+(`MELCloudHomeCoordinator._run_startup_fetch`), created with
+`hass.async_create_background_task`. `async_setup` no longer awaits it.
+
+`hass.async_create_task` is deliberately *not* used:
+`async_block_till_done()` awaits `hass._tasks` and reaches
+`hass._background_tasks` only with `wait_background_tasks=True`
+(`core.py:962-977`), so a tracked task would still block HA bootstrap and
+every test that blocks till done.
+
+**The periodic 30/60-minute timer registrations stay eager in
+`async_setup`.** `_update_single_energy_tracker` (`coordinator.py:282`) is a
+complete independent fetch-and-apply with no dependency on the initial
+fetch, so registering the timers up front means a cancelled or failed
+startup fetch still recovers at the next tick. Moving registration into the
+background task would trade that self-healing away.
+
+**The task is cancelled and awaited in `async_shutdown`**, before
+`client.close()`. Awaiting matters: HA's own background-task cleanup runs in
+`_async_process_on_unload`, which fires *after* `async_unload_entry` has
+already called `async_shutdown` and closed the client
+(`config_entries.py:1002-1004, 1185`). Cancelling without awaiting would let
+an in-flight request have its session closed underneath it.
+
+`/context` is unaffected and stays synchronous in
+`async_config_entry_first_refresh` — core climate and power-state entities
+need it to exist at all.
+
+## Consequences
+
+- Entities appear immediately on restart instead of after the full fetch.
+  Energy and telemetry sensors (never core climate or power-state entities)
+  may read `unknown` for the duration of that fetch, where previously they
+  did not exist at all until it completed.
+- This does not change what `unknown` means. ADR-020 already established
+  that a missing reading reads `unknown`, not `unavailable`; this only
+  changes when that already-correct state is observable.
+- **A transient `unknown` does not corrupt long-term statistics.** Verified
+  against HA's statistics compiler:
+  - `unknown` never becomes a sample — `_entity_history_to_float_and_state`
+    (`components/sensor/recorder.py:218-233`) parses with `float()` inside
+    `try/except (ValueError, TypeError)`, so the state is dropped before
+    reaching any reset logic.
+  - The comparison baseline survives the restart in the database, not in
+    memory: `new_state = old_state = last_stat.get("state")` (`:692-698`),
+    read via `get_latest_short_term_statistics_with_session` (`:591`).
+  - `reset_detected` (`:452-470`) is purely value-based —
+    `fstate < 0.9 * previous_fstate`. It has no time term, so a gap of any
+    length is invisible to it.
+  - A compile window containing only `unknown` is skipped wholesale
+    (`:582-583`), leaving no row rather than a zero.
+  - First-ever setup is equally safe: with no prior statistics the zero
+    point is set from the first *valid float* (`:734-739`), which is still
+    the first real value.
+- The same code path shows that a `total_increasing` value moving
+  *backwards* by more than 10% **does** start a new cycle (`:740-757`) —
+  the phantom-spike mechanism. Nothing in this decision can cause that, but
+  the energy-tracker lost-update recorded in the backlog can; that item is a
+  real hazard rather than a theoretical one.
+- Restart traffic is unchanged in volume: this decision moves 22 of the 31
+  requests off the blocking path, it does not remove any.

--- a/docs/decisions/021-deferred-startup-fetch.md
+++ b/docs/decisions/021-deferred-startup-fetch.md
@@ -53,13 +53,18 @@ move is a robustness downgrade in its own right — see Decision.
 
 **The first energy and telemetry fetch runs in a background task**
 (`MELCloudHomeCoordinator._run_startup_fetch`), created with
-`hass.async_create_background_task`. `async_setup` no longer awaits it.
+`ConfigEntry.async_create_background_task` — the same call the WebSocket
+listener already uses. `async_setup` no longer awaits it.
 
-`hass.async_create_task` is deliberately *not* used:
-`async_block_till_done()` awaits `hass._tasks` and reaches
-`hass._background_tasks` only with `wait_background_tasks=True`
-(`core.py:962-977`), so a tracked task would still block HA bootstrap and
-every test that blocks till done.
+`async_create_task` is deliberately *not* used: `async_block_till_done()`
+awaits only the foreground task set, reaching background tasks solely with
+`wait_background_tasks=True`, so a tracked task would still block HA
+bootstrap and every test that blocks till done.
+
+Entry-scoped rather than `hass`-scoped so the task is tied to the entry
+lifecycle: if setup raises after the task is created, HA never calls
+`async_shutdown` for a failed entry, and a `hass`-scoped task would go on
+fetching with nothing left to cancel it.
 
 **The periodic 30/60-minute timer registrations stay eager in
 `async_setup`.** `_update_single_energy_tracker` (`coordinator.py:282`) is a
@@ -68,12 +73,13 @@ fetch, so registering the timers up front means a cancelled or failed
 startup fetch still recovers at the next tick. Moving registration into the
 background task would trade that self-healing away.
 
-**The task is cancelled and awaited in `async_shutdown`**, before
-`client.close()`. Awaiting matters: HA's own background-task cleanup runs in
-`_async_process_on_unload`, which fires *after* `async_unload_entry` has
-already called `async_shutdown` and closed the client
-(`config_entries.py:1002-1004, 1185`). Cancelling without awaiting would let
-an in-flight request have its session closed underneath it.
+**The task is also cancelled and awaited explicitly in `async_shutdown`**,
+before `client.close()`. HA's own entry-scoped cleanup is not enough on its
+own: it runs in `_async_process_on_unload`, which fires *after*
+`async_unload_entry` has already called `async_shutdown` and closed the
+client, so an in-flight request would have its session closed underneath it.
+Cancelling here, and awaiting rather than only cancelling, lets it unwind
+first.
 
 `/context` is unaffected and stays synchronous in
 `async_config_entry_first_refresh` — core climate and power-state entities
@@ -89,26 +95,16 @@ need it to exist at all.
   that a missing reading reads `unknown`, not `unavailable`; this only
   changes when that already-correct state is observable.
 - **A transient `unknown` does not corrupt long-term statistics.** Verified
-  against HA's statistics compiler:
-  - `unknown` never becomes a sample — `_entity_history_to_float_and_state`
-    (`components/sensor/recorder.py:218-233`) parses with `float()` inside
-    `try/except (ValueError, TypeError)`, so the state is dropped before
-    reaching any reset logic.
-  - The comparison baseline survives the restart in the database, not in
-    memory: `new_state = old_state = last_stat.get("state")` (`:692-698`),
-    read via `get_latest_short_term_statistics_with_session` (`:591`).
-  - `reset_detected` (`:452-470`) is purely value-based —
-    `fstate < 0.9 * previous_fstate`. It has no time term, so a gap of any
-    length is invisible to it.
-  - A compile window containing only `unknown` is skipped wholesale
-    (`:582-583`), leaving no row rather than a zero.
-  - First-ever setup is equally safe: with no prior statistics the zero
-    point is set from the first *valid float* (`:734-739`), which is still
-    the first real value.
-- The same code path shows that a `total_increasing` value moving
-  *backwards* by more than 10% **does** start a new cycle (`:740-757`) —
-  the phantom-spike mechanism. Nothing in this decision can cause that, but
-  the energy-tracker lost-update recorded in the backlog can; that item is a
-  real hazard rather than a theoretical one.
+  against HA's statistics compiler (`components/sensor/recorder.py`):
+  `unknown` never becomes a sample, because
+  `_entity_history_to_float_and_state` parses with `float()` inside
+  `try/except` and drops the state before any reset logic sees it; and
+  `reset_detected` is purely value-based (`fstate < 0.9 * previous_fstate`)
+  with no time term, so a gap of any length is invisible to it. The
+  comparison baseline is read from the database rather than memory, so it
+  survives the restart, and a compile window containing only `unknown` is
+  skipped rather than written as a zero. A reset is therefore triggered only
+  by a value moving *backwards* — which nothing here can cause, though the
+  energy-tracker lost-update in the backlog can.
 - Restart traffic is unchanged in volume: this decision moves 22 of the 31
   requests off the blocking path, it does not remove any.

--- a/docs/decisions/021-deferred-startup-fetch.md
+++ b/docs/decisions/021-deferred-startup-fetch.md
@@ -90,6 +90,13 @@ client, so an in-flight request would have its session closed underneath it.
 Cancelling here, and awaiting rather than only cancelling, lets it unwind
 first.
 
+Note this path runs on entry **unload or reload only** — HA does not unload
+config entries when it shuts down, so `async_shutdown` is not involved in a
+restart. Nothing leaks on shutdown regardless: HA's `async_stop` cancels
+entry background tasks directly. The distinction matters when testing —
+restarting the container exercises the setup path, not this one; reloading
+the config entry is what exercises this one.
+
 `/context` is unaffected and stays synchronous in
 `async_config_entry_first_refresh` — core climate and power-state entities
 need it to exist at all.

--- a/docs/decisions/021-deferred-startup-fetch.md
+++ b/docs/decisions/021-deferred-startup-fetch.md
@@ -11,14 +11,13 @@ sequential HTTP requests before any entity existed — 1× `/context`, 6×
 `trendsummary`, 2× `comfort-graph`, 10× telemetry-energy, 12×
 telemetry-actual, on a 6 ATA + 2 ATW fixture. It scales linearly with device
 count, and `RequestPacer` enforces a 0.5s minimum gap between requests
-(`api/pacing.py:11`), so the wall-clock floor is structural rather than mock
-latency — roughly 66 seconds in that trace.
+(`DEFAULT_MIN_REQUEST_INTERVAL`), so the wall-clock floor is structural
+rather than mock latency — roughly 66 seconds in that trace.
 
 None of it was optional, because `async_setup_entry` awaited
-`coordinator.async_config_entry_first_refresh()` (`__init__.py:294`) and
-`coordinator.async_setup()` (`:306`) in full before
-`async_forward_entry_setups` (`:352`). No entity of any kind existed until
-all 31 requests had completed.
+`coordinator.async_config_entry_first_refresh()` and
+`coordinator.async_setup()` in full before `async_forward_entry_setups`.
+No entity of any kind existed until all 31 requests had completed.
 
 ### The rejected alternative: jitter for fleet desynchronization
 
@@ -67,11 +66,21 @@ lifecycle: if setup raises after the task is created, HA never calls
 fetching with nothing left to cancel it.
 
 **The periodic 30/60-minute timer registrations stay eager in
-`async_setup`.** `_update_single_energy_tracker` (`coordinator.py:282`) is a
-complete independent fetch-and-apply with no dependency on the initial
-fetch, so registering the timers up front means a cancelled or failed
-startup fetch still recovers at the next tick. Moving registration into the
-background task would trade that self-healing away.
+`async_setup`.** `_update_single_energy_tracker` is a complete independent
+fetch-and-apply with no dependency on the initial fetch, so registering the
+timers up front means a cancelled or failed startup fetch still recovers at
+the next tick. Moving registration into the background task would trade that
+self-healing away.
+
+A consequence of registering first: the timers are now live *before* the
+deferred fetch starts, so a pathologically slow startup fetch (30+ minutes)
+could overlap a periodic tick and invoke the same tracker twice
+concurrently. Benign — each unit's cumulative-total and hour-values
+mutations happen in one synchronous burst with no `await` between read and
+write, so a concurrent call re-reads whatever the first already wrote. That
+is the same idempotency that already makes normal re-polling safe. Noted
+because the previous ordering made the overlap impossible, so it is a new
+property rather than an inherited one.
 
 **The task is also cancelled and awaited explicitly in `async_shutdown`**,
 before `client.close()`. HA's own entry-scoped cleanup is not enough on its

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -95,7 +95,7 @@ Energy consumption sensors are compatible with Home Assistant's Energy Dashboard
 1. Go to **Settings** → **Dashboards** → **Energy**
 2. Add your devices under "Individual devices"
 3. Select the energy sensor for each unit
-4. Energy data accumulates over time and persists across restarts
+4. Energy data accumulates over time and persists across restarts (see [Setup Lifecycle](architecture.md#setup-lifecycle-fresh-install-vs-restart) for how a fresh install differs — the first poll seeds a baseline rather than counting as consumption)
 
 **Outdoor Temperature Sensor (ATA):**
 

--- a/tests/integration/test_coordinator_startup_deferral.py
+++ b/tests/integration/test_coordinator_startup_deferral.py
@@ -1,12 +1,6 @@
-"""Tests for the deferred startup fetch of energy/telemetry data.
+"""Tests for the deferred startup fetch of energy/telemetry data (ADR-021).
 
-The first energy/telemetry fetch after a restart is ~22 sequential paced
-requests (ADR-021). It runs in a background task so entity creation isn't
-blocked on it. These tests pin that behaviour by making the fetch hang
-forever: entities must still appear, and unloading must still be clean.
-
-Follows HA best practices: observable behaviour through hass.states only,
-never coordinator internals. Reference: docs/testing-best-practices.md
+Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
@@ -18,9 +12,6 @@ from homeassistant.core import HomeAssistant
 
 from .conftest import create_mock_ata_energy_context, setup_ata_integration_custom
 
-# Entity ID convention (docs/entities.md): short_id = first 4 + last 4 chars
-# of the unit UUID with hyphens removed. TEST_ATA_UNIT_ID dehyphenates to
-# "a1b2c3d456789abcdef0123456789abc" -> "a1b2_9abc".
 CLIMATE_ENTITY_ID = "climate.melcloudhome_a1b2_9abc_climate"
 ROOM_TEMP_ENTITY_ID = "sensor.melcloudhome_a1b2_9abc_room_temperature"
 
@@ -31,16 +22,14 @@ async def test_entities_created_while_energy_fetch_is_still_running(
 ) -> None:
     """Entity creation must not wait on the energy fetch.
 
-    The fetch blocks on an Event that is never set. If setup were still
-    awaiting it, this test would hang rather than fail - which is the
-    point: a fetch that completes instantly is indistinguishable from one
-    that never blocked, so only a hanging fetch proves the deferral.
+    The fetch never returns. If setup were still awaiting it, this test
+    would hang rather than fail - which is the point: a fetch that
+    completes instantly is indistinguishable from one that never blocked.
     """
-    blocked = asyncio.Event()
 
     def configure_client(mock_client: AsyncMock) -> None:
         async def hang(*_args, **_kwargs):
-            await blocked.wait()
+            await asyncio.Event().wait()
 
         mock_client.get_energy_data = AsyncMock(side_effect=hang)
 
@@ -56,28 +45,21 @@ async def test_entities_created_while_energy_fetch_is_still_running(
     assert hass.states.get(ROOM_TEMP_ENTITY_ID) is not None
 
     # Unload with the fetch still in flight: must not raise or hang, and
-    # must not leave the client closed underneath an in-flight request.
+    # must not close the client underneath an in-flight request.
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio
 async def test_energy_fetch_still_runs_after_setup(hass: HomeAssistant) -> None:
-    """Deferring the fetch must not skip it - the requests still happen."""
-    called = asyncio.Event()
+    """Deferring the fetch must not skip it.
 
-    def configure_client(mock_client: AsyncMock) -> None:
-        async def record(*_args, **_kwargs):
-            called.set()
-            return {}
-
-        mock_client.get_energy_data = AsyncMock(side_effect=record)
-
-    await setup_ata_integration_custom(
-        hass,
-        create_mock_ata_energy_context(),
-        configure_client=configure_client,
+    Without this, dropping the background task entirely still passes the
+    test above.
+    """
+    _, mock_client = await setup_ata_integration_custom(
+        hass, create_mock_ata_energy_context()
     )
     await hass.async_block_till_done()
 
-    assert called.is_set(), "energy fetch was deferred but never ran"
+    assert mock_client.get_energy_data.called, "energy fetch deferred but never ran"

--- a/tests/integration/test_coordinator_startup_deferral.py
+++ b/tests/integration/test_coordinator_startup_deferral.py
@@ -1,0 +1,83 @@
+"""Tests for the deferred startup fetch of energy/telemetry data.
+
+The first energy/telemetry fetch after a restart is ~22 sequential paced
+requests (ADR-021). It runs in a background task so entity creation isn't
+blocked on it. These tests pin that behaviour by making the fetch hang
+forever: entities must still appear, and unloading must still be clean.
+
+Follows HA best practices: observable behaviour through hass.states only,
+never coordinator internals. Reference: docs/testing-best-practices.md
+Run with: make test-integration
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from .conftest import create_mock_ata_energy_context, setup_ata_integration_custom
+
+# Entity ID convention (docs/entities.md): short_id = first 4 + last 4 chars
+# of the unit UUID with hyphens removed. TEST_ATA_UNIT_ID dehyphenates to
+# "a1b2c3d456789abcdef0123456789abc" -> "a1b2_9abc".
+CLIMATE_ENTITY_ID = "climate.melcloudhome_a1b2_9abc_climate"
+ROOM_TEMP_ENTITY_ID = "sensor.melcloudhome_a1b2_9abc_room_temperature"
+
+
+@pytest.mark.asyncio
+async def test_entities_created_while_energy_fetch_is_still_running(
+    hass: HomeAssistant,
+) -> None:
+    """Entity creation must not wait on the energy fetch.
+
+    The fetch blocks on an Event that is never set. If setup were still
+    awaiting it, this test would hang rather than fail - which is the
+    point: a fetch that completes instantly is indistinguishable from one
+    that never blocked, so only a hanging fetch proves the deferral.
+    """
+    blocked = asyncio.Event()
+
+    def configure_client(mock_client: AsyncMock) -> None:
+        async def hang(*_args, **_kwargs):
+            await blocked.wait()
+
+        mock_client.get_energy_data = AsyncMock(side_effect=hang)
+
+    entry, _ = await setup_ata_integration_custom(
+        hass,
+        create_mock_ata_energy_context(),
+        configure_client=configure_client,
+    )
+
+    assert hass.states.get(CLIMATE_ENTITY_ID) is not None, (
+        "core climate entity must exist without waiting for the energy fetch"
+    )
+    assert hass.states.get(ROOM_TEMP_ENTITY_ID) is not None
+
+    # Unload with the fetch still in flight: must not raise or hang, and
+    # must not leave the client closed underneath an in-flight request.
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.asyncio
+async def test_energy_fetch_still_runs_after_setup(hass: HomeAssistant) -> None:
+    """Deferring the fetch must not skip it - the requests still happen."""
+    called = asyncio.Event()
+
+    def configure_client(mock_client: AsyncMock) -> None:
+        async def record(*_args, **_kwargs):
+            called.set()
+            return {}
+
+        mock_client.get_energy_data = AsyncMock(side_effect=record)
+
+    await setup_ata_integration_custom(
+        hass,
+        create_mock_ata_energy_context(),
+        configure_client=configure_client,
+    )
+    await hass.async_block_till_done()
+
+    assert called.is_set(), "energy fetch was deferred but never ran"


### PR DESCRIPTION
## Summary

`async_setup_entry` awaited the first energy and telemetry fetch before forwarding platform setup, so no entity existed until that finished. The fetch is one request per ATA unit and two per ATW unit for energy, plus six per ATW unit for telemetry, all held to a 0.5s minimum gap by `RequestPacer`. That is 22 requests on the 8-device install measured here, and it grows with device count.

Setup blocked for roughly 54 seconds on that install. It now returns without waiting for the fetch, which runs in a background task instead.

## Changes

- `MELCloudHomeCoordinator._run_startup_fetch` does the first ATA/ATW energy and telemetry fetch in an entry-scoped background task.
- The periodic 30/60-minute timer registrations stay in `async_setup`, so polling still recovers at the next tick if the startup fetch fails or is cancelled.
- `async_shutdown` cancels the task, awaits it before `client.close()`, and logs that it did.
- ADR-021 covers the decision, the jitter alternative that was rejected, and why a brief `unknown` cannot corrupt long-term statistics.
- `docs/architecture.md` gains a Setup Lifecycle section. A restart now briefly shows `unknown` on those sensors; a fresh install shows entities sooner than before.

## Why entry-scoped

`async_create_task` would keep blocking HA bootstrap, since `async_block_till_done` waits on foreground tasks. `hass.async_create_background_task` fixes that but leaves the task unowned: if setup raises after it starts, nothing cancels it. `ConfigEntry.async_create_background_task` is cancelled by HA on unload and on failed setup.

The explicit cancel-and-await in `async_shutdown` is still needed, because HA's own cleanup runs after `async_unload_entry` has closed the client. ADR-021 has the detail.

## Test plan

- [x] Full integration suite green, with two new tests. The first hangs the energy fetch on an `Event` that never resolves, so entities must appear and the entry must unload anyway. Deleting the background-task creation fails the second test and leaves the first passing.
- [x] Devserver: entities created while the fetch was still running, and the request count is unchanged, so nothing was dropped rather than moved.
- [x] Devserver: reloaded the config entry mid-fetch with a telemetry request confirmed in flight. Clean cancellation, no session-closed warning and no unretrieved task exception. A container restart does not reach this path, since HA unloads entries only on unload or reload.
- [x] Prod: setup returned immediately instead of blocking for roughly 54 seconds, and energy totals kept accumulating across the restart.
- [x] Prod, soaked overnight: the energy timer held its 30-minute cadence, no tasks leaked, and no cumulative total moved backwards.
