### PR TITLE
fix(energy): floor the request window to whole UTC hours

### DIFF
--- a/custom_components/melcloudhome/api/models_ata.py
+++ b/custom_components/melcloudhome/api/models_ata.py
@@ -141,6 +141,10 @@ class AirToAirUnit:
     # for telling "endpoint failing for this unit" apart from "no data yet".
     outdoor_temp_last_error: str | None = None
     outdoor_temp_last_error_at: datetime | None = None  # UTC-aware
+    # When a poll last completed, whatever it found. Read against
+    # outdoor_temp_reading.recorded_at, this separates "the endpoint has
+    # nothing newer" from "we have not asked recently" (UTC-aware).
+    outdoor_temp_last_poll_at: datetime | None = None
     # Protection modes (from GET /context; null until ever configured on this unit)
     frost_protection: ProtectionModeState | None = None
     overheat_protection: ProtectionModeState | None = None

--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -206,6 +206,10 @@ class AirToWaterUnit:
     # for telling "endpoint failing for this unit" apart from "no data yet".
     outdoor_temp_last_error: str | None = None
     outdoor_temp_last_error_at: datetime | None = None  # UTC-aware
+    # When a poll last completed, whatever it found. Read against
+    # outdoor_temp_reading.recorded_at, this separates "the endpoint has
+    # nothing newer" from "we have not asked recently" (UTC-aware).
+    outdoor_temp_last_poll_at: datetime | None = None
 
     # Holiday Mode & Frost Protection (read-only state)
     holiday_mode_enabled: bool = False

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -126,6 +126,13 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             str, datetime
         ] = {}  # Per-unit last poll time
 
+        # Units currently in an outdoor-temp failure streak. A failed poll still
+        # resets the 30-minute timer and keeps the previous value, so without
+        # this a unit failing every poll is indistinguishable from an idle one
+        # at prod's INFO level. Warn on entering the streak, stay quiet inside
+        # it, re-arm on the next success.
+        self._outdoor_temp_failing: set[str] = set()
+
         # Initialize ATA control client
         self.control_client_ata = ATAControlClient(
             hass=hass,
@@ -657,6 +664,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 unit.outdoor_temp_reading = old_unit.outdoor_temp_reading
                 unit.outdoor_temp_last_error = old_unit.outdoor_temp_last_error
                 unit.outdoor_temp_last_error_at = old_unit.outdoor_temp_last_error_at
+                unit.outdoor_temp_last_poll_at = old_unit.outdoor_temp_last_poll_at
 
             if not self._should_poll_outdoor_temp(unit_id):
                 continue
@@ -669,6 +677,11 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 self._record_outdoor_temp_poll(unit_id)
                 unit.outdoor_temp_last_error = None
                 unit.outdoor_temp_last_error_at = None
+                unit.outdoor_temp_last_poll_at = datetime.now(UTC)
+
+                if unit_id in self._outdoor_temp_failing:
+                    self._outdoor_temp_failing.discard(unit_id)
+                    _LOGGER.info("%s for %s is working again", log_label, unit.name)
 
                 if reading is not None:
                     unit.has_outdoor_temp_sensor = True
@@ -686,12 +699,22 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 self._record_outdoor_temp_poll(unit_id)
                 unit.outdoor_temp_last_error = f"{type(err).__name__}: {err}"
                 unit.outdoor_temp_last_error_at = datetime.now(UTC)
+                unit.outdoor_temp_last_poll_at = datetime.now(UTC)
                 _LOGGER.debug(
                     "Failed to fetch %s for %s",
                     log_label,
                     unit.name,
                     exc_info=True,
                 )
+                if unit_id not in self._outdoor_temp_failing:
+                    self._outdoor_temp_failing.add(unit_id)
+                    _LOGGER.warning(
+                        "%s for %s failed and the sensor will keep its previous "
+                        "value until a poll succeeds: %s",
+                        log_label,
+                        unit.name,
+                        err,
+                    )
 
     def _should_poll_outdoor_temp(self, unit_id: str) -> bool:
         """Check if outdoor temp should be polled for a specific unit."""

--- a/custom_components/melcloudhome/diagnostics_shared.py
+++ b/custom_components/melcloudhome/diagnostics_shared.py
@@ -25,4 +25,9 @@ def serialize_outdoor_temp_fields(
             if unit.outdoor_temp_last_error_at
             else None
         ),
+        "outdoor_temp_last_poll_at": (
+            unit.outdoor_temp_last_poll_at.isoformat()
+            if unit.outdoor_temp_last_poll_at
+            else None
+        ),
     }

