### PR TITLE
fix(dev): generate the ATW testing dashboard from the entity registry

### DIFF
--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -164,6 +164,31 @@ This restores the dev environment to a clean snapshot with:
 You'll need to add the integration through the UI (Settings → Devices & Services).
 Much faster than creating the user account from scratch!
 
+### Regenerate the ATW testing dashboard:
+
+```bash
+python3 tools/build_dev_dashboard.py      # every ATW unit in the dev registry
+make dev-restart                          # lovelace configs are read at startup
+```
+
+`make dev-reset` restores `dev-config-template/.storage/`, so only the dashboard
+committed there survives a reset. That committed copy holds the mock server's
+units, and re-running the generator adds back any real units your account can
+reach.
+
+Refreshing the committed copy after changing the dashboard's design:
+
+```bash
+python3 tools/build_dev_dashboard.py --mock-only \
+    --out dev-config-template/.storage/lovelace.melcloudhome_testing
+```
+
+`--mock-only` is what keeps real building and device names out of the repo: entity
+IDs carry the building name as a prefix, and for a real account that is personal
+data. Keep `MOCK_BUILDINGS` in the script matching the mock server's buildings:
+an unrecognised building is treated as real and excluded, so a stale list costs a
+missing view.
+
 ### Save and restore snapshots:
 
 **Save current state:**

