### PR TITLE
feat(diagnostics): stamp every outdoor-temperature poll, warn on failure

### DIFF
--- a/custom_components/melcloudhome/api/models_ata.py
+++ b/custom_components/melcloudhome/api/models_ata.py
@@ -141,6 +141,9 @@ class AirToAirUnit:
     # for telling "endpoint failing for this unit" apart from "no data yet".
     outdoor_temp_last_error: str | None = None
     outdoor_temp_last_error_at: datetime | None = None  # UTC-aware
+    # When a poll last completed, whatever it found (UTC-aware). Separates a
+    # stale endpoint from a stalled poll when read against recorded_at.
+    outdoor_temp_last_poll_at: datetime | None = None
     # Protection modes (from GET /context; null until ever configured on this unit)
     frost_protection: ProtectionModeState | None = None
     overheat_protection: ProtectionModeState | None = None

--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -206,6 +206,9 @@ class AirToWaterUnit:
     # for telling "endpoint failing for this unit" apart from "no data yet".
     outdoor_temp_last_error: str | None = None
     outdoor_temp_last_error_at: datetime | None = None  # UTC-aware
+    # When a poll last completed, whatever it found (UTC-aware). Separates a
+    # stale endpoint from a stalled poll when read against recorded_at.
+    outdoor_temp_last_poll_at: datetime | None = None
 
     # Holiday Mode & Frost Protection (read-only state)
     holiday_mode_enabled: bool = False

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -126,6 +126,10 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             str, datetime
         ] = {}  # Per-unit last poll time
 
+        # Units in an outdoor-temp failure streak. Warn on entry, stay quiet
+        # inside, re-arm on the next success.
+        self._outdoor_temp_failing: set[str] = set()
+
         # Initialize ATA control client
         self.control_client_ata = ATAControlClient(
             hass=hass,
@@ -252,6 +256,14 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             self.client.get_atw_outdoor_temperature,
             "ATW outdoor temperature",
         )
+
+        # A lapsing share removes a unit mid-streak; without this it never
+        # warns again when it returns still failing.
+        live_unit_ids: set[str] = set()
+        for building in context.buildings:
+            live_unit_ids.update(unit.id for unit in building.air_to_air_units)
+            live_unit_ids.update(unit.id for unit in building.air_to_water_units)
+        self._outdoor_temp_failing &= live_unit_ids
 
         # Update caches for O(1) lookups
         self._rebuild_caches(context)
@@ -657,6 +669,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 unit.outdoor_temp_reading = old_unit.outdoor_temp_reading
                 unit.outdoor_temp_last_error = old_unit.outdoor_temp_last_error
                 unit.outdoor_temp_last_error_at = old_unit.outdoor_temp_last_error_at
+                unit.outdoor_temp_last_poll_at = old_unit.outdoor_temp_last_poll_at
 
             if not self._should_poll_outdoor_temp(unit_id):
                 continue
@@ -669,6 +682,13 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 self._record_outdoor_temp_poll(unit_id)
                 unit.outdoor_temp_last_error = None
                 unit.outdoor_temp_last_error_at = None
+                unit.outdoor_temp_last_poll_at = datetime.now(UTC)
+
+                if unit_id in self._outdoor_temp_failing:
+                    self._outdoor_temp_failing.discard(unit_id)
+                    # Warning, not info: at WARNING the failure would
+                    # otherwise read as never closing.
+                    _LOGGER.warning("%s for %s is working again", log_label, unit.name)
 
                 if reading is not None:
                     unit.has_outdoor_temp_sensor = True
@@ -683,15 +703,26 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 else:
                     _LOGGER.debug("No %s data for %s", log_label, unit.name)
             except Exception as err:
+                failed_at = datetime.now(UTC)
                 self._record_outdoor_temp_poll(unit_id)
                 unit.outdoor_temp_last_error = f"{type(err).__name__}: {err}"
-                unit.outdoor_temp_last_error_at = datetime.now(UTC)
+                unit.outdoor_temp_last_error_at = failed_at
+                unit.outdoor_temp_last_poll_at = failed_at
                 _LOGGER.debug(
                     "Failed to fetch %s for %s",
                     log_label,
                     unit.name,
                     exc_info=True,
                 )
+                if unit_id not in self._outdoor_temp_failing:
+                    self._outdoor_temp_failing.add(unit_id)
+                    _LOGGER.warning(
+                        "%s for %s failed and the sensor will keep its previous "
+                        "value until a poll succeeds: %s",
+                        log_label,
+                        unit.name,
+                        err,
+                    )
 
     def _should_poll_outdoor_temp(self, unit_id: str) -> bool:
         """Check if outdoor temp should be polled for a specific unit."""

--- a/custom_components/melcloudhome/diagnostics_shared.py
+++ b/custom_components/melcloudhome/diagnostics_shared.py
@@ -25,4 +25,9 @@ def serialize_outdoor_temp_fields(
             if unit.outdoor_temp_last_error_at
             else None
         ),
