### PR TITLE
fix(energy): floor the request window to whole UTC hours

### DIFF
--- a/custom_components/melcloudhome/energy_tracker_ata.py
+++ b/custom_components/melcloudhome/energy_tracker_ata.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from .api.client import MELCloudHomeClient
 from .api.models import AirToAirUnit, UserContext
-from .const import DATA_LOOKBACK_HOURS_ENERGY
 from .energy_tracker_base import EnergyTrackerBase
 
 if TYPE_CHECKING:
@@ -109,8 +108,7 @@ class ATAEnergyTracker(EnergyTrackerBase):
         )
 
         # Setup time range for energy data fetch
-        to_time = datetime.now(UTC)
-        from_time = to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)
+        from_time, to_time = self._energy_window(datetime.now(UTC))
 
         # Wrap with retry for automatic session recovery
         data = await self._execute_with_retry(

--- a/custom_components/melcloudhome/energy_tracker_atw.py
+++ b/custom_components/melcloudhome/energy_tracker_atw.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 from .api.client_atw import ATWControlClient
 from .api.models import UserContext
 from .api.models_atw import AirToWaterUnit
-from .const import DATA_LOOKBACK_HOURS_ENERGY
 from .energy_tracker_base import EnergyTrackerBase
 
 if TYPE_CHECKING:
@@ -120,8 +119,7 @@ class ATWEnergyTracker(EnergyTrackerBase):
         )
 
         # Setup time range for energy data fetch
-        to_time = datetime.now(UTC)
-        from_time = to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)
+        from_time, to_time = self._energy_window(datetime.now(UTC))
 
         # Fetch both consumed and produced
         await self._update_measure(unit, "consumed", from_time, to_time)

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -182,8 +182,15 @@ class EnergyTrackerBase(ABC):
         unit's own zone (ADR-022). Measured 2026-08-25: units at +1 and +2 both
         reported newest bucket 07:00 for one window, and pushing "to" three
         hours past either unit's local wall-clock surfaced nothing newer.
+
+        Both bounds are normalised to UTC first. The request format
+        ("%Y-%m-%d %H:%M", api/client.py) carries no offset marker, so strftime
+        drops the tzinfo silently: a local-aware `now` would query a shifted
+        window with no error anywhere. A naive `now` raises instead.
         """
-        to_time = now
+        if now.tzinfo is None:
+            raise ValueError("energy window needs an aware datetime, got naive")
+        to_time = now.astimezone(UTC)
         from_time = (to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)).replace(
             minute=0, second=0, microsecond=0
         )

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -176,6 +176,12 @@ class EnergyTrackerBase(ABC):
         0.567 again.
 
         The wider window is accepted - the floored request returns 200.
+
+        Flooring in UTC is correct because this endpoint labels its hour buckets
+        in UTC, unlike the /report/v1/ endpoints, which stamp points in the
+        unit's own zone (ADR-022). Measured 2026-08-25: units at +1 and +2 both
+        reported newest bucket 07:00 for one window, and pushing "to" three
+        hours past either unit's local wall-clock surfaced nothing newer.
         """
         to_time = now
         from_time = (to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)).replace(

--- a/custom_components/melcloudhome/energy_tracker_base.py
+++ b/custom_components/melcloudhome/energy_tracker_base.py
@@ -10,7 +10,11 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers.storage import Store
 
-from .const import HOUR_VALUE_RETENTION_HOURS, MAX_PLAUSIBLE_HOURLY_ENERGY_KWH
+from .const import (
+    DATA_LOOKBACK_HOURS_ENERGY,
+    HOUR_VALUE_RETENTION_HOURS,
+    MAX_PLAUSIBLE_HOURLY_ENERGY_KWH,
+)
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -158,6 +162,26 @@ class EnergyTrackerBase(ABC):
         # new energy data arrives.
         if self._clean_hour_values(datetime.now(UTC)):
             await self._save_energy_data()
+
+    @staticmethod
+    def _energy_window(now: datetime) -> tuple[datetime, datetime]:
+        """Return the (from, to) window for an energy request.
+
+        Do not remove the hour floor on "from". The server sums only the
+        samples at or after "from", so an unfloored bound makes the oldest
+        bucket a shrinking partial hour: each poll asks for a smaller slice
+        than the last, reads a lower value, and trips the decrease guard.
+        Measured 2026-08-25: bucket 2026-08-23 06:00 held 0.567 kWh, read as
+        0.433 at :16 past and 0.133 at :46; re-requesting it floored returned
+        0.567 again.
+
+        The wider window is accepted - the floored request returns 200.
+        """
+        to_time = now
+        from_time = (to_time - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)).replace(
+            minute=0, second=0, microsecond=0
+        )
+        return from_time, to_time
 
     @staticmethod
     def _parse_hour_timestamp(hour_timestamp: str) -> datetime | None:

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -21,7 +21,11 @@ from pytest_homeassistant_custom_component.common import (
     async_fire_time_changed,
 )
 