--- a/custom_components/melcloudhome/energy_tracker_ata.py
+++ b/custom_components/melcloudhome/energy_tracker_ata.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from .api.client import MELCloudHomeClient
 from .api.models import AirToAirUnit, UserContext
-from .const import DATA_LOOKBACK_HOURS_ENERGY
 from .energy_tracker_base import EnergyTrackerBase
 
 if TYPE_CHECKING:
@@ -109,8 +108,7 @@ class ATAEnergyTracker(EnergyTrackerBase):
         )
 
         # Setup time range for energy data fetch
-        to_time = datetime.now(UTC)
-        from_time = to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)
+        from_time, to_time = self._energy_window(datetime.now(UTC))
 
         # Wrap with retry for automatic session recovery
         data = await self._execute_with_retry(

--- a/custom_components/melcloudhome/energy_tracker_atw.py
+++ b/custom_components/melcloudhome/energy_tracker_atw.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from .api.client_atw import ATWControlClient
 from .api.models import UserContext
 from .api.models_atw import AirToWaterUnit
-from .const import DATA_LOOKBACK_HOURS_ENERGY
 from .energy_tracker_base import EnergyTrackerBase
 
 if TYPE_CHECKING:
@@ -120,8 +119,7 @@ class ATWEnergyTracker(EnergyTrackerBase):
         )
 
         # Setup time range for energy data fetch
-        to_time = datetime.now(UTC)
-        from_time = to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)
+        from_time, to_time = self._energy_window(datetime.now(UTC))
 
         # Fetch both consumed and produced
         await self._update_measure(unit, "consumed", from_time, to_time)

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -178,6 +178,13 @@ class EnergyTrackerBase(ABC):
         wrong, only the question.
 
         The wider window is accepted - the floored request returns 200.
+
+        Flooring in UTC is correct because this endpoint's hour labels are UTC,
+        unlike the /report/v1/ endpoints, which stamp points in the unit's own
+        zone (ADR-022). Measured 2026-08-25 07:51 UTC: a Europe/London (+1) and
+        a Europe/Skopje (+2) unit both reported newest bucket 07:00 for an
+        identical window, and pushing "to" three hours past either unit's local
+        wall-clock surfaced no newer bucket.
         """
         to_time = now
         from_time = (to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)).replace(

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.storage import Store
 
-from .const import HOUR_VALUE_RETENTION_HOURS, MAX_PLAUSIBLE_HOURLY_ENERGY_KWH
+from .const import (
+    DATA_LOOKBACK_HOURS_ENERGY,
+    HOUR_VALUE_RETENTION_HOURS,
+    MAX_PLAUSIBLE_HOURLY_ENERGY_KWH,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -158,6 +162,28 @@ class EnergyTrackerBase(ABC):
         # new energy data arrives.
         if self._clean_hour_values(datetime.now(UTC)):
             await self._save_energy_data()
+
+    @staticmethod
+    def _energy_window(now: datetime) -> tuple[datetime, datetime]:
+        """Return the (from, to) window for an energy request.
+
+        Do not remove the hour floor on "from". The server sums only the
+        samples at or after "from", so an unfloored bound makes the oldest
+        bucket a shrinking partial hour. Every poll then asks for a smaller
+        slice of it than the last one did, the value comes back lower, and the
+        decrease guard logs it as "possible API issue" - roughly four times an
+        hour per unit, forever. Measured 2026-08-25: bucket
+        2026-08-23 06:00 held 0.567 kWh, read as 0.433 at :16 past and 0.133 at
+        :46; re-requesting it floored returned 0.567 again. The data was never
+        wrong, only the question.
+
+        The wider window is accepted - the floored request returns 200.
+        """
+        to_time = now
+        from_time = (to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        return from_time, to_time
 
     @staticmethod
     def _parse_hour_timestamp(hour_timestamp: str) -> datetime | None:

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -185,8 +185,16 @@ class EnergyTrackerBase(ABC):
         a Europe/Skopje (+2) unit both reported newest bucket 07:00 for an
         identical window, and pushing "to" three hours past either unit's local
         wall-clock surfaced no newer bucket.
+
+        Both bounds are normalised to UTC first. The request format
+        ("%Y-%m-%d %H:%M", api/client.py) carries no offset marker, so strftime
+        drops the tzinfo silently: a caller passing a local-aware `now` would
+        query the wrong window with no error anywhere. A naive `now` cannot be
+        rescued and raises instead.
         """
