### PR TITLE
fix(atw): read zone 2 presence from capabilities, not the HasZone2 setting

### DIFF
--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -154,9 +154,6 @@ class AirToWaterUnit:
     set_temperature_zone1: float | None  # Target room temperature (10-30°C)
     room_temperature_zone1: float | None  # Current room temperature
 
-    # Zone 2 (usually not present)
-    has_zone2: bool
-
     # DHW (Domestic Hot Water)
     set_tank_water_temperature: float | None  # Target DHW temp (40-60°C)
     tank_water_temperature: float | None  # Current DHW temp
@@ -224,12 +221,9 @@ class AirToWaterUnit:
         # Parse settings array into dict for easy access
         settings = {item["name"]: item["value"] for item in settings_list}
 
-        # Extract Zone 2 flag (can be string "0"/"1" or int)
-        has_zone2_value = settings.get("HasZone2", "0")
-        if isinstance(has_zone2_value, str):
-            has_zone2 = has_zone2_value != "0" and has_zone2_value.lower() != "false"
-        else:
-            has_zone2 = bool(has_zone2_value)
+        # `HasZone2` in settings is free text ("None" on single-zone devices), so
+        # zone-2 presence comes from capabilities, which is a real bool.
+        has_zone2 = capabilities.has_zone2
 
         # Extract cooling mode flag from settings (some devices report it here)
         # Check settings first, then fall back to capabilities
@@ -273,7 +267,6 @@ class AirToWaterUnit:
             set_temperature_zone1=_parse_float(settings.get("SetTemperatureZone1")),
             room_temperature_zone1=_parse_float(settings.get("RoomTemperatureZone1")),
             # Zone 2 (if present)
-            has_zone2=has_zone2,
             operation_mode_zone2=operation_mode_zone2,
             set_temperature_zone2=_parse_float(settings.get("SetTemperatureZone2"))
             if has_zone2

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -201,7 +201,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                     atw_unit.set_temperature_zone1,
                 ]
 
