### PR TITLE
ci: run checks on pull requests targeting any base branch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     - cron: "30 7 * * 1"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   schedule:
     - cron: "0 0 * * 1"  # Weekly on Monday
   workflow_dispatch:


### PR DESCRIPTION
Test, Validate, CodeQL and zizmor were gated on `pull_request: branches: [main]`, so a PR stacked on another branch only ran the secret scan. `main`'s protection requires Lint & Type Check, Run All Tests, Validate and codecov/patch, so those PRs sit at `BLOCKED` and the stack UI flags them "not ready" — currently #255 and #272 in stack #271.

- Drop the base-branch filter from the `pull_request` trigger in `test.yml`, `validate.yml`, `codeql.yml`, `zizmor.yml`
- `push` triggers unchanged (still `main` only)

Test plan:

- [ ] Full check suite runs on this PR
- [ ] `zizmor --persona auditor` clean
- [ ] After merge, `gh stack sync` re-pushes stack #271 and #255/#272 pick up the required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