-        to_time = now
+        if now.tzinfo is None:
+            raise ValueError("energy window needs an aware datetime, got naive")
+        to_time = now.astimezone(UTC)
         from_time = (to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)).replace(
             minute=0, second=0, microsecond=0
         )

--- a/custom_components/melcloudhome/sensor_ata.py
+++ b/custom_components/melcloudhome/sensor_ata.py
@@ -95,7 +95,6 @@ ATA_SENSOR_TYPES: tuple[ATASensorEntityDescription, ...] = (
         should_create_fn=lambda unit: unit.capabilities.has_energy_consumed_meter,
     ),
     # Outdoor temperature - ambient temperature from outdoor unit sensor
-    # Only created for devices where outdoor sensor detected during capability discovery
     # Updates every 30 minutes via trendsummary API endpoint
     ATASensorEntityDescription(
         key="outdoor_temperature",

--- a/custom_components/melcloudhome/telemetry_tracker.py
+++ b/custom_components/melcloudhome/telemetry_tracker.py
@@ -139,7 +139,9 @@ class TelemetryTracker:
         # absent ones hold no genuine reading (an empty series or a flat 25
         # placeholder - see docs/api/atw-api-reference.md), so the capability
         # filter that used to decide what to REQUEST now decides what to keep
-        # (#266). Same rules, same outcome, one request.
+        # (#266). Same rules, same outcome, one request. The sensors themselves
+        # are gated in sensor_atw.py; this only keeps fake values out of the
+        # cache.
         wanted = list(ATW_TELEMETRY_MEASURES)
         if unit.capabilities and unit.capabilities.has_zone2:
             wanted.extend(ATW_TELEMETRY_MEASURES_ZONE1)

--- a/docs/decisions/023-atw-water-temperatures-from-report.md
+++ b/docs/decisions/023-atw-water-temperatures-from-report.md
@@ -93,16 +93,18 @@ response carried zone-2 series. Shipping zone-2 datasets for a unit that has
 zone 2 is therefore an assumption, taken deliberately (2026-08-21, reaffirmed
 2026-08-22) rather than established by evidence.**
 
-**What tilts it that way:** the vendor's decompiled `App.Shared.ReportTimeDataSet`
-carries hardcoded static templates for `flow_temperature_zone2` and
-`return_temperature_zone2` alongside the eight datasets seen on the wire,
-`App.Shared` is shared with the server so the server builds responses from those
-templates, and the `INTEMP_REPORT` label namespace has keys for both.
+**What tilts it that way:** the report's dataset ids are exactly the measure names
+the per-measure telemetry endpoint used, zone-2 names included (`const.py`), so the
+report continues a naming scheme that already has a place for them; and the eight
+datasets a single-zone unit receives include `*_zone1` and `*_boiler` series for
+hardware it does not have, so the server is not filtering datasets by device
+capability on any axis visible from the wire.
 
-**What keeps it an assumption:** the same namespace carries
-`ROOM_TEMPERATURE_ZONE1` and `SET_TEMPERATURE_ZONE1`, and neither is emitted even
-though that hardware exists. Template and label presence is a superset of what
-the server sends.
+**What keeps it an assumption:** if that unfiltered set is simply fixed at eight,
+zone-2 series never arrive for anyone. The `INTEMP_REPORT` label namespace also
+carries `ROOM_TEMPERATURE_ZONE1` and `SET_TEMPERATURE_ZONE1` — both observed on
+`comfort-graph` — and neither is emitted here even though that hardware exists, so
+label presence is a superset of what the server sends.
 
 **What would falsify it:** a diagnostics capture from a real two-zone unit taken
 while the system is actively heating, showing the report without zone-2 datasets.

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -35,7 +35,7 @@ For each air conditioning unit, the following entities are created:
 ### Sensors
 
 - **Room Temperature**: `sensor.melcloudhome_{short_id}_room_temperature`
-- **Outdoor Temperature**: `sensor.melcloudhome_{short_id}_outdoor_temperature` (if available)
+- **Outdoor Temperature**: `sensor.melcloudhome_{short_id}_outdoor_temperature`
 - **WiFi Signal**: `sensor.melcloudhome_{short_id}_wifi_signal` (diagnostic)
 - **Energy**: `sensor.melcloudhome_{short_id}_energy` (cumulative kWh)
 - **Frost Protection Minimum/Maximum**: `sensor.melcloudhome_{short_id}_frost_protection_minimum` / `_maximum` (°C, diagnostic; created when the API reports the `frostProtection` object — every ATA unit does, as a server-side default, whether or not the mode has ever been configured)

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -21,7 +21,11 @@ from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
 )
 