+        "outdoor_temp_last_poll_at": (
+            unit.outdoor_temp_last_poll_at.isoformat()
+            if unit.outdoor_temp_last_poll_at
+            else None
+        ),
     }

--- a/custom_components/melcloudhome/sensor_ata.py
+++ b/custom_components/melcloudhome/sensor_ata.py
@@ -95,7 +95,6 @@ ATA_SENSOR_TYPES: tuple[ATASensorEntityDescription, ...] = (
         should_create_fn=lambda unit: unit.capabilities.has_energy_consumed_meter,
     ),
     # Outdoor temperature - ambient temperature from outdoor unit sensor
-    # Only created for devices where outdoor sensor detected during capability discovery
     # Updates every 30 minutes via trendsummary API endpoint
     ATASensorEntityDescription(
         key="outdoor_temperature",

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -35,7 +35,7 @@ For each air conditioning unit, the following entities are created:
 ### Sensors
 
 - **Room Temperature**: `sensor.melcloudhome_{short_id}_room_temperature`
-- **Outdoor Temperature**: `sensor.melcloudhome_{short_id}_outdoor_temperature` (if available)
+- **Outdoor Temperature**: `sensor.melcloudhome_{short_id}_outdoor_temperature`
 - **WiFi Signal**: `sensor.melcloudhome_{short_id}_wifi_signal` (diagnostic)
 - **Energy**: `sensor.melcloudhome_{short_id}_energy` (cumulative kWh)
 - **Frost Protection Minimum/Maximum**: `sensor.melcloudhome_{short_id}_frost_protection_minimum` / `_maximum` (°C, diagnostic; created when the API reports the `frostProtection` object — every ATA unit does, as a server-side default, whether or not the mode has ever been configured)

--- a/tests/integration/test_outdoor_temperature_sensor.py
+++ b/tests/integration/test_outdoor_temperature_sensor.py
@@ -272,3 +272,150 @@ async def test_idle_unit_reprobed_after_polling_interval(
     assert unit.outdoor_temp_reading.value == 15.0, (
         f"Expected 15.0°C after re-probe, got {unit.outdoor_temp_reading}"
     )
+
+
+async def test_outdoor_temp_failure_warns_once_per_streak(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a failing outdoor-temp poll warns on entry to the streak only.
+
+    A failed poll resets the 30-minute timer and keeps the previous value, so a
+    unit failing every poll looked identical to an idle one at prod's level.
+    Warning every poll would be its own noise problem, so it marks entry to the
+    streak, stays quiet inside it, and re-arms once a poll succeeds.
+
+    Validates: one warning on entering a streak, silence inside it, a recovery
+    line on the way out, and a fresh warning for the next streak
+    Tests through: the log, and hass.states for the retained sensor
+    """
+    unit = create_mock_ata_unit(
+        unit_id=LIVING_ROOM_ID,
+        name="Living Room AC",
+        has_outdoor_sensor=True,
+    )
+    mock_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[unit])]
+    )
+    boom = RuntimeError("upstream exploded")
+
+    def configure(client: Any) -> None:
+        client.get_outdoor_temperature = AsyncMock(side_effect=boom)
+        client.ata = MagicMock()
+        client.ata.set_power = AsyncMock()
+        client.ata.set_temperature = AsyncMock()
+
+    caplog.clear()
+    entry, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=configure
+    )
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    def failure_warnings() -> list[str]:
+        return [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "keep its previous value" in r.getMessage()
+        ]
+
+    def recovery_warnings() -> list[str]:
+        return [
+            r.getMessage()
+            for r in caplog.records
+            if r.levelname == "WARNING" and "is working again" in r.getMessage()
+        ]
+
+    async def poll_again() -> None:
+        # reset_outdoor_temp_polling clears only the 30-minute gate, so the
+        # streak state survives - which is what this test is about.
+        coordinator.reset_outdoor_temp_polling()
+        await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+        await hass.async_block_till_done()
+
+    assert len(failure_warnings()) == 1, "entering the streak should warn once"
+
+    state = hass.states.get("sensor.melcloudhome_0efc_87db_outdoor_temperature")
+    assert state is not None
+    assert state.state == "unknown"
+
+    # Second failing poll: still inside the streak, so still one warning. An
+    # unconditional warning would give two here.
+    await poll_again()
+    assert len(failure_warnings()) == 1, "a poll inside the streak must stay quiet"
+    assert recovery_warnings() == []
+
+    # A success closes the streak and says so.
+    mock_client.get_outdoor_temperature = AsyncMock(
+        return_value=Reading(11.0, RECORDED_AT)
+    )
+    await poll_again()
+    assert len(recovery_warnings()) == 1, "leaving the streak should log recovery"
+    assert len(failure_warnings()) == 1
+
+    state = hass.states.get("sensor.melcloudhome_0efc_87db_outdoor_temperature")
+    assert state is not None
+    assert state.state == "11.0"
+
+    # Failing again is a new streak, so it warns again.
+    mock_client.get_outdoor_temperature = AsyncMock(side_effect=boom)
+    await poll_again()
+    assert len(failure_warnings()) == 2, "a new streak should warn again"
+
+
+async def test_outdoor_temp_streak_forgotten_when_unit_leaves(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a unit leaving the account clears its failure streak.
+
+    Shared units disappear when a share lapses. If the streak outlived the
+    unit, one that came back still failing would never warn again.
+
+    Validates: a returning unit warns again rather than staying suppressed
+    Tests through: the log, across a context that drops then restores the unit
+    """
+    unit = create_mock_ata_unit(
+        unit_id=LIVING_ROOM_ID,
+        name="Living Room AC",
+        has_outdoor_sensor=True,
+    )
+    with_unit = create_mock_ata_user_context([create_mock_ata_building(units=[unit])])
+    without_unit = create_mock_ata_user_context([create_mock_ata_building(units=[])])
+    boom = RuntimeError("upstream exploded")
+
+    def configure(client: Any) -> None:
+        client.get_outdoor_temperature = AsyncMock(side_effect=boom)
+        client.ata = MagicMock()
+        client.ata.set_power = AsyncMock()
+        client.ata.set_temperature = AsyncMock()
+
+    caplog.clear()
+    entry, mock_client = await setup_ata_integration_custom(
+        hass, with_unit, configure_client=configure
+    )
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    def failure_warnings() -> int:
+        return len(
+            [
+                r
+                for r in caplog.records
+                if r.levelname == "WARNING"
+                and "keep its previous value" in r.getMessage()
+            ]
+        )
+
+    async def poll_again() -> None:
+        coordinator.reset_outdoor_temp_polling()
+        await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+        await hass.async_block_till_done()
+
+    assert failure_warnings() == 1
+
+    # The share lapses: the unit is gone from the context entirely.
+    mock_client.get_user_context = AsyncMock(return_value=without_unit)
+    await poll_again()
+    assert failure_warnings() == 1, "an absent unit must not warn"
+
+    # It comes back, still failing. Without pruning it would stay suppressed.
+    mock_client.get_user_context = AsyncMock(return_value=with_unit)
+    await poll_again()
+    assert failure_warnings() == 2, "a returning unit should warn again"


### PR DESCRIPTION
## Summary

Sits on #286.

Diagnostics record the reading and any error, which leaves an unchanging outdoor temperature ambiguous: the endpoint has nothing newer, or polling stopped. A poll stamp read against the reading's own `recorded_at` (`docs/decisions/022-reading-provenance.md`) separates them. A failed poll keeps the previous value and resets the 30-minute timer, so a unit failing every poll looks like an idle one in the log; entering a failure streak now warns once.

## Key changes

- `outdoor_temp_last_poll_at` on both unit models, stamped from one `now()` on the success and failure paths alike, carried across refreshes and serialised by `diagnostics_shared.py`.
- A per-unit failure-streak set gates the warning to the poll that opens a streak, and clears on the next success or when the unit leaves the account.
- The comment and `docs/entities.md` qualifier calling the ATA outdoor-temperature sensor conditional are dropped; every unit gets one (#53).

## What changes for users

- A failing outdoor-temperature poll writes one warning naming the unit, and one more when polling recovers. The sensor keeps its last value, so the remedy is to check that unit still reports to the vendor.
- A diagnostics download carries `outdoor_temp_last_poll_at` per unit.

## Risks accepted

Warning once per streak leaves an installation whose log has rotated past that line with a stale reading and no live signal; the diagnostics stamp identifies it. That stamp duplicates a poll time the coordinator already keeps, accepted because the diagnostics serialisers take a unit; the two would drift if a later path stamped only one. Reverting the branch restores current behaviour.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

- [x] `make pre-commit`: all hooks pass.
- [x] `make test-api`: 395 passed, 1 skipped, 16 deselected, 1 xfailed.
- [x] `make test-integration`: 260 passed, 1 warning. Two new tests in `tests/integration/test_outdoor_temperature_sensor.py`: four polls assert one warning on entering a streak, silence inside it, a recovery line on success, and a fresh warning for the next streak; a unit dropped from the context and restored still failing warns again. Both checked by mutation, where removing either guard fails its test.
- [x] `make test-e2e`: 16 passed, 397 deselected.
- [x] Prod deployment: deployed 2026-08-27, byte-identical by sha256 across the five changed files. `outdoor_temp_last_poll_at` is populated for all 8 devices; read against `outdoor_temp_recorded_at` it showed two units serving readings 5 hours and 3.6 hours stale against a fresh poll, which is the ambiguity the field exists to resolve.
- [x] Failure and recovery path, in a live Home Assistant against a mock forced to 500 on both outdoor-temperature endpoints: four units across both device types each warned once on entering the streak; two further failing rounds produced no repeat; and when the endpoint returned, three units logged one recovery each at warning level while a fourth, still failing on an unrelated 429, stayed suppressed.
- [ ] Failure path against the real endpoint: not seen since deployment.
