### PR TITLE
docs(skills): add a pr-body skill that composes from the diff

### DIFF
--- a/.claude/skills/pr-body/.markdownlint.jsonc
+++ b/.claude/skills/pr-body/.markdownlint.jsonc
@@ -1,0 +1,6 @@
+{
+  // Tables and inline-code examples cannot be wrapped without breaking them,
+  // so MD013 applies to prose only. Prose is wrapped by:
+  //   npx --yes prettier@3 --prose-wrap always --print-width 80 --write *.md
+  "MD013": { "line_length": 80, "tables": false, "code_blocks": false }
+}

--- a/.claude/skills/pr-body/SKILL.md
+++ b/.claude/skills/pr-body/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: pr-body
+description:
+  Use when composing or revising a pull request description in this repo,
+  including PRs that sit in a stack.
+---
+
+# PR Body
+
+## Overview
+
+A PR body tells a reviewer what changed, what to check, and what risk they are
+accepting by merging. It is written from the diff and the linked decision
+record.
+
+## Source contract
+
+Inputs: `git diff <base>..HEAD`, `git diff --shortstat <base>..HEAD`, the linked
+ADR/plan/issue, and `.github/pull_request_template.md`.
+
+**Resolve the base from the branch; a caller need not supply it.**
+`gh stack view --json` names the branch below this one in a stack; that is the
+base. With no stack, the base is the trunk. Sanity-check either answer against
+`git log --oneline <base>..HEAD`: the commits shown must be this branch's own
+work, and a parent's commits appearing there means the base is wrong.
+
+The session transcript is not an input. A sentence that exists because of
+something that happened while the work was done (an investigation, a wrong turn,
+a precedent you discovered, an objection raised earlier) belongs in the ADR or
+nowhere.
+
+## Handoff
+
+Three rules that bind even if you read nothing else. Detail and reasoning:
+**REQUIRED: follow `handoff.md`.**
+
+- A subagent writes the body. The author names the branch and passes the ADR
+  paths and a list of verified facts, no narrative. The writer resolves the base
+  itself.
+- The body goes in a file, never pasted into chat as the deliverable.
+- If that file already exists, ask before writing and wait for the answer.
+
+## The shape
+
+Three sections are required, from `.github/pull_request_template.md`. Three more
+are conditional, each on something you can check rather than judge. Nothing
+else: a named-but-optional section is how a template rots, and Motivation,
+Background, Implementation notes and Screenshots all invite the narrative the
+source contract removes.
+
+The file opens with the title as an H1, so the one line a reviewer reads first
+is reviewed and versioned with the body rather than improvised at the command
+line.
+
+**Write the title last, from the finished body.** Composing the body is what
+establishes what the change is; a title written first frames the body instead,
+and you cannot tell whether a title merely repeats the Summary's opening
+sentence until that sentence exists.
+
+Rules, all drawn from this repo's merged titles:
+
+- Conventional-commit form, `type(scope): summary`. Lowercase after the colon,
+  no trailing period.
+- Types in use here: `fix`, `feat`, `refactor`, `perf`, `docs`, `ci`, `chore`,
+  `test`. Scope is the area touched: `atw`, `ata`, `sensor`, `coordinator`,
+  `i18n`, `mock`, `diagnostics`, `dev`.
+- **Type by the effect on a user, not by the shape of the diff.** Something
+  broken now working is a `fix` even when the diff adds a lot; #257, #258 and
+  #266 are all endpoint or parsing changes typed that way.
+- 50 to 75 characters. The merged corpus runs 53 to 82 and clusters there;
+  GitHub truncates beyond about 70 in some views.
+- Name what changed. The why belongs to the Summary, and the title should not
+  restate its first sentence.
+- **Try the positive form before reaching for a contrast.** Merged titles do use
+  `X, not Y` (#255, #257, #264), but reframing around what is being removed came
+  out shorter than the original in every one of those cases, and it names the
+  actionable half: `stop trusting live context for outdoor temperature` beats
+  `source outdoor temperature from comfort-graph, not live context` by 13
+  characters and says the same thing. Keep the contrast only when the positive
+  form loses a fact.
+
+```markdown
+# fix(atw): source water temperatures from the internaltemperatures report
+```
+
+Then, in order:
+
+1. `## Summary`: **required.** What changed and why, from the diff, citing the
+   related `#number` inline. One pointer to the ADR, plan or issue that holds
+   the evidence.
+2. `## Key changes`: **when the diff touches more than five files.** One bullet
+   per behaviour a reviewer can verify in the diff. Below that, fold it into the
+   Summary.
+3. `## What changes for users`: **when a user will notice something**, such as a
+   state that reads differently, a discontinuity in recorded history, an
+   automation that has to adapt. One section, one bullet each, with the remedy.
+   Internal changes nobody outside the repo can observe do not belong here.
+4. `## Risks accepted`: **when merging accepts a known risk**, such as an
+   assumption shipped without evidence, a downside taken deliberately. Say what
+   the risk is, what it costs if it turns out wrong, how it would be detected,
+   and how it would be undone. This is what a maintainer hunts for months later
+   when the risk lands.
+5. `## AI Disclosure`: **required.** Reproduce the template's two boxes and
+   leave **both unchecked**. The second reads "I reviewed and ran the change
+   myself", a claim about the human author that nobody else can make for them.
+   They tick one before opening the PR.
+6. `## Testing`: **required.** What ran and what it showed. An unchecked box for
+   anything a reviewer would otherwise assume was covered.
+
+A checked box asserts the claim holds at the current tip. Something verified
+before later commits landed is unverified again, so a box can age out of true
+without anyone editing it.
+
+**Word every box as the claim it asserts, never as a negation.** Ticking is what
+makes the claim true, so `- [ ] No prod soak` inverts its own meaning the moment
+someone ticks it. Write the claim, `- [ ] Prod deployment and soak`, and put why
+it is unticked after it, as a note that gets deleted when the box is earned.
+
+An unticked box says what **you** did not verify. It does not assert that nobody
+did: other sessions, other machines and runs that left no artefact in the repo
+are all invisible from here. "Not run here" is warranted; "has not happened" is
+not.
+
+## When the base is another branch
+
+If `<base>` is not the trunk, the PR sits in a stack. Four things follow:
+
+- Diff against the parent: `git diff <parent>..HEAD`. Diffing against the trunk
+  shows the parent's changes as if they were yours.
+- The Summary's first line names what this builds on and what it needs from it.
+  One line. The parent PR describes itself, so restating any of its content
+  belongs nowhere. Cite the parent's PR number if it has one; before that, name
+  the branch and expect a number to replace it.
+- **Write a stack bottom-up.** The lower layer needs nothing from the layer
+  above, so it is drafted, opened and numbered first, which is what gives the
+  layer above both a number to cite and a body to measure against.
+- Compare this body's `wc -w` against the parent's before handing it over. A
+  layer smaller than its parent gets a shorter body.
+
+## Name the category
+
+State why a fact matters. Never restate the fact.
+
+| write this                                       | not this                        |
+| ------------------------------------------------ | ------------------------------- |
+| for real devices the prefix is the building name | one of them is a street address |
+| the cassette carries account identifiers         | the account is `<address>`      |
+| the log names a shared device                    | the device is `<name>`          |
+
+A body is public the moment the PR opens. Applies to device names, building
+names, addresses, account identifiers and UUIDs.
+
+## Evidence lives in the record
+
+Measurements, probe counts, failure rates, rejected alternatives and provenance
+go in the ADR or plan. The body carries the conclusion and a link. A number
+repeated in both places dates the body the moment it is re-measured.
+
+Design rationale for a tool lives in that tool's docstring.
+
+## Proportion
+
+Measure the prose sections. The Testing list and the disclosure boxes sit
+outside the count: their length tracks how much was verified, and trimming them
+to hit a number is the one cut that loses a reviewer something.
+
+Weigh it against review surface rather than raw lines. Deleted fixtures,
+cassettes and generated files inflate `--shortstat` without adding anything to
+read, so count the files someone must actually review.
+
+Compare like with like. The merged corpus predates `What changes for users` and
+`Risks accepted`, so its numbers describe `Summary` plus `Key changes` and
+nothing else: about 40 words for a two-line i18n fix (#255, 2 files), 200 for a
+20-file endpoint change (#257), 390 for an 11-file feature (#268), 550 for a
+33-file refactor (#269). Hold those two sections against that range.
+
+The other two sections are justified by whether their content is real, not by a
+word budget: a user-visible change nobody would otherwise notice, and a risk
+somebody inherits by merging, are both worth their length. Cutting them to hit a
+number removes the part of the body a reviewer most needs.
+
+So when a body reads long, the question is whether `Summary` and `Key changes`
+have drifted past the corpus for a comparable review surface. File count
+predicts length poorly, and padding to reach a number is always wrong.
+
+Across a stack, compare against the parent's body. With no parent body written
+yet, use the calibration above and say in your handover that the comparison was
+unavailable.
+
+## Common mistakes
+
+Observed in baseline testing, every one of these from an author who had the diff
+in front of them.
+
+| mistake                                                                                                     | fix                                                                                                                            |
+| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Restating a sensitive value the reason merely refers to                                                     | Name the category                                                                                                              |
+| Opening with how the problem was discovered                                                                 | Open with what changed                                                                                                         |
+| Reproducing the ADR's measurement table                                                                     | One clause plus the link                                                                                                       |
+| "moved from X to Y", "previously", "used to"                                                                | State current behaviour only                                                                                                   |
+| Any negation carrying the emphasis: `X, not Y`, `X rather than Y`, `isn't an option`, `is not the argument` | Say what is true, positively. Contrast two real options by naming both                                                         |
+| Rebutting a position the PR never raises                                                                    | Delete the paragraph                                                                                                           |
+| Explaining why a card, flag or graph exists                                                                 | Put it in the docstring                                                                                                        |
+| Arguing for the method instead of reporting what ran                                                        | Say what ran and what it showed. A Testing preamble that defends the approach is commentary                                    |
+| An em dash                                                                                                  | A colon where it introduces an elaboration, commas or brackets where it wraps an aside. A body full of them reads as generated |
+| Every box checked when verification is partial                                                              | Leave the box unchecked and say why                                                                                            |
+| Overwriting a body that was handed over for editing                                                         | Read it first, keep the author's wording, report the change                                                                    |

--- a/.claude/skills/pr-body/handoff.md
+++ b/.claude/skills/pr-body/handoff.md
@@ -1,0 +1,168 @@
+# PR body handoff
+
+Mechanics for producing and handing over a PR body. The writing rules are in
+`SKILL.md`.
+
+## Dispatch a fresh agent to write it
+
+Whoever did the work cannot un-know how it went, and that knowledge shapes the
+body around the session. So the author gathers, and a subagent writes.
+
+Pass it exactly this:
+
+- the branch, and nothing about its base; the writer resolves that itself
+- the paths of the ADR, plan or issue that hold the evidence
+- **a list of verified facts** for the Testing section: what ran, what it
+  showed, and what was not done
+
+Pass no narrative. Test counts and soak results are facts and belong in the
+list; the story of obtaining them is what stays behind. If a fact cannot be
+stated without its story, it belongs in the ADR.
+
+**Facts you can establish, establish.** Run `make test-api`,
+`make test-integration`, `make test-e2e`, `make pre-commit`, and grep the diff
+for what it shows. A suite you ran beats a suite someone told you about, and it
+beats a note in a file claiming someone ran it.
+
+**Check the running dev environment before writing any box off.** `docker ps`,
+then the integration's own log lines in `ha-melcloud-dev`. Live-API and live-HA
+behaviour that no test reproduces is often recorded there (request counts and
+their status codes, missing-measure events, startup errors), and it is the one
+source of evidence a repo-only search never finds.
+
+**Run them against the branch you are describing.** `git diff` reads refs, so
+the diff needs no checkout. Anything you _run_ reads the working tree, so a
+suite executed on another branch reports another branch's result.
+
+Compare `git branch --show-current` to the target before running anything. If
+they differ, add a worktree rather than moving the shared tree:
+
+```bash
+git worktree add ../melcloudhome-worktrees/<name> --detach <branch>
+```
+
+Run `uv sync --group reverse-engineering` inside it, run the suites from there,
+and remove it when done. A checkout would move a tree that other sessions and a
+bind-mounted dev container are using, and each would start seeing different
+code. A worktree also holds its branch for the whole run: a single check of the
+shared tree proves the branch at that instant, and another session can move it
+while your suites are still going.
+
+The body itself is written into the main checkout, whichever worktree the suites
+ran in.
+
+The `make test-*` targets pin one Docker project name with fixed container names
+and tear it down on exit, so two runs at once kill each other. A suite failing
+while another session is testing is an artefact until it fails again on its own.
+
+A claim you cannot establish and were not told stays an unchecked box. That is
+the safe direction: an unchecked box understates coverage, and a checked one
+that nobody verified is how a reviewer ends up trusting a test that never ran.
+
+A suite the diff cannot reach is a third case, and it gets a reason rather than
+a bare box. A bare unchecked box there reads as something forgotten:
+
+```markdown
+- [ ] `make test-e2e`: not run; the diff is one dev-only script and a lovelace
+      JSON, neither on an e2e path.
+```
+
+Take no facts from a file left in `_claude/pr-bodies/` by an earlier session.
+Its title cannot tell you whether a human confirmed those lines or a previous
+agent asserted them.
+
+The agent reads this skill, composes from the diff, and reports back the path.
+
+## Review what the writer reports
+
+A clean-scoring body can still be wrong on facts, so check the writer's claims
+before handing the path on. A checked box can be stale as easily as false,
+established once and left standing while the code moved past it, so ask what tip
+each check was made against. A **targeted** read of the archive is the tool:
+grep the lines a claim is about. A checkbox claim costs eight lines to confirm;
+reading the whole thing pulls its prose in for no gain.
+
+One shape of claim cannot be checked that way. "The archive never mentions X" is
+an absence over the whole file, and no targeted read establishes it. Either the
+writer cites where it looked, or you pass the claim on as the writer's
+unverified assertion. Report what you confirmed and what you took on trust,
+separately: a summary saying the claims hold, when two of them were never
+reachable, is the same defect in your own report that you were checking the body
+for.
+
+## Write it to a file
+
+Write to `_claude/pr-bodies/<branch>.md`, with slashes in the branch name
+replaced by hyphens, and hand over the path. Review happens in an editor, so
+never paste a body into chat instead.
+
+**If that file already exists, stop before opening it.** An edit in progress is
+invisible from here: the file is its only record, and `_claude/` is gitignored
+so there is no second copy.
+
+1. Note that it exists and when it was written:
+   `date -u -r <file> "+%Y-%m-%d %H:%M:%S"`. Do not read its contents **before
+   the writer is dispatched**. The decision needs the file's existence, not its
+   wording, and a previous body in the caller's context is what shapes the next
+   one like it. That risk ends once the writer has composed from the diff.
+2. Ask the author whether to archive it. Ask before writing anything, and wait
+   for the answer.
+3. On yes, rename it to `<name>-old-<timestamp>.md` in the same directory,
+   timestamp from `date -u "+%Y-%m-%d-%H-%M-%S"`: UTC, hyphenated so it needs no
+   quoting.
+4. Dispatch the writer and give it the archived path. Reading the archive is the
+   writer's job: it reconciles the old body against the verified facts and
+   reports every conflict it finds, which is how a fabrication in the previous
+   version gets caught.
+
+On no, the author is keeping their version. Hand back the path and stop. If they
+instead want that version edited, it is not a fresh compose: read it, keep their
+wording, and change only what they name.
+
+**Timestamps are UTC, from `date -u`.** `stat -f "%Sm" -t "…UTC"` formats local
+time and labels it UTC regardless, which reads an hour off under BST. A commit's
+time in UTC is
+`TZ=UTC git log -1 --format=%cd --date=format-local:"%Y-%m-%d %H:%M:%S"`.
+
+**Whether an existing body is current is a question about the code, not about
+neighbouring files.** Compare its mtime to the branch tip's commit time and
+check the tree is clean. Another file being newer, whether a fact list or a
+sibling branch's body, carries no information about this body at all.
+
+Before handing it over, format it and check it:
+
+```bash
+npx --yes prettier@3 --prose-wrap preserve --write _claude/pr-bodies/<name>.md
+grep -n '—' _claude/pr-bodies/<name>.md   # em dashes: rewrite, see SKILL.md
+```
+
+`--prose-wrap preserve` is deliberate. It fixes list spacing, trailing
+whitespace, table alignment and the final newline while leaving long lines
+alone, because GitHub reflows paragraphs and a hard-wrapped body reads badly
+there. Do not run markdownlint on a body: its line-length rule fires on prose
+that is meant to be unwrapped, and following it would break the convention.
+
+## Creating the PR from the file
+
+The H1 is the title, so it is not part of the body. Passing the whole file would
+print the title twice:
+
+```bash
+BODY=_claude/pr-bodies/<name>.md
+gh pr create --base <base> --head <branch> \
+  --title "$(sed -n '1s/^# //p' "$BODY")" \
+  --body-file <(tail -n +3 "$BODY")
+```
+
+`tail -n +3` drops the H1 and the blank line under it. For a stack, create the
+lower PR first, put its number in the layer above, then
+`gh stack link <lower> <upper>` to register the stack on GitHub: a correct base
+chain alone leaves the PRs unlinked in the stack view.
+
+Creating the PR is not part of this skill. Hand over the path and let the author
+run it.
+
+End by giving the path to the new file, the archived path if one was made, the
+word count against `git diff --shortstat`, and any decision left for the author:
+an unchecked box, or a claim you could not verify. Print the body itself only
+when asked for it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ make test                        # All tests with coverage
 - **Testing strategy:** `docs/testing-strategy.md` - Test types, when to use each
 - **Deployment tools:** `tools/README.md` - Automated deployment, remote testing
 - **Release process:** `docs/release-process.md` - Release + beta workflows
+- **Writing a PR description:** the `pr-body` skill in `.claude/skills/pr-body/` - required sections, the title as an H1, and what a Testing box may claim
 
 ### Research & Tools
 


### PR DESCRIPTION
## Summary

Stacks on `feat/dev-dashboard-generator` and needs nothing from it: both are independent docs changes queued to merge in order.

A new `pr-body` skill under `.claude/skills/pr-body/` holds how a PR description gets written here. `SKILL.md` carries the writing rules, `handoff.md` the mechanics of producing the file and handing it over, and a committed `.markdownlint.jsonc` scopes MD013 to prose so the wrapping convention is checkable. `CLAUDE.md` gains one line under Development Guides so the skill is discoverable.

The shape is six sections. Three are required by `.github/pull_request_template.md`; the other three are conditional on something checkable. The title is an H1 at the top of the file, written last, in conventional-commit form, and typed by its effect on a user. Every checkbox is worded as the claim it asserts, so ticking cannot invert its meaning, and an unticked box is scoped to its author: it says what was not verified here and claims nothing about other sessions. A subagent composes from the diff while the session that did the work gathers facts and reviews it, because that session cannot un-know how the work went. The skill ends at the written file; creating the PR stays the author's to run.

No ADR or plan backs this and no issue tracks it. The skill files are the artefact.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

Built test-first against fresh-context subagents. The generations are archived under gitignored `_claude/pr-bodies-run*/` and are not part of the diff.

- [x] Baselines with no skill present wrote a street address into a body 2 of 2, opened with how the problem was discovered, and ran 361 and 475 words for a 286-line script. Five generations under the skill took em dashes to zero and unticked boxes carrying a reason from 2 of 9 to 9 of 11, and produced conventional-commit H1s typed by effect rather than by the commit. One proposed rule was dropped when its test failed to reproduce the problem it targeted.
- [x] `npx markdownlint-cli2` on both skill files: 0 issues, under the committed config. Prose wrapped with `npx prettier@3 --prose-wrap always --print-width 80`, zero em dashes in either file.
- [ ] `make pre-commit`: not run on this branch.
- [ ] `make test-api`, `make test-integration`, `make test-e2e`: not run and not reachable; the diff is two markdown files, a lint config and one line of `CLAUDE.md`, with nothing under `custom_components/` or `tests/`.