-from custom_components.melcloudhome.const import DOMAIN, HOUR_VALUE_RETENTION_HOURS
+from custom_components.melcloudhome.const import (
+    DATA_LOOKBACK_HOURS_ENERGY,
+    DOMAIN,
+    HOUR_VALUE_RETENTION_HOURS,
+)
 
 from .conftest import (
     MOCK_CLIENT_PATH,
@@ -1181,3 +1185,53 @@ async def test_energy_polling_cancellation_on_shutdown(hass: HomeAssistant) -> N
         # Verify no additional energy fetches after unload
         # (Polling task should be cancelled)
         assert mock_client.get_energy_data.call_count == initial_calls
+
+
+@pytest.mark.asyncio
+async def test_energy_request_window_starts_on_the_hour(hass: HomeAssistant) -> None:
+    """Test that the energy request's "from" bound is floored to the hour.
+
+    The server sums only the samples at or after "from", so an unfloored bound
+    makes the oldest bucket a shrinking partial hour: every poll asks for a
+    smaller slice than the last, the value comes back lower, and the decrease
+    guard logs it as "possible API issue" ~4 times an hour per unit forever.
+    Measured on prod 2026-08-25 before the fix; see EnergyTrackerBase._energy_window.
+
+    Validates: the window's leading bucket is always requested whole
+    Tests through: the arguments the client is called with
+    """
+    mock_context = create_mock_ata_energy_context()
+    mock_energy_data = create_mock_energy_response([("2025-01-15T10:00:00Z", 500.0)])
+
+    with (
+        patch(MOCK_CLIENT_PATH) as mock_client_class,
+        patch(MOCK_STORE_PATH) as mock_store_class,
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_store = mock_store_class.return_value
+        mock_store.async_load = AsyncMock(return_value=None)
+        mock_store.async_save = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        mock_client.get_energy_data.assert_called()
+        from_time, to_time = mock_client.get_energy_data.call_args.args[1:3]
+
+        assert from_time.minute == 0
+        assert from_time.second == 0
+        assert from_time.microsecond == 0
+        # Flooring only ever widens the window, never narrows it
+        assert to_time - from_time >= timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -1235,3 +1235,27 @@ async def test_energy_request_window_starts_on_the_hour(hass: HomeAssistant) -> 
         assert from_time.microsecond == 0
         # Flooring only ever widens the window, never narrows it
         assert to_time - from_time >= timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)
+
+
+def test_energy_window_normalises_to_utc() -> None:
+    """Test that a local-aware "now" produces the same window as its UTC equal.
+
+    The request format carries no offset marker and strftime drops tzinfo, so an
+    un-normalised local-aware bound would query the wrong window silently.
+    """
+    from zoneinfo import ZoneInfo
+
+    from custom_components.melcloudhome.energy_tracker_base import EnergyTrackerBase
+
+    instant = datetime(2026, 8, 25, 7, 51, tzinfo=UTC)
+    from_utc, to_utc = EnergyTrackerBase._energy_window(instant)
+    from_local, to_local = EnergyTrackerBase._energy_window(
+        instant.astimezone(ZoneInfo("Europe/Skopje"))
+    )
+
+    assert (from_utc, to_utc) == (from_local, to_local)
+    assert from_utc.utcoffset() == timedelta(0)
+    assert from_utc.hour == 7  # floored in UTC, not in +02:00
+
+    with pytest.raises(ValueError, match="aware datetime"):
+        EnergyTrackerBase._energy_window(datetime(2026, 8, 25, 7, 51))

--- a/tests/integration/test_outdoor_temperature_sensor.py
+++ b/tests/integration/test_outdoor_temperature_sensor.py
@@ -272,3 +272,48 @@ async def test_idle_unit_reprobed_after_polling_interval(
     assert unit.outdoor_temp_reading.value == 15.0, (
         f"Expected 15.0°C after re-probe, got {unit.outdoor_temp_reading}"
     )
+
+
+async def test_outdoor_temp_failure_warns_once_per_streak(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a failing outdoor-temp poll warns once, not on every poll.
+
+    A failed poll resets the 30-minute timer and keeps the previous value, so
+    without a warning at INFO a unit failing every poll looks identical to an
+    idle one. Repeating the warning every poll would be its own noise problem,
+    so it marks entry to the failure streak only.
+
+    Validates: exactly one warning per failure streak
+    Tests through: the log, and hass.states for the retained sensor
+    """
+    unit = create_mock_ata_unit(
+        unit_id=LIVING_ROOM_ID,
+        name="Living Room AC",
+        has_outdoor_sensor=True,
+    )
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[unit])]
+    )
+
+    def configure(client: Any) -> None:
+        client.get_outdoor_temperature = AsyncMock(
+            side_effect=RuntimeError("upstream exploded")
+        )
+        client.ata = MagicMock()
+        client.ata.set_power = AsyncMock()
+        client.ata.set_temperature = AsyncMock()
+
+    caplog.clear()
+    await setup_ata_integration_custom(hass, mock_context, configure_client=configure)
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelname == "WARNING" and "keep its previous value" in r.getMessage()
+    ]
+    assert len(warnings) == 1, f"expected one warning, got {len(warnings)}"
+
+    state = hass.states.get("sensor.melcloudhome_0efc_87db_outdoor_temperature")
+    assert state is not None
+    assert state.state == "unknown"

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -43,7 +43,7 @@ logger = logging.getLogger(__name__)
 
 
 # Dataset id -> (base temperature, hidden). `hidden` mirrors the vendor's
-# hardcoded per-dataset-id constant (decompiled App.Shared.ReportTimeDataSet):
+# hardcoded per-dataset-id constant:
 # a presentation default, not a capability signal.
 #
 # Suffixed series the unit's hardware lacks are served as a constant 25. The


### PR DESCRIPTION
## Summary

Sits on #283 and needs nothing from it; the documentation correction here amends ADR-023, which #275 introduces. Energy requests floor the `from` bound to the hour and normalise both bounds to UTC, so the oldest hourly bucket is always requested whole: the server sums only the samples at or after `from`, and a bound inside the hour returns a partial slice of that bucket which shrinks as the poll clock advances. The measurements and the UTC-label evidence are in the docstring of `EnergyTrackerBase._energy_window`. Two further commits make the outdoor-temperature poll observable from outside: diagnostics gain the time of the last poll, and a unit whose poll starts failing says so once. The rest correct comments and documentation that no longer describe the code.

## Key changes

- `EnergyTrackerBase._energy_window` computes the request window, floors `from` to the hour, and converts both bounds with `astimezone(UTC)`. A naive `now` raises. The ATA and ATW trackers both take their window from it.
- `sensor_ata.py` and `docs/entities.md`: the ATA outdoor-temperature sensor is created for every unit, and both now say so.
- `telemetry_tracker.py`: a clause naming `sensor_atw.py` as where the zone-2 and boiler sensors are gated, so the request filter here reads as the cache-hygiene measure it is.
- ADR-023 and the mock's dataset comment rest the zone-2 assumption on evidence observable in a captured API response: the dataset ids, and the unfiltered eight-dataset set a single-zone unit receives.
- Diagnostics carry `outdoor_temp_last_poll_at`, stamped on every path. Read against `outdoor_temp_recorded_at` it separates "the endpoint has nothing newer" from "we have not asked recently". `outdoor_temp_last_error` answers neither, being cleared by any call that did not raise, including one that returned no reading.
- A unit entering an outdoor-temperature failure streak warns once, naming the unit and that the sensor keeps its previous value; recovery logs once at info. A failed poll resets the 30-minute timer and logged only at debug, so such a unit read as an idle one.

## What changes for users

- No sensor value or statistic changes, since the decrease guard already kept the correct value. The recurring "possible API issue" warning in the log stops.
- A new warning can appear: a unit whose outdoor-temperature poll begins failing logs once that the sensor will hold its previous value until a poll succeeds. It was previously silent at the default log level, so a first sighting of it means the condition was already there, not that this change caused it.

## Risks accepted

- The hour floor is applied in UTC on the evidence of live probes of two units at different offsets, with no vendor contract behind it, while `/report/v1/` on the same account labels its points in the unit's own zone (ADR-022). If some units label these buckets locally at an offset that is not a whole number of hours, the floored bound lands mid-bucket and their warnings persist. That persistence is the detection; the undo is a revert of the two energy commits.
- The outdoor-temperature failure warning guards a path derivable from the code, where a failed poll resets the 30-minute timer and logs only at debug, but which has not been observed happening on a real deployment. If such failures prove common the warning could become noise, and the streak gate is then the thing to tighten.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

- [x] `make pre-commit`: all hooks passed.
- [x] `make test-api`: 395 passed, 1 skipped, 1 xfailed, 16 deselected.
- [x] `make test-integration`: 259 passed, 1 warning.
- [x] `make test-e2e`: 16 passed, 397 deselected.
- [x] Three integration tests added. In `tests/integration/test_coordinator_energy.py`: the energy request's `from` bound is floored to the hour and the window only ever widens, and a local-aware `now` yields the same window as its UTC equivalent while a naive one raises. In `tests/integration/test_outdoor_temperature_sensor.py`: a failing outdoor-temperature poll warns exactly once per failure streak.
- [x] Live probes of the vendor energy endpoint, establishing that its hourly buckets are labelled in UTC; recorded in the `_energy_window` docstring.
- [x] Prod deployment of the energy commits: 2026-08-25 08:10:29 UTC, with all 62 shipped `.py` and `.json` files verified byte-identical by per-file SHA-256 to the branch as it stood at that commit.
- [ ] Prod deployment of the branch tip: the two observability commits landed after that deployment and have not run on a real installation. They add a diagnostics field and one warning, and change no request or entity state.
- [x] Prod confirmation that the recurring energy warning stops: zero "decreased from A to B kWh - keeping previous value (possible API issue)" warnings across 29 consecutive 30-minute energy poll rounds (2026-08-26 21:40 to 2026-08-27 12:10 local), and across the 8 rounds immediately following the deployment. This exercises the energy commits, which are what was deployed. Before the fix the warning fired on every round without exception. The deployment has run 51 hours without a restart; rounds between the two observed windows are no longer evidenceable because the container log has rotated past them, and the round count is derived from delta log lines so it is a floor rather than a census.