--- a/dev-config-template/.storage/lovelace.melcloudhome_testing
+++ b/dev-config-template/.storage/lovelace.melcloudhome_testing
@@ -1,272 +1,345 @@
 {
-  "version": 1,
-  "minor_version": 1,
-  "key": "lovelace.melcloudhome_testing",
-  "data": {
-    "config": {
-      "views": [
+ "version": 1,
+ "minor_version": 1,
+ "key": "lovelace.melcloudhome_testing",
+ "data": {
+  "config": {
+   "views": [
+    {
+     "type": "sections",
+     "max_columns": 4,
+     "title": "My Home House Heat Pump (mock)",
+     "sections": [
+      {
+       "type": "grid",
+       "cards": [
         {
-          "title": "Icons",
-          "sections": [
-            {
-              "type": "grid",
-              "cards": [
-                {
-                  "type": "heading",
-                  "heading": "ATW - Heat Pump",
-                  "heading_style": "title"
-                },
-                {
-                  "type": "vertical-stack",
-                  "cards": [
-                    {
-                      "type": "thermostat",
-                      "entity": "climate.melcloudhome_bf2d_5666_zone_1",
-                      "features": [
-                        {
-                          "type": "climate-hvac-modes"
-                        },
-                        {
-                          "style": "icons",
-                          "type": "climate-preset-modes"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "tile",
-                      "entity": "switch.melcloudhome_bf2d_5666_system_power",
-                      "name": {
-                        "type": "entity"
-                      },
-                      "vertical": false,
-                      "features_position": "bottom"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "grid",
-              "cards": [
-                {
-                  "type": "heading",
-                  "heading": "ATW - Tank",
-                  "heading_style": "title"
-                },
-                {
-                  "type": "vertical-stack",
-                  "cards": [
-                    {
-                      "type": "thermostat",
-                      "entity": "water_heater.melcloudhome_bf2d_5666_tank",
-                      "features": [
-                        {
-                          "type": "water-heater-operation-modes"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "tile",
-                      "entity": "switch.melcloudhome_bf2d_5666_system_power",
-                      "name": {
-                        "type": "entity"
-                      },
-                      "vertical": false,
-                      "features_position": "bottom"
-                    },
-                    {
-                      "type": "tile",
-                      "entity": "sensor.melcloudhome_bf2d_5666_operation_status",
-                      "name": {
-                        "type": "entity"
-                      },
-                      "show_entity_picture": false,
-                      "hide_state": false,
-                      "vertical": false,
-                      "features_position": "bottom"
-                    },
-                    {
-                      "type": "tile",
-                      "entity": "binary_sensor.melcloudhome_bf2d_5666_forced_dhw_active",
-                      "name": {
-                        "type": "entity"
-                      },
-                      "vertical": false,
-                      "features_position": "bottom"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "grid",
-              "cards": [
-                {
-                  "type": "heading",
-                  "heading": "ATA",
-                  "heading_style": "title"
-                },
-                {
-                  "type": "thermostat",
-                  "entity": "climate.melcloudhome_bf8d_5119_climate",
-                  "features": [
-                    {
-                      "style": "icons",
-                      "type": "climate-fan-modes"
-                    },
-                    {
-                      "type": "climate-hvac-modes"
-                    },
-                    {
-                      "style": "icons",
-                      "type": "climate-swing-modes"
-                    },
-                    {
-                      "style": "icons",
-                      "type": "climate-swing-horizontal-modes"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "type": "sections",
-          "max_columns": 4,
-          "cards": []
+         "type": "heading",
+         "heading": "My Home House Heat Pump (mock) - live",
+         "heading_style": "title"
         },
         {
-          "title": "Dropdowns",
-          "sections": [
-            {
-              "type": "grid",
-              "cards": [
-                {
-                  "type": "heading",
-                  "heading": "ATW - Heat Pump",
-                  "heading_style": "title"
-                },
-                {
-                  "type": "vertical-stack",
-                  "cards": [
-                    {
-                      "type": "thermostat",
-                      "entity": "climate.melcloudhome_bf2d_5666_zone_1",
-                      "features": [
-                        {
-                          "style": "dropdown",
-                          "type": "climate-hvac-modes"
-                        },
-                        {
-                          "style": "dropdown",
-                          "type": "climate-preset-modes"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "tile",
-                      "entity": "switch.melcloudhome_bf2d_5666_system_power",
-                      "name": {
-                        "type": "entity"
-                      },
-                      "vertical": false,
-                      "features_position": "bottom"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "grid",
-              "cards": [
-                {
-                  "type": "heading",
-                  "heading": "ATW - Tank",
-                  "heading_style": "title"
-                },
-                {
-                  "type": "vertical-stack",
-                  "cards": [
-                    {
-                      "type": "thermostat",
-                      "entity": "water_heater.melcloudhome_bf2d_5666_tank",
-                      "features": [
-                        {
-                          "style": "dropdown",
-                          "type": "water-heater-operation-modes"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "tile",
-                      "entity": "switch.melcloudhome_bf2d_5666_system_power",
-                      "name": {
-                        "type": "entity"
-                      },
-                      "vertical": false,
-                      "features_position": "bottom"
-                    },
-                    {
-                      "type": "tile",
-                      "entity": "sensor.melcloudhome_bf2d_5666_operation_status",
-                      "name": {
-                        "type": "entity"
-                      },
-                      "show_entity_picture": false,
-                      "hide_state": false,
-                      "vertical": false,
-                      "features_position": "bottom"
-                    },
-                    {
-                      "type": "tile",
-                      "entity": "binary_sensor.melcloudhome_bf2d_5666_forced_dhw_active",
-                      "name": {
-                        "type": "entity"
-                      },
-                      "vertical": false,
-                      "features_position": "bottom"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "grid",
-              "cards": [
-                {
-                  "type": "heading",
-                  "heading": "ATA",
-                  "heading_style": "title"
-                },
-                {
-                  "type": "thermostat",
-                  "entity": "climate.melcloudhome_bf8d_5119_climate",
-                  "features": [
-                    {
-                      "style": "dropdown",
-                      "type": "climate-fan-modes"
-                    },
-                    {
-                      "style": "dropdown",
-                      "type": "climate-hvac-modes"
-                    },
-                    {
-                      "style": "dropdown",
-                      "type": "climate-swing-modes"
-                    },
-                    {
-                      "style": "dropdown",
-                      "type": "climate-swing-horizontal-modes"
-                    }
-                  ]
-                }
-              ]
-            }
-          ],
-          "type": "sections",
-          "max_columns": 4,
-          "cards": []
+         "type": "tile",
+         "entity": "climate.my_home_melcloudhome_bf2d_5666_zone_1"
+        },
+        {
+         "type": "tile",
+         "entity": "water_heater.my_home_melcloudhome_bf2d_5666_tank"
+        },
+        {
+         "type": "tile",
+         "entity": "switch.my_home_melcloudhome_bf2d_5666_system_power"
+        },
+        {
+         "type": "tile",
+         "entity": "sensor.my_home_melcloudhome_bf2d_5666_operation_status"
+        },
+        {
+         "type": "tile",
+         "entity": "binary_sensor.my_home_melcloudhome_bf2d_5666_forced_dhw_active"
+        },
+        {
+         "type": "tile",
+         "entity": "sensor.my_home_melcloudhome_bf2d_5666_outdoor_temperature"
+        },
+        {
+         "type": "tile",
+         "entity": "sensor.my_home_melcloudhome_bf2d_5666_tank_temperature"
         }
-      ]
+       ]
+      },
+      {
+       "type": "grid",
+       "cards": [
+        {
+         "type": "heading",
+         "heading": "Water temperatures",
+         "heading_style": "title"
+        },
+        {
+         "type": "statistics-graph",
+         "chart_type": "line",
+         "period": "5minute",
+         "entities": [
+          "sensor.my_home_melcloudhome_bf2d_5666_flow_temperature",
+          "sensor.my_home_melcloudhome_bf2d_5666_return_temperature",
+          "sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_zone_1",
+          "sensor.my_home_melcloudhome_bf2d_5666_return_temperature_zone_1",
+          "sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_zone_2",
+          "sensor.my_home_melcloudhome_bf2d_5666_return_temperature_zone_2",
+          "sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_boiler",
+          "sensor.my_home_melcloudhome_bf2d_5666_return_temperature_boiler"
+         ],
+         "stat_types": [
+          "mean"
+         ],
+         "days_to_show": 7,
+         "title": "All water temperatures (7d mean) - includes series no longer reported",
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "history-graph",
+         "hours_to_show": 24,
+         "title": "Raw states (24h) - gaps are unknown, not a steady value",
+         "entities": [
+          "sensor.my_home_melcloudhome_bf2d_5666_flow_temperature",
+          "sensor.my_home_melcloudhome_bf2d_5666_return_temperature",
+          "sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_zone_1",
+          "sensor.my_home_melcloudhome_bf2d_5666_return_temperature_zone_1",
+          "sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_zone_2",
+          "sensor.my_home_melcloudhome_bf2d_5666_return_temperature_zone_2",
+          "sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_boiler",
+          "sensor.my_home_melcloudhome_bf2d_5666_return_temperature_boiler"
+         ],
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "markdown",
+         "title": "Reading provenance",
+         "content": "| measure | value | last_reading |\n|---|---|---|\n| flow temperature | {{ states('sensor.my_home_melcloudhome_bf2d_5666_flow_temperature') }} | {{ state_attr('sensor.my_home_melcloudhome_bf2d_5666_flow_temperature', 'last_reading') or '-' }} |\n| return temperature | {{ states('sensor.my_home_melcloudhome_bf2d_5666_return_temperature') }} | {{ state_attr('sensor.my_home_melcloudhome_bf2d_5666_return_temperature', 'last_reading') or '-' }} |\n| flow temperature zone 1 | {{ states('sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_zone_1') }} | {{ state_attr('sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_zone_1', 'last_reading') or '-' }} |\n| return temperature zone 1 | {{ states('sensor.my_home_melcloudhome_bf2d_5666_return_temperature_zone_1') }} | {{ state_attr('sensor.my_home_melcloudhome_bf2d_5666_return_temperature_zone_1', 'last_reading') or '-' }} |\n| flow temperature zone 2 | {{ states('sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_zone_2') }} | {{ state_attr('sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_zone_2', 'last_reading') or '-' }} |\n| return temperature zone 2 | {{ states('sensor.my_home_melcloudhome_bf2d_5666_return_temperature_zone_2') }} | {{ state_attr('sensor.my_home_melcloudhome_bf2d_5666_return_temperature_zone_2', 'last_reading') or '-' }} |\n| flow temperature boiler | {{ states('sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_boiler') }} | {{ state_attr('sensor.my_home_melcloudhome_bf2d_5666_flow_temperature_boiler', 'last_reading') or '-' }} |\n| return temperature boiler | {{ states('sensor.my_home_melcloudhome_bf2d_5666_return_temperature_boiler') }} | {{ state_attr('sensor.my_home_melcloudhome_bf2d_5666_return_temperature_boiler', 'last_reading') or '-' }} |",
+         "grid_options": {
+          "columns": "full"
+         }
+        }
+       ]
+      },
+      {
+       "type": "grid",
+       "cards": [
+        {
+         "type": "heading",
+         "heading": "Energy and diagnostics",
+         "heading_style": "title"
+        },
+        {
+         "type": "statistics-graph",
+         "chart_type": "line",
+         "period": "hour",
+         "entities": [
+          "sensor.my_home_melcloudhome_bf2d_5666_energy_consumed",
+          "sensor.my_home_melcloudhome_bf2d_5666_energy_produced"
+         ],
+         "stat_types": [
+          "sum"
+         ],
+         "days_to_show": 7,
+         "title": "Energy (7d)",
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "statistics-graph",
+         "chart_type": "line",
+         "period": "5minute",
+         "entities": [
+          "sensor.my_home_melcloudhome_bf2d_5666_coefficient_of_performance"
+         ],
+         "stat_types": [
+          "mean",
+          "min",
+          "max"
+         ],
+         "days_to_show": 7,
+         "title": "COP (7d)",
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "statistics-graph",
+         "chart_type": "line",
+         "period": "hour",
+         "entities": [
+          "sensor.my_home_melcloudhome_bf2d_5666_wifi_signal"
+         ],
+         "stat_types": [
+          "mean"
+         ],
+         "days_to_show": 7,
+         "title": "WiFi signal (7d)",
+         "grid_options": {
+          "columns": "full"
+         }
+        }
+       ]
+      }
+     ]
+    },
+    {
+     "type": "sections",
+     "max_columns": 4,
+     "title": "Shared Building Dual Zone Heat Pump (mock)",
+     "sections": [
+      {
+       "type": "grid",
+       "cards": [
+        {
+         "type": "heading",
+         "heading": "Shared Building Dual Zone Heat Pump (mock) - live",
+         "heading_style": "title"
+        },
+        {
+         "type": "tile",
+         "entity": "climate.shared_building_melcloudhome_aed2_9abc_zone_1"
+        },
+        {
+         "type": "tile",
+         "entity": "climate.shared_building_melcloudhome_aed2_9abc_zone_2"
+        },
+        {
+         "type": "tile",
+         "entity": "water_heater.shared_building_melcloudhome_aed2_9abc_tank"
+        },
+        {
+         "type": "tile",
+         "entity": "switch.shared_building_melcloudhome_aed2_9abc_system_power"
+        },
+        {
+         "type": "tile",
+         "entity": "sensor.shared_building_melcloudhome_aed2_9abc_operation_status"
+        },
+        {
+         "type": "tile",
+         "entity": "binary_sensor.shared_building_melcloudhome_aed2_9abc_forced_dhw_active"
+        },
+        {
+         "type": "tile",
+         "entity": "sensor.shared_building_melcloudhome_aed2_9abc_outdoor_temperature"
+        },
+        {
+         "type": "tile",
+         "entity": "sensor.shared_building_melcloudhome_aed2_9abc_tank_temperature"
+        }
+       ]
+      },
+      {
+       "type": "grid",
+       "cards": [
+        {
+         "type": "heading",
+         "heading": "Water temperatures",
+         "heading_style": "title"
+        },
+        {
+         "type": "statistics-graph",
+         "chart_type": "line",
+         "period": "5minute",
+         "entities": [
+          "sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature",
+          "sensor.shared_building_melcloudhome_aed2_9abc_return_temperature",
+          "sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_zone_1",
+          "sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_zone_1",
+          "sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_zone_2",
+          "sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_zone_2",
+          "sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_boiler",
+          "sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_boiler"
+         ],
+         "stat_types": [
+          "mean"
+         ],
+         "days_to_show": 7,
+         "title": "All water temperatures (7d mean) - includes series no longer reported",
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "history-graph",
+         "hours_to_show": 24,
+         "title": "Raw states (24h) - gaps are unknown, not a steady value",
+         "entities": [
+          "sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature",
+          "sensor.shared_building_melcloudhome_aed2_9abc_return_temperature",
+          "sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_zone_1",
+          "sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_zone_1",
+          "sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_zone_2",
+          "sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_zone_2",
+          "sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_boiler",
+          "sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_boiler"
+         ],
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "markdown",
+         "title": "Reading provenance",
+         "content": "| measure | value | last_reading |\n|---|---|---|\n| flow temperature | {{ states('sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature') }} | {{ state_attr('sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature', 'last_reading') or '-' }} |\n| return temperature | {{ states('sensor.shared_building_melcloudhome_aed2_9abc_return_temperature') }} | {{ state_attr('sensor.shared_building_melcloudhome_aed2_9abc_return_temperature', 'last_reading') or '-' }} |\n| flow temperature zone 1 | {{ states('sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_zone_1') }} | {{ state_attr('sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_zone_1', 'last_reading') or '-' }} |\n| return temperature zone 1 | {{ states('sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_zone_1') }} | {{ state_attr('sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_zone_1', 'last_reading') or '-' }} |\n| flow temperature zone 2 | {{ states('sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_zone_2') }} | {{ state_attr('sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_zone_2', 'last_reading') or '-' }} |\n| return temperature zone 2 | {{ states('sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_zone_2') }} | {{ state_attr('sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_zone_2', 'last_reading') or '-' }} |\n| flow temperature boiler | {{ states('sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_boiler') }} | {{ state_attr('sensor.shared_building_melcloudhome_aed2_9abc_flow_temperature_boiler', 'last_reading') or '-' }} |\n| return temperature boiler | {{ states('sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_boiler') }} | {{ state_attr('sensor.shared_building_melcloudhome_aed2_9abc_return_temperature_boiler', 'last_reading') or '-' }} |",
+         "grid_options": {
+          "columns": "full"
+         }
+        }
+       ]
+      },
+      {
+       "type": "grid",
+       "cards": [
+        {
+         "type": "heading",
+         "heading": "Energy and diagnostics",
+         "heading_style": "title"
+        },
+        {
+         "type": "statistics-graph",
+         "chart_type": "line",
+         "period": "hour",
+         "entities": [
+          "sensor.shared_building_melcloudhome_aed2_9abc_energy_consumed",
+          "sensor.shared_building_melcloudhome_aed2_9abc_energy_produced"
+         ],
+         "stat_types": [
+          "sum"
+         ],
+         "days_to_show": 7,
+         "title": "Energy (7d)",
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "statistics-graph",
+         "chart_type": "line",
+         "period": "5minute",
+         "entities": [
+          "sensor.shared_building_melcloudhome_aed2_9abc_coefficient_of_performance"
+         ],
+         "stat_types": [
+          "mean",
+          "min",
+          "max"
+         ],
+         "days_to_show": 7,
+         "title": "COP (7d)",
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "statistics-graph",
+         "chart_type": "line",
+         "period": "hour",
+         "entities": [
+          "sensor.shared_building_melcloudhome_aed2_9abc_wifi_signal"
+         ],
+         "stat_types": [
+          "mean"
+         ],
+         "days_to_show": 7,
+         "title": "WiFi signal (7d)",
+         "grid_options": {
+          "columns": "full"
+         }
+        }
+       ]
+      }
+     ]
     }
+   ]
   }
+ }
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,5 +1,24 @@
 # Custom Component Development Tools
 
+## Dev Dashboard Generator
+
+### `build_dev_dashboard.py`
+
+Generates the dev ATW testing dashboard from the running dev instance's entity
+and device registries: one view per ATW unit, with live tiles, water-temperature
+statistics and raw-state graphs, a `last_reading` provenance table, and energy,
+COP and WiFi graphs.
+
+```bash
+python3 tools/build_dev_dashboard.py                 # all ATW units
+python3 tools/build_dev_dashboard.py --mock-only \
+    --out dev-config-template/.storage/lovelace.melcloudhome_testing
+```
+
+Then `make dev-restart`, since lovelace configs are read at startup. See
+[DEV-SETUP.md](../DEV-SETUP.md) for why the committed copy is `--mock-only`, and
+the script's own docstring for what each card is for.
+
 ## Automated Deployment & Testing
 
 ### `deploy_custom_component.py`

--- a/tools/build_dev_dashboard.py
+++ b/tools/build_dev_dashboard.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Generate the dev ATW testing dashboard from the live entity registry.
+
+`make dev-reset` restores `dev-config-template/.storage/`, so a dashboard only
+survives a reset if it lives there. A static snapshot cannot: entity IDs carry
+the building name as a prefix (`<building>_melcloudhome_<id>_<measure>`), and
+for real devices that name is personal data which must not reach the repo.
+
+So the design is committed as this generator rather than as its output. It reads
+whatever ATW units the registry holds and emits cards for them, which also means
+it keeps working when a device share lapses or a building is renamed.
+
+    # write the live dashboard for every ATW unit found
+    python3 tools/build_dev_dashboard.py
+
+    # refresh the committed template with the mock units only
+    python3 tools/build_dev_dashboard.py --mock-only \
+        --out dev-config-template/.storage/lovelace.melcloudhome_testing
+
+Restart HA afterwards (`make dev-restart`) - lovelace configs are read at
+startup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+DEV_STORAGE = Path("dev-config/.storage")
+DASHBOARD = "lovelace.melcloudhome_testing"
+
+# The mock server's two building names (tools/mock_melcloud_server.py, "My Home"
+# and "Shared Building"), which are synthetic and safe to commit. Keep this list
+# matching the mock, and add nothing else to it: every other building name comes
+# from a real MELCloud account, and one of them is a street address. An
+# unrecognised building is treated as real and excluded by --mock-only, so the
+# failure mode of a stale list is a missing view rather than a leak.
+MOCK_BUILDINGS = ("my_home", "shared_building")
+
+# Every water-temperature series the vendor defines. Listed in full for every
+# unit whether or not the entity still exists: #266 stopped creating the ones
+# for absent hardware, so on most units the suffixed four are orphaned registry
+# entries. Graphing them anyway is deliberate - where a series stops is the
+# discontinuity worth comparing against the MELCloud Home app's own charts.
+WATER_TEMPS = (
+    "flow_temperature",
+    "return_temperature",
+    "flow_temperature_zone_1",
+    "return_temperature_zone_1",
+    "flow_temperature_zone_2",
+    "return_temperature_zone_2",
+    "flow_temperature_boiler",
+    "return_temperature_boiler",
+)
+
+ENTITY_RE = re.compile(r"^[a-z_]+\.(.+_melcloudhome_[0-9a-f]{4}_[0-9a-f]{4})_")
+
+
+def find_atw_units(storage: Path) -> list[tuple[str, bool]]:
+    """Return (entity_id_prefix, has_zone2) for each ATW unit in the registry.
+
+    An ATW unit is identified by its water heater; zone 2 by a second climate
+    entity. Both are capability-gated at creation (#266), so the registry is
+    the honest source for what a unit actually has.
+    """
+    registry = json.loads((storage / "core.entity_registry").read_text())
+    prefixes: set[str] = set()
+    entity_ids: set[str] = set()
+    for entry in registry["data"]["entities"]:
+        entity_id = entry["entity_id"]
+        entity_ids.add(entity_id)
+        match = ENTITY_RE.match(entity_id)
+        if match:
+            prefixes.add(match.group(1))
+
+    units = []
+    for prefix in sorted(prefixes):
+        if f"water_heater.{prefix}_tank" not in entity_ids:
+            continue  # ATA unit
+        units.append((prefix, f"climate.{prefix}_zone_2" in entity_ids))
+    return units
+
+
+def device_names(storage: Path) -> dict[str, str]:
+    """Map entity-id prefix -> the device's display name, read at runtime.
+
+    Device names are personal data for real units, so they are looked up from
+    the local registry rather than written into this file.
+    """
+    registry = json.loads((storage / "core.device_registry").read_text())
+    names = {}
+    for device in registry["data"]["devices"]:
+        name = device.get("name_by_user") or device.get("name") or ""
+        for identifier in device.get("identifiers", []):
+            if len(identifier) > 1:
+                names[str(identifier[1])] = name
+    return names
+
+
+def label(prefix: str, names: dict[str, str]) -> str:
+    """A human view title, preferring the device's own name."""
+    short = prefix.split("_melcloudhome_")[1]
+    kind = "mock" if prefix.startswith(MOCK_BUILDINGS) else "real"
+    for unit_id, name in names.items():
+        clean = unit_id.replace("-", "")
+        if name and short == f"{clean[:4]}_{clean[-4:]}":
+            return f"{name} ({kind})"
+    building = prefix.split("_melcloudhome_")[0].replace("_", " ").title()
+    return f"{building} {short} ({kind})"
+
+
+def _heading(text: str) -> dict[str, Any]:
+    return {"type": "heading", "heading": text, "heading_style": "title"}
+
+
+def _stats(
+    entities: list[str],
+    *,
+    title: str,
+    period: str = "5minute",
+    stat_types: list[str] | None = None,
+    days: int = 7,
+) -> dict[str, Any]:
+    return {
+        "type": "statistics-graph",
+        "chart_type": "line",
+        "period": period,
+        "entities": entities,
+        "stat_types": stat_types or ["mean"],
+        "days_to_show": days,
+        "title": title,
+        "grid_options": {"columns": "full"},
+    }
+
+
+def _provenance(prefix: str) -> dict[str, Any]:
+    """A table of each water temperature's value and its last_reading.
+
+    A statistics graph cannot show an attribute, and last_reading is what
+    separates a genuinely steady circuit from a feed that stopped (ADR-022).
+    """
+    rows = []
+    for measure in WATER_TEMPS:
+        entity = f"sensor.{prefix}_{measure}"
+        rows.append(
+            f"| {measure.replace('_', ' ')} "
+            f"| {{{{ states('{entity}') }}}} "
+            f"| {{{{ state_attr('{entity}', 'last_reading') or '-' }}}} |"
+        )
+    return {
+        "type": "markdown",
+        "title": "Reading provenance",
+        "content": "| measure | value | last_reading |\n|---|---|---|\n"
+        + "\n".join(rows),
+        "grid_options": {"columns": "full"},
+    }
+
+
+def build_view(prefix: str, has_zone2: bool, names: dict[str, str]) -> dict[str, Any]:
+    name = label(prefix, names)
+    water = [f"sensor.{prefix}_{m}" for m in WATER_TEMPS]
+
+    live: list[dict[str, Any]] = [_heading(f"{name} - live")]
+    live.append({"type": "tile", "entity": f"climate.{prefix}_zone_1"})
+    if has_zone2:
+        live.append({"type": "tile", "entity": f"climate.{prefix}_zone_2"})
+    live += [
+        {"type": "tile", "entity": f"water_heater.{prefix}_tank"},
+        {"type": "tile", "entity": f"switch.{prefix}_system_power"},
+        {"type": "tile", "entity": f"sensor.{prefix}_operation_status"},
+        {"type": "tile", "entity": f"binary_sensor.{prefix}_forced_dhw_active"},
+        {"type": "tile", "entity": f"sensor.{prefix}_outdoor_temperature"},
+        {"type": "tile", "entity": f"sensor.{prefix}_tank_temperature"},
+    ]
+
+    temps = [
+        _heading("Water temperatures"),
+        _stats(
+            water,
+            title="All water temperatures (7d mean) - includes series no longer reported",
+        ),
+        {
+            # Raw states, because statistics hide the distinction this change
+            # introduced: a missing reading is a gap here, not a flat line.
+            "type": "history-graph",
+            "hours_to_show": 24,
+            "title": "Raw states (24h) - gaps are unknown, not a steady value",
+            "entities": water,
+            "grid_options": {"columns": "full"},
+        },
+        _provenance(prefix),
+    ]
+
+    energy = [
+        _heading("Energy and diagnostics"),
+        _stats(
+            [
+                f"sensor.{prefix}_energy_consumed",
+                f"sensor.{prefix}_energy_produced",
+            ],
+            title="Energy (7d)",
+            period="hour",
+            stat_types=["sum"],
+        ),
+        _stats(
+            [f"sensor.{prefix}_coefficient_of_performance"],
+            title="COP (7d)",
+            stat_types=["mean", "min", "max"],
+        ),
+        _stats(
+            [f"sensor.{prefix}_wifi_signal"],
+            title="WiFi signal (7d)",
+            period="hour",
+        ),
+    ]
+
+    return {
+        "type": "sections",
+        "max_columns": 4,
+        "title": name,
+        "sections": [
+            {"type": "grid", "cards": live},
+            {"type": "grid", "cards": temps},
+            {"type": "grid", "cards": energy},
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--storage",
+        type=Path,
+        default=DEV_STORAGE,
+        help="HA .storage directory to read the registry from",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help=f"output file (default: <storage>/{DASHBOARD})",
+    )
+    parser.add_argument(
+        "--mock-only",
+        action="store_true",
+        help="emit only mock-server units, so the output is safe to commit",
+    )
+    args = parser.parse_args()
+
+    units = find_atw_units(args.storage)
+    names = device_names(args.storage)
+    if args.mock_only:
+        units = [u for u in units if u[0].startswith(MOCK_BUILDINGS)]
+    if not units:
+        print("No ATW units found - is the integration configured?")
+        return 1
+
+    out = args.out or args.storage / DASHBOARD
+    envelope: dict[str, Any] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": DASHBOARD,
+        "data": {
+            "config": {
+                "views": [build_view(p, z, names) for p, z in units],
+            }
+        },
+    }
+    if out.exists():
+        # Keep whatever version/minor_version HA is writing today
+        existing = json.loads(out.read_text())
+        existing["data"]["config"] = envelope["data"]["config"]
+        envelope = existing
+
+    out.write_text(json.dumps(envelope, indent=1) + "\n")
+    print(f"Wrote {out} with {len(units)} view(s):")
+    for prefix, has_zone2 in units:
+        print(f"  {label(prefix, names)}{' [zone 2]' if has_zone2 else ''}")
+    print("Restart HA to pick it up: make dev-restart")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Builds on `feat/atw-water-temp-report-unification`, whose water-temperature behaviour these cards are there to exercise; that branch has no PR number yet, so expect one to replace the branch name here.

`tools/build_dev_dashboard.py` generates the dev ATW testing dashboard from the live HA entity and device registries: one view per ATW unit, with zone 2 and the device's display name resolved at run time. Entity IDs carry the building name as a prefix, and for real devices that prefix is personal data, so `--mock-only` limits the output to the mock server's synthetic buildings and that filtered form is what is committed under `dev-config-template/.storage/`, where it survives `make dev-reset`. The water-temperature cards cover every vendor-defined series, including the ones #266's capability gating leaves uncreated. Design rationale lives in the module docstring; `last_reading` semantics are in ADR-022 (`docs/decisions/022-reading-provenance.md`) and the report source in ADR-023 (`docs/decisions/023-atw-water-temperatures-from-report.md`).

## Risks accepted

Regenerating the committed template without `--mock-only` writes real building and device names into the repo. The generator's building allowlist only decides which units that flag keeps, so nothing blocks the unfiltered form, and detection rests on diff review at commit time because these names are not a pattern gitleaks matches. Undo is a regenerate with the flag, plus a history rewrite if the leak has already landed.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

- [x] `make pre-commit`: all 12 hooks pass, gitleaks included.
- [x] `--mock-only` output is byte-identical to the committed `dev-config-template/.storage/lovelace.melcloudhome_testing`, so that file is regenerable and holds only the mock server's two synthetic buildings.
- [x] Full run against the live dev registry emits 4 views for 4 ATW units, 2 mock and 2 real, with zone-2 detection firing on the one dual-zone unit.
- [x] 6 of the 77 entity references in that output are absent from the registry, all zone-2 flow and return water temperatures on single-zone units, which is the generator's intended behaviour.
- [x] The unprefixed entity IDs the committed dashboard carried match none of the 177 melcloudhome entities in the live dev registry, spread across 12 entity-id prefixes.
- [x] The `ha-melcloud-dev` container serves the generated 4-view dashboard with no lovelace or dashboard errors across its startups; its only melcloudhome warnings come from the mock's randomised telemetry.
- [ ] `make test-api`, `make test-integration`, `make test-e2e`: not run here; the diff is one dev-only script and a lovelace JSON, neither on a test path.
- [ ] Automated coverage for `tools/build_dev_dashboard.py`: none exists.
- [x] Dashboard confirmed visually in a browser: not done here.
- [ ] Prod deployment and soak: not applicable, `tools/` sits outside `custom_components/` so nothing in this layer ships to users.
