### PR TITLE
docs(atw): state what the two-zone capture actually shows

### DIFF
--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -61,11 +61,13 @@ ATW_TELEMETRY_MEASURES = [
 ]
 
 # Zone-1-suffixed measures, only requested when the device has a second zone.
-# On a single-zone system the unsuffixed pair above IS the zone 1 flow/return, and
-# these return a constant 25 placeholder instead of a reading. Confirmed by a real
-# two-zone device reporting 22.5 here while its boiler pair sat at 25.0, against two
-# single-zone devices reporting 25.0 for both pairs.
-# See docs/api/atw-api-reference.md.
+# On a single-zone system these return a constant 25 placeholder instead of a
+# reading — measured on two devices over a full day, while the unsuffixed pair
+# varied normally — so the unsuffixed pair appears to BE the zone 1 flow/return
+# there. The positive case is not established: the one two-zone capture was of an
+# idle system, where flow == return proves nothing either way. Gating on has_zone2
+# cannot regress a two-zone device, since it only ever suppresses when zone 2 is
+# absent. See docs/api/atw-api-reference.md.
 ATW_TELEMETRY_MEASURES_ZONE1 = [
     "flow_temperature_zone1",
     "return_temperature_zone1",

--- a/docs/api/atw-api-reference.md
+++ b/docs/api/atw-api-reference.md
@@ -639,12 +639,20 @@ including the 7-decimal timestamp format.
   a full day while `flow_temperature` and `return_temperature` varied normally. The vendor's
   own client charts that flat line when the series is enabled, so this is server-side
   behaviour rather than a client convention.
-- **The zone-1 suffix is only populated on multi-zone systems.** A real two-zone device
-  reported 22.5 for `flow_temperature_zone1` / `return_temperature_zone1` while its boiler pair
-  sat at 25.0 — real zone-1 values and a placeholder boiler pair, in the same payload. On a
-  single-zone system the unsuffixed `flow_temperature` / `return_temperature` *are* the zone-1
-  flow and return. The integration gates these measures accordingly (Section 8, and
-  `telemetry_tracker.py`).
+- **On single-zone devices the zone-1 suffix carries the placeholder, not a reading.** Two
+  single-zone units read a flat 25 on `flow_temperature_zone1` / `return_temperature_zone1`
+  for a full day while the unsuffixed pair varied normally. The working assumption is that
+  the unsuffixed `flow_temperature` / `return_temperature` *are* the zone-1 flow and return on
+  such a system, and the integration gates the suffixed pair on Zone 2 support accordingly
+  (Section 8, and `telemetry_tracker.py`).
+
+  **What the one two-zone capture does and does not show.** The only capture from a real
+  two-zone device (v2.1.0, Feb 2026) has the zone-1 pair at 22.5/22.5 and the boiler pair at
+  25.0/25.0, so the zone-1 pair differs from the boiler placeholder. But that unit's `power`
+  was `false`, and on a non-circulating system flow equalling return exactly is what a real
+  idle loop looks like as much as a placeholder. It is a single snapshot, so it does **not**
+  establish that the zone-1 pair carries real readings when zone 2 is present. Settling that
+  needs a time series from a two-zone system while it is actively heating.
 - **Unverified:** whether zone-2 datasets appear for a unit that has zone 2 **on this
   endpoint**. Both units observed here were single-zone and neither response contained zone-2
   series, so it is unknown whether the server selects datasets per device or the report is

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -174,10 +174,10 @@ capabilities, because MELCloud returns a constant 25 °C for measures the hardwa
 have rather than no data at all — so creating them unconditionally produced sensors that
 looked like readings and never were.
 
-The zone-1 pair is gated on Zone 2 support, which reads oddly but is correct: on a
-single-zone system the *unsuffixed* Flow and Return **are** the zone 1 flow and return, and
-the suffixed pair is only populated when there is more than one zone. The boiler pair is
-gated on the device reporting a boiler.
+The Zone 1 pair requires the device to have a **second** zone. On a single-zone system those
+two measures return the placeholder rather than a reading, and the plain Flow Temperature and
+Return Temperature are the zone 1 flow and return. The boiler pair requires the device to
+report a boiler.
 
 A gated sensor that does exist can still sit at `unknown` when a telemetry fetch returns no
 datapoints for it. That is expected and separate from the gating above.


### PR DESCRIPTION
#266's justification claimed a real two-zone device "reported real zone-1 values" at 22.5 while its boiler pair sat at 25.0. That overstates a single snapshot, and the claim had spread into an API doc, a user-facing doc and a shipped code comment.

That unit's `power` was `false`, and its zone-1 flow and return are identical at 22.5/22.5 while the unsuffixed pair differs by 8° (29.5/21.5). On a non-circulating system flow equalling return exactly is what a real idle loop looks like as much as a placeholder. It also sits at 22.5 rather than 25.0, so either there are several placeholder values or that reading is real-but-idle. One snapshot cannot separate them.

What is established is the single-zone side: two devices, flat 25 for a full day on the suffixed pair while the unsuffixed pair varied, cross-checked against MELCloud's own `report/v1/internaltemperatures`. That is what the gate rests on.

## Changes

- `docs/api/atw-api-reference.md` — drops "the zone-1 suffix is only populated on multi-zone systems". States the measured single-zone fact, labels the inference as a working assumption, and adds what the one two-zone capture does and does not show, plus what would settle it: a time series from a two-zone system while it is actively heating.
- `docs/entities.md` — states the rule and its mechanism instead of editorialising about the rule being surprising.
- `custom_components/melcloudhome/const.py` — the comment said "Confirmed by a real two-zone device". Now says the positive case is not established, and records why that is tolerable: gating on `has_zone2` only ever suppresses when zone 2 is absent, so it cannot regress a two-zone device.

No behaviour change. The gate is unchanged and correct; only the stated reason was too strong.

## Test plan

- [x] `make pre-commit`
- [x] No code paths touched — one comment, two docs