-                if atw_unit.has_zone2:
+                if atw_unit.capabilities.has_zone2:
                     base_msg += " | Z2: %s°C→%s°C"
                     base_args.extend(
                         [

--- a/custom_components/melcloudhome/diagnostics_atw.py
+++ b/custom_components/melcloudhome/diagnostics_atw.py
@@ -26,15 +26,19 @@ def serialize_atw_unit(unit: AirToWaterUnit) -> dict[str, Any]:
         "operation_mode_zone1": unit.operation_mode_zone1,
         "set_temperature_zone1": unit.set_temperature_zone1,
         "room_temperature_zone1": unit.room_temperature_zone1,
-        "operation_mode_zone2": unit.operation_mode_zone2 if unit.has_zone2 else None,
-        "set_temperature_zone2": unit.set_temperature_zone2 if unit.has_zone2 else None,
+        "operation_mode_zone2": unit.operation_mode_zone2
+        if unit.capabilities.has_zone2
+        else None,
+        "set_temperature_zone2": unit.set_temperature_zone2
+        if unit.capabilities.has_zone2
+        else None,
         "room_temperature_zone2": (
-            unit.room_temperature_zone2 if unit.has_zone2 else None
+            unit.room_temperature_zone2 if unit.capabilities.has_zone2 else None
         ),
         "tank_water_temperature": unit.tank_water_temperature,
         "set_tank_water_temperature": unit.set_tank_water_temperature,
         "forced_hot_water_mode": unit.forced_hot_water_mode,
-        "has_zone2": unit.has_zone2,
+        "has_zone2": unit.capabilities.has_zone2,
         "outdoor_temperature": unit.outdoor_temperature,
         **serialize_outdoor_temp_fields(unit),
     }

--- a/custom_components/melcloudhome/sensor_atw.py
+++ b/custom_components/melcloudhome/sensor_atw.py
@@ -88,7 +88,7 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.room_temperature_zone2,
-        should_create_fn=lambda unit: unit.has_zone2,
+        should_create_fn=lambda unit: unit.capabilities.has_zone2,
     ),
     # Tank water temperature
     ATWSensorEntityDescription(
@@ -167,7 +167,7 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("flow_temperature_zone2"),
-        should_create_fn=lambda unit: unit.has_zone2,
+        should_create_fn=lambda unit: unit.capabilities.has_zone2,
     ),
     ATWSensorEntityDescription(
         key="return_temperature_zone2",
@@ -176,7 +176,7 @@ ATW_SENSOR_TYPES: tuple[ATWSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.telemetry.get("return_temperature_zone2"),
-        should_create_fn=lambda unit: unit.has_zone2,
+        should_create_fn=lambda unit: unit.capabilities.has_zone2,
     ),
     ATWSensorEntityDescription(
         key="flow_temperature_boiler",

--- a/docs/api/atw-api-reference.md
+++ b/docs/api/atw-api-reference.md
@@ -81,7 +81,7 @@ Air-to-Water heat pumps are **ONE physical device** with **TWO functional capabi
 | `TankWaterTemperature` | number | Current DHW temp |
 | `SetTankWaterTemperature` | number | DHW target |
 | `ForcedHotWaterMode` | boolean | DHW priority enabled |
-| `HasZone2` | number | Zone 2 support (0=no, 2=yes) |
+| `HasZone2` | string | **Ignored** - free-text (`"None"` or `"0"` on every captured device). Use `capabilities.hasZone2`. |
 | `HasCoolingMode` | boolean | Cooling available (usually false) |
 | `IsInError` | boolean | Error state |
 | `ErrorCode` | string | Error code if any |
@@ -278,7 +278,7 @@ Settings are returned as name-value pairs:
   {"name": "TankWaterTemperature", "value": "45"},
   {"name": "SetTankWaterTemperature", "value": "50"},
   {"name": "ForcedHotWaterMode", "value": "False"},
-  {"name": "HasZone2", "value": "0"},  // "0" = no Zone 2, "2" = has Zone 2
+  {"name": "HasZone2", "value": "0"},  // ignored; newer captures send "None" here
   {"name": "HasCoolingMode", "value": "False"},
   {"name": "IsInError", "value": "False"},
   {"name": "ErrorCode", "value": ""},

--- a/tests/api/test_atw_models.py
+++ b/tests/api/test_atw_models.py
@@ -5,6 +5,7 @@ These tests validate that models correctly parse real API responses.
 """
 
 import logging
+from copy import deepcopy
 from typing import Any, cast
 
 import pytest
@@ -200,19 +201,19 @@ class TestAirToWaterUnit:
         assert unit.set_temperature_zone1 is None
 
     def test_unit_from_dict_parses_zone2_when_present(self):
-        """Test that Zone 2 fields are parsed when HasZone2=1."""
+        """Test that Zone 2 fields are parsed when capabilities report zone 2."""
         unit = AirToWaterUnit.from_dict(ATW_UNIT_WITH_ZONE2)
 
-        assert unit.has_zone2 is True
+        assert unit.capabilities.has_zone2 is True
         assert unit.operation_mode_zone2 == "HeatRoomTemperature"
         assert unit.room_temperature_zone2 == 19.0
         assert unit.set_temperature_zone2 == 20.0
 
     def test_unit_from_dict_parses_zone2_when_absent(self):
-        """Test that Zone 2 fields are None when HasZone2=0."""
+        """Test that Zone 2 fields are None when capabilities report no zone 2."""
         unit = AirToWaterUnit.from_dict(ATW_UNIT_HEATING_DHW)
 
-        assert unit.has_zone2 is False
+        assert unit.capabilities.has_zone2 is False
         assert unit.operation_mode_zone2 is None
         assert unit.room_temperature_zone2 is None
         assert unit.set_temperature_zone2 is None
@@ -466,19 +467,26 @@ class TestEdgeCases:
         unit_idle = AirToWaterUnit.from_dict(ATW_UNIT_IDLE)
         assert unit_idle.error_code is None
 
-    def test_string_zero_converts_to_false_for_haszone2(self):
-        """Test that string "0" for HasZone2 converts to False."""
-        unit = AirToWaterUnit.from_dict(ATW_UNIT_HEATING_DHW)
+    @pytest.mark.parametrize("settings_value", ["None", "1"])
+    def test_zone2_settings_string_cannot_conjure_zone2(
+        self, settings_value: str
+    ) -> None:
+        """A single-zone device's `HasZone2` string is ignored, whatever it says.
 
-        # HasZone2 is "0" (string)
-        assert unit.has_zone2 is False
+        Real single-zone devices report "None"; parsing that as truthy gave them
+        zone-2 data and entities that could never hold a value.
+        """
+        data = deepcopy(ATW_UNIT_HEATING_DHW)  # capabilities.hasZone2 is False
+        settings = cast(list[dict[str, Any]], data["settings"])
+        for setting in settings:
+            if setting["name"] == "HasZone2":
+                setting["value"] = settings_value
+        settings.append({"name": "RoomTemperatureZone2", "value": "19"})
 
-    def test_string_one_converts_to_true_for_haszone2(self):
-        """Test that string "1" for HasZone2 converts to True."""
-        unit = AirToWaterUnit.from_dict(ATW_UNIT_WITH_ZONE2)
+        unit = AirToWaterUnit.from_dict(data)
 
-        # HasZone2 is "1" (string)
-        assert unit.has_zone2 is True
+        assert unit.capabilities.has_zone2 is False
+        assert unit.room_temperature_zone2 is None
 
     def test_half_degree_temperatures(self) -> None:
         """Test that half-degree temperatures are parsed correctly."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -161,7 +161,6 @@ def create_mock_atw_unit(
         set_temperature_zone2=set_temperature_zone2,
         room_temperature_zone2=room_temperature_zone2,
         operation_status=operation_status,
-        has_zone2=has_zone2,
         is_in_error=is_in_error,
         error_code=error_code,
         rssi=rssi,

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -258,7 +258,7 @@ def _create_mock_atw_unit(unit_id: str, name: str) -> MagicMock:
     unit.operation_mode_zone1 = "HeatThermostat"
     unit.set_temperature_zone1 = 22.0
     unit.room_temperature_zone1 = 21.0
-    unit.has_zone2 = False
+    unit.capabilities.has_zone2 = False
     unit.operation_mode_zone2 = None
     unit.set_temperature_zone2 = None
     unit.room_temperature_zone2 = None

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -1488,7 +1488,8 @@ class MockMELCloudServer:
                 "name": "ForcedHotWaterMode",
                 "value": str(state["forced_hot_water_mode"]),
             },
-            {"name": "HasZone2", "value": str(int(state["has_zone2"]))},
+            # Real single-zone devices report "None" here, not "0"
+            {"name": "HasZone2", "value": "1" if state["has_zone2"] else "None"},
             {"name": "InStandbyMode", "value": str(state["in_standby_mode"])},
             {"name": "IsInError", "value": str(state["is_in_error"])},
             {"name": "ErrorCode", "value": state.get("error_code", "")},

--- a/tools/test_atw_mock_server.py
+++ b/tools/test_atw_mock_server.py
@@ -174,8 +174,8 @@ async def test_mock_server(port: int = 8888) -> bool:
 
             # Test 12: Zone 2 handling
             print("\n✅ Test 12: Zone 2 Handling")
-            print(f"   has_zone2: {unit.has_zone2}")
-            if unit.has_zone2:
+            print(f"   has_zone2: {unit.capabilities.has_zone2}")
+            if unit.capabilities.has_zone2:
                 print("   Zone 2 fields present (multi-zone device)")
             else:
                 print("   No Zone 2 (single-zone device)")


### PR DESCRIPTION
Real ATW devices report `{"name":"HasZone2","value":"None"}` when they have no second zone. The settings parser treated only `"0"` and `"false"` as falsy, so `"None"` read as true. Every single-zone heat pump got three zone-2 sensors that can never hold a value, plus a diagnostics dump claiming `has_zone2: true`.

`capabilities.hasZone2` is a real boolean, and it is already what climate, the control guards and telemetry gate on. Only the sensors, the coordinator log and diagnostics used the settings string, so nothing was controllable and no API traffic was wasted.

## Changes

- `has_zone2` now comes from `capabilities.hasZone2`. The `HasZone2` settings parse is gone.
- Deleted the mirrored `AirToWaterUnit.has_zone2` field, so all 7 consumers read `capabilities.has_zone2` and there is one source for the fact.
- Regression test asserts the settings string cannot conjure zone-2 data. It fails against the old parser.
- Mock server now emits `"None"` for single-zone devices instead of `"0"`. That mismatch is why dev never reproduced this.
- `docs/api/atw-api-reference.md` claimed `"2" = has Zone 2`. No capture supports it: the claim came from #58, whose own mock emits `"1"`. Now documented as ignored free text.

## Evidence

The bad parse dates from #32 (2026-01-10), but it was harmless until v2.3.0. One ATW unit appears in diagnostics from three versions: `has_zone2: false` on v2.0.0-beta.5 and v2.1.0, then `has_zone2: true` on v2.3.0, with no zone-2 data and no zone-2 climate entity in any of them. v2.3.0 is the mobile API migration (#94), and the two APIs encode the falsy value differently: `"0"` on the old one, `"None"` on the new. So the phantom sensors date from v2.3.0 (2026-04-16), not from January.

No capture, cassette or diagnostics dump contains an ATW device with zone 2 — the three `/context` JSONs from #32, all 38 cassettes and `tested-hardware.md` are single-zone, and `ATW_UNIT_WITH_ZONE2` is synthetic. The cassette evidence is two devices re-recorded across those 38 files, not 38 independent samples. So both sources are untested on the truthy side, and capabilities wins on the argument from types: a typed boolean has exactly one possible truthy value, while the free-text string has two competing guesses (`"1"` and `"2"`) and none confirmed. That is why the string is left unparsed rather than guessed at.

Three ATW devices show the phantom pattern: zone-2 sensors, no zone-2 climate, no zone-2 values.

## User impact

Every single-zone ATW device on v2.3.0 or later has three zone-2 sensors that have always been blank. They stop being created, so they go `unavailable` and can be deleted by hand. Orphaned registry entries are left alone, as HA does elsewhere.

## Test plan

- [x] `make test-api` (379 passed)
- [x] `make test-integration` (212 passed)
- [x] `make test-e2e` (14 passed)
- [x] `make pre-commit`
- [x] Devserver against the real API: both single-zone ATW devices log without the `Z2:` suffix, and their 6 zone-2 sensors read `unavailable` / `restored: True`
- [x] Devserver against the mock, fresh entry with no registry history: the single-zone device (`HasZone2: "None"`) gets **no** zone-2 entities created, and the dual-zone device gets all four live - `climate…zone_2` in state `heat`, zone-2 room 21.0, flow 37.8, return 35.2
