### PR TITLE
docs(atw): document the internaltemperatures report endpoint

### DIFF
--- a/docs/api/atw-api-reference.md
+++ b/docs/api/atw-api-reference.md
@@ -569,6 +569,83 @@ GET /telemetry/telemetry/actual/{unitId}?from=2026-01-18T16:00&to=2026-01-18T20:
 - **RSSI:** Don't poll this endpoint for RSSI — use the `rssi` field on `/context` instead (Section 2), which refreshes every ~60s instead of hourly
 - Use 4-hour lookback window for recent data
 
+### Batched Alternative: Internal Temperatures Report
+
+Returns **every water temperature in one request**, instead of one request per measure. This
+is what the MELCloud Home web app's water-temperatures chart uses. **Not currently used by
+this integration** (see below for why it isn't a drop-in swap).
+
+```
+GET /report/v1/internaltemperatures?unitId={unitId}&period=Hourly&from=2026-08-21T00:00:00.0000000&to=2026-08-21T08:00:00.0000000
+```
+
+Same parameter shape as `report/v1/trendsummary` and `report/v1/comfort-graph` (Section 9),
+including the 7-decimal timestamp format.
+
+**Datasets returned** (8 for a single-zone unit):
+
+- `set_tank_water_temperature`, `tank_water_temperature`
+- `flow_temperature`, `return_temperature`
+- `flow_temperature_zone1`, `return_temperature_zone1`
+- `flow_temperature_boiler`, `return_temperature_boiler`
+
+**Response Format:**
+```json
+[
+  {
+    "reportPeriod": 1,
+    "timeUnit": "hour",
+    "stepSize": 1,
+    "from": "2026-08-21T00:00:00",
+    "to": "2026-08-21T08:00:00",
+    "datasets": [
+      {
+        "id": "flow_temperature",
+        "label": "REPORT.INTEMP_REPORT.DATASET.LABELS.FLOW_TEMPERATURE",
+        "data": [{ "x": "2026-08-21T06:00:16", "y": 55.5 }],
+        "borderColor": "#D32A2A",
+        "hidden": false
+      }
+    ],
+    "annotations": [],
+    "previousTriggers": []
+  }
+]
+```
+
+`label` is a localisation key, not display text — the vendor's client resolves it client-side.
+
+**Data Characteristics:**
+
+- **Use `period=Hourly`.** It yields genuine per-reading timestamps (irregular seconds, e.g.
+  `06:00:16`). `period=Daily` returns 30-minute bucket labels that are not reading times —
+  the same data-quality problem documented for `trendsummary` in issue #152.
+- **Window limit: 8 hours.** 4h, 6h and 8h succeed; 12h and 16h return HTTP 500. Comparable
+  to `comfort-graph`'s own window ceiling, different magnitude.
+- **The final datapoint is synthetic.** Every dataset ends with a point stamped with the query
+  `to` and the previous value repeated (the "to-echo" artifact, issue #224). Strip it before
+  reading a latest value or freshness is reported as zero.
+- `hidden` is a **presentation** default, not a capability signal. It is a hardcoded constant
+  keyed on dataset id — identical for every device, with no per-unit input — and it is `true`
+  for all four zone/boiler-suffixed series. It means "off by default in the vendor's chart",
+  **not** "this hardware is absent"; in `comfort-graph` it is also `true` for
+  `room_temperature_zone1`, which is certainly real on a single-zone unit. Do not gate on it.
+- **Absent hardware returns a constant `25`, not an empty series or an error.** On two
+  single-zone units (both `hasBoiler: false`) the four zone1/boiler series were flat at 25 for
+  a full day while `flow_temperature` and `return_temperature` varied normally. The vendor's
+  own client charts that flat line when the series is enabled, so this is server-side
+  behaviour rather than a client convention.
+- **Unverified:** whether zone-2 datasets appear for a unit that has zone 2. Both units
+  observed were single-zone and neither response contained zone-2 series, so it is unknown
+  whether the server selects datasets per device or the report is always these 8.
+
+**Trade-off versus per-measure telemetry:** one request replaces six, but a single failure then
+costs all measures for that cycle rather than one. With equal failure rates the expected data
+loss is unchanged, so the swap is a reliability win only if this endpoint proves more reliable
+than `/telemetry/telemetry/actual`.
+
+*(Endpoint behaviour above measured 2026-08-21 against two real ATW units.)*
+
 ---
 
 ## 9. Energy Reporting

--- a/docs/api/atw-api-reference.md
+++ b/docs/api/atw-api-reference.md
@@ -524,8 +524,12 @@ POST /api/protection/frost
 ### Real-Time Telemetry (Actual Values)
 
 ```
-GET /telemetry/telemetry/actual/{unitId}?from=2026-01-18T16:00&to=2026-01-18T20:00&measure=flow_temperature
+GET /telemetry/telemetry/actual/{unitId}?from=2026-01-18 16:00&to=2026-01-18 20:00&measure=flow_temperature
 ```
+
+Note the space between date and time, not a `T` — that is what the client sends
+(`client.py`, `get_telemetry_actual`). The report endpoints use
+`YYYY-MM-DDTHH:MM:SS.0000000` instead.
 
 **Supported Measures:**
 - `flow_temperature` - System flow temperature (°C)
@@ -573,7 +577,7 @@ GET /telemetry/telemetry/actual/{unitId}?from=2026-01-18T16:00&to=2026-01-18T20:
 
 Returns **every water temperature in one request**, instead of one request per measure. This
 is what the MELCloud Home web app's water-temperatures chart uses. **Not currently used by
-this integration** (see below for why it isn't a drop-in swap).
+this integration.**
 
 ```
 GET /report/v1/internaltemperatures?unitId={unitId}&period=Hourly&from=2026-08-21T00:00:00.0000000&to=2026-08-21T08:00:00.0000000
@@ -645,16 +649,13 @@ including the 7-decimal timestamp format.
   endpoint**. Both units observed here were single-zone and neither response contained zone-2
   series, so it is unknown whether the server selects datasets per device or the report is
   always these 8. (The two-zone evidence above comes from per-measure telemetry on a device
-  that is no longer reachable, not from this endpoint.)
+  that is no longer reachable, not from this endpoint.) **This would have to be answered before
+  anything relied on this endpoint for zone-2 data**, since zone-2 water temps currently come
+  from per-measure calls and do work for the users who have them.
 
-**Trade-off versus per-measure telemetry:** the saving depends on the device. Since the
-zone1/boiler measures are now gated on capabilities, a single-zone unit without a boiler makes
-only **2** per-measure calls, so this endpoint would replace 2 requests with 1 — not 6 with 1.
-A two-zone unit with a boiler still makes 8. And a single failure here costs every measure for
-that cycle rather than one, so with equal failure rates the expected data loss is unchanged.
-The swap is worth making only if this endpoint proves measurably more reliable than
-`/telemetry/telemetry/actual`, and the gain is smallest on exactly the configuration most
-users have.
+**Relationship to the per-measure endpoint:** this returns the same water temperatures that
+`/telemetry/telemetry/actual` serves one measure at a time (Section 8). Note that a single
+failure here costs every measure for that cycle rather than one.
 
 *(Endpoint behaviour above measured 2026-08-21 against two real ATW units.)*
 

--- a/docs/api/atw-api-reference.md
+++ b/docs/api/atw-api-reference.md
@@ -635,14 +635,26 @@ including the 7-decimal timestamp format.
   a full day while `flow_temperature` and `return_temperature` varied normally. The vendor's
   own client charts that flat line when the series is enabled, so this is server-side
   behaviour rather than a client convention.
-- **Unverified:** whether zone-2 datasets appear for a unit that has zone 2. Both units
-  observed were single-zone and neither response contained zone-2 series, so it is unknown
-  whether the server selects datasets per device or the report is always these 8.
+- **The zone-1 suffix is only populated on multi-zone systems.** A real two-zone device
+  reported 22.5 for `flow_temperature_zone1` / `return_temperature_zone1` while its boiler pair
+  sat at 25.0 — real zone-1 values and a placeholder boiler pair, in the same payload. On a
+  single-zone system the unsuffixed `flow_temperature` / `return_temperature` *are* the zone-1
+  flow and return. The integration gates these measures accordingly (Section 8, and
+  `telemetry_tracker.py`).
+- **Unverified:** whether zone-2 datasets appear for a unit that has zone 2 **on this
+  endpoint**. Both units observed here were single-zone and neither response contained zone-2
+  series, so it is unknown whether the server selects datasets per device or the report is
+  always these 8. (The two-zone evidence above comes from per-measure telemetry on a device
+  that is no longer reachable, not from this endpoint.)
 
-**Trade-off versus per-measure telemetry:** one request replaces six, but a single failure then
-costs all measures for that cycle rather than one. With equal failure rates the expected data
-loss is unchanged, so the swap is a reliability win only if this endpoint proves more reliable
-than `/telemetry/telemetry/actual`.
+**Trade-off versus per-measure telemetry:** the saving depends on the device. Since the
+zone1/boiler measures are now gated on capabilities, a single-zone unit without a boiler makes
+only **2** per-measure calls, so this endpoint would replace 2 requests with 1 — not 6 with 1.
+A two-zone unit with a boiler still makes 8. And a single failure here costs every measure for
+that cycle rather than one, so with equal failure rates the expected data loss is unchanged.
+The swap is worth making only if this endpoint proves measurably more reliable than
+`/telemetry/telemetry/actual`, and the gain is smallest on exactly the configuration most
+users have.
 
 *(Endpoint behaviour above measured 2026-08-21 against two real ATW units.)*
 


### PR DESCRIPTION
Documents `/report/v1/internaltemperatures`, which returns every ATW water temperature in one request. It's what the MELCloud Home web app's water-temperatures chart uses. Docs only, and the endpoint is not currently used by the integration.

Gotchas recorded, all measured against two real ATW units:

- `period=Hourly` gives genuine reading timestamps. `Daily` gives 30-minute bucket labels, the #152 problem.
- Hourly window ceiling is 8h. 12h and 16h return 500.
- The final datapoint is the #224 to-echo artifact.
- `hidden` is a presentation default keyed on dataset id, identical for every device, so it cannot be used as a capability signal.
- Absent hardware returns a constant 25 rather than an empty series.
- The zone-1 suffix is only populated on multi-zone systems. A two-zone device returned 22.5 for the zone-1 pair while its boiler pair read 25.0. This is the rule #266 gates on.

Deliberately no "should we adopt it" analysis. That reasoning moved twice while I was writing this, in opposite directions, and an API reference that carries a design argument goes stale every time the argument does. The endpoint's behaviour is stable; the decision lives in a plan.

Two things flagged in the doc for whoever picks that decision up:

- Whether zone-2 datasets appear for a unit that has zone 2 is unverified on this endpoint. Both units observed were single-zone. Zone-2 water temps currently come from per-measure calls and do work, so this would have to be answered before anything relied on this endpoint for them.
- A single failure here costs every measure for that cycle rather than one.

Also corrects a pre-existing error in the per-measure telemetry example, which used `from=2026-01-18T16:00`. The client sends a space, not a `T`, and copying the documented form returns 500. Found by copying it myself.

- [x] `make pre-commit`