-from custom_components.melcloudhome.const import DOMAIN, HOUR_VALUE_RETENTION_HOURS
+from custom_components.melcloudhome.const import (
+    DATA_LOOKBACK_HOURS_ENERGY,
+    DOMAIN,
+    HOUR_VALUE_RETENTION_HOURS,
+)
 
 from .conftest import (
     MOCK_CLIENT_PATH,
@@ -1181,3 +1185,53 @@ async def test_energy_polling_cancellation_on_shutdown(hass: HomeAssistant) -> N
         # Verify no additional energy fetches after unload
         # (Polling task should be cancelled)
         assert mock_client.get_energy_data.call_count == initial_calls
+
+
+@pytest.mark.asyncio
+async def test_energy_request_window_starts_on_the_hour(hass: HomeAssistant) -> None:
+    """Test that the energy request's "from" bound is floored to the hour.
+
+    The server sums only the samples at or after "from", so an unfloored bound
+    makes the oldest bucket a shrinking partial hour: every poll asks for a
+    smaller slice than the last, the value comes back lower, and the decrease
+    guard logs it as "possible API issue" ~4 times an hour per unit forever.
+    Measured on prod 2026-08-25 before the fix; see EnergyTrackerBase._energy_window.
+
+    Validates: the window's leading bucket is always requested whole
+    Tests through: the arguments the client is called with
+    """
+    mock_context = create_mock_ata_energy_context()
+    mock_energy_data = create_mock_energy_response([("2025-01-15T10:00:00Z", 500.0)])
+
+    with (
+        patch(MOCK_CLIENT_PATH) as mock_client_class,
+        patch(MOCK_STORE_PATH) as mock_store_class,
+    ):
+        mock_client = mock_client_class.return_value
+        mock_client.login = AsyncMock()
+        mock_client.close = AsyncMock()
+        mock_client.get_user_context = AsyncMock(return_value=mock_context)
+        mock_client.get_energy_data = AsyncMock(return_value=mock_energy_data)
+        type(mock_client).is_authenticated = PropertyMock(return_value=True)
+
+        mock_store = mock_store_class.return_value
+        mock_store.async_load = AsyncMock(return_value=None)
+        mock_store.async_save = AsyncMock()
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password"},
+            unique_id="test@example.com",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        mock_client.get_energy_data.assert_called()
+        from_time, to_time = mock_client.get_energy_data.call_args.args[1:3]
+
+        assert from_time.minute == 0
+        assert from_time.second == 0
+        assert from_time.microsecond == 0
+        # Flooring only ever widens the window, never narrows it
+        assert to_time - from_time >= timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -1235,3 +1235,27 @@ async def test_energy_request_window_starts_on_the_hour(hass: HomeAssistant) -> 
         assert from_time.microsecond == 0
         # Flooring only ever widens the window, never narrows it
         assert to_time - from_time >= timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)
+
+
+def test_energy_window_normalises_to_utc() -> None:
+    """Test that a local-aware "now" produces the same window as its UTC equal.
+
+    The request format carries no offset marker and strftime drops tzinfo, so an
+    un-normalised local-aware bound would query the wrong window silently.
+    """
+    from zoneinfo import ZoneInfo
+
+    from custom_components.melcloudhome.energy_tracker_base import EnergyTrackerBase
+
+    instant = datetime(2026, 8, 25, 7, 51, tzinfo=UTC)
+    from_utc, to_utc = EnergyTrackerBase._energy_window(instant)
+    from_local, to_local = EnergyTrackerBase._energy_window(
+        instant.astimezone(ZoneInfo("Europe/Skopje"))
+    )
+
+    assert (from_utc, to_utc) == (from_local, to_local)
+    assert from_utc.utcoffset() == timedelta(0)
+    assert from_utc.hour == 7  # floored in UTC, not in +02:00
+
+    with pytest.raises(ValueError, match="aware datetime"):
+        EnergyTrackerBase._energy_window(datetime(2026, 8, 25, 7, 51))


### PR DESCRIPTION
## Summary

Sits on #283.

Both energy trackers now take their window from `EnergyTrackerBase._energy_window`: `to` normalised to UTC, `from` normalised and floored to the hour.

The server sums only the samples at or after `from`, so an unfloored `from` left the window's oldest bucket a shrinking partial hour: each poll asked for a smaller slice than the last, read a lower value, and tripped the decrease guard. Flooring asks for that bucket whole. Normalising matters because the request format carries no offset marker, so a local-aware bound would query a shifted window in silence; a naive one raises. The measurements, and why UTC is the zone to floor in, are in the `_energy_window` docstring (`custom_components/melcloudhome/energy_tracker_base.py`), with the contrast against `docs/decisions/022-reading-provenance.md`.

## What changes for users

- The energy decrease warnings stop appearing in the Home Assistant log. Recorded totals were correct throughout, because the guard keeps the previous value when it fires, so there is no history to repair and nothing to do.

## Risks accepted

Flooring in UTC rests on this endpoint labelling its hour buckets in UTC, measured against units at two whole-hour offsets east of UTC. Should some unit's buckets turn out to be labelled in its own zone, or sit at an offset that is not a whole hour, its oldest bucket becomes partial again and the decrease warnings return for that unit, which is how it would surface. Reverting this branch restores the previous window. Totals stay correct either way, since the guard keeps the previous value.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

- [x] `make pre-commit`: all hooks pass.
- [x] `make test-api`: 395 passed, 1 skipped, 16 deselected, 1 xfailed.
- [x] `make test-integration`: 258 passed, 1 warning. Two new tests in `tests/integration/test_coordinator_energy.py`: the `from` bound the client is called with lands on the hour and flooring only ever widens the window; a local-aware `now` yields the same window as its UTC equal, and a naive one raises.
- [x] `make test-e2e`: 16 passed, 397 deselected.
- [x] Prod deployment and soak: zero decrease-guard warnings across two days' uptime
