### PR TITLE
fix(ata): reject unlisted fan speeds and flatten names at parse time

### DIFF
--- a/custom_components/melcloudhome/api/const_ata.py
+++ b/custom_components/melcloudhome/api/const_ata.py
@@ -68,6 +68,16 @@ VANE_NUMERIC_TO_WORD = {
 # "Auto", and reports "Off" when it is not running. All six were observed on
 # real hardware on 2026-08-28. Anything outside this list is rejected at parse
 # time, because the sensor is a device_class=ENUM whose options derive from it.
+#
+# This is the vocabulary observed so far, NOT a proven ceiling.
+# `numberOfFanSpeeds` does not bound the field: on 2026-08-28 a unit
+# advertising `numberOfFanSpeeds: 3`, set to "Three", reported "Four" in the
+# same /context object (read from the API directly, not through this parser).
+# Whether the unit has more taps than it advertises or reports on a different
+# internal scale is unknown, so a unit at the top of a five-speed range might
+# report something above "Five". Do not add speculative values here: an
+# unlisted value warns once and reads `unknown`, and that warning is the only
+# way we would find out.
 ACTUAL_FAN_SPEEDS = [
     "Off",
     "One",

--- a/custom_components/melcloudhome/api/const_ata.py
+++ b/custom_components/melcloudhome/api/const_ata.py
@@ -63,6 +63,20 @@ VANE_NUMERIC_TO_WORD = {
     "7": "Swing",
 }
 
+# ActualFanSpeed values, as the API words them. The same ordinal series as
+# FAN_SPEEDS, except a running unit reports the speed it picked rather than
+# "Auto", and reports "Off" when it is not running. All six were observed on
+# real hardware on 2026-08-28. Anything outside this list is rejected at parse
+# time, because the sensor is a device_class=ENUM whose options derive from it.
+ACTUAL_FAN_SPEEDS = [
+    "Off",
+    "One",
+    "Two",
+    "Three",
+    "Four",
+    "Five",
+]
+
 # Fan Speed Mappings (Control API numeric strings <-> word strings)
 # Used for normalization when API returns "0"-"5" but we use "Auto", "One"-"Five"
 FAN_SPEED_NUMERIC_TO_WORD = {
@@ -93,6 +107,7 @@ TEMP_MIN_COOL_DRY = 16.0
 # Note: Headers are constructed inline by the API client
 
 __all__ = [
+    "ACTUAL_FAN_SPEEDS",
     "API_CONTROL_UNIT",
     "API_FIELD_AIR_TO_AIR_UNITS",
     "FAN_SPEEDS",

--- a/custom_components/melcloudhome/api/const_ata.py
+++ b/custom_components/melcloudhome/api/const_ata.py
@@ -76,6 +76,10 @@ VANE_NUMERIC_TO_WORD = {
 # and nothing has been observed above "Five". Do not add speculative values
 # here: an unlisted value warns once and reads `unknown`, and that warning is
 # the only way we would find out the range is wider.
+#
+# Adding an observed value is two places, not one: the sensor's `options` derive
+# from this list, but each of the 14 files under `translations/` needs a
+# matching `state` key or the new value shows untranslated everywhere.
 ACTUAL_FAN_SPEEDS = [
     "Off",
     "One",

--- a/custom_components/melcloudhome/api/const_ata.py
+++ b/custom_components/melcloudhome/api/const_ata.py
@@ -70,14 +70,12 @@ VANE_NUMERIC_TO_WORD = {
 # time, because the sensor is a device_class=ENUM whose options derive from it.
 #
 # This is the vocabulary observed so far, NOT a proven ceiling.
-# `numberOfFanSpeeds` does not bound the field: on 2026-08-28 a unit
-# advertising `numberOfFanSpeeds: 3`, set to "Three", reported "Four" in the
-# same /context object (read from the API directly, not through this parser).
-# Whether the unit has more taps than it advertises or reports on a different
-# internal scale is unknown, so a unit at the top of a five-speed range might
-# report something above "Five". Do not add speculative values here: an
-# unlisted value warns once and reads `unknown`, and that warning is the only
-# way we would find out.
+# `numberOfFanSpeeds` does not bound the field: on 2026-08-28 all three
+# three-speed units on the test account reported "Four" while set to "Three",
+# read from /context directly rather than through this parser. Why is unknown,
+# and nothing has been observed above "Five". Do not add speculative values
+# here: an unlisted value warns once and reads `unknown`, and that warning is
+# the only way we would find out the range is wider.
 ACTUAL_FAN_SPEEDS = [
     "Off",
     "One",

--- a/custom_components/melcloudhome/api/models.py
+++ b/custom_components/melcloudhome/api/models.py
@@ -11,6 +11,7 @@ from typing import Any
 from . import const_ata, const_atw, const_shared
 from .models_ata import AirToAirUnit
 from .models_atw import AirToWaterUnit
+from .parsing import strip_line_breaks
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -58,9 +59,12 @@ class Building:
         # Parse A2W units (NEW)
         a2w_units_data = data.get(const_atw.API_FIELD_AIR_TO_WATER_UNITS, [])
 
+        # Flattened before the log below as well as the field: a building name
+        # is app-chosen too (see models_ata.from_dict).
+        building_name = strip_line_breaks(data.get("name", "Unknown"))
+
         # DEBUG: Log building context for ATW units
         if a2w_units_data:
-            building_name = data.get("name", "Unknown")
             _LOGGER.debug(
                 "[Building '%s'] Processing %d ATW unit(s)",
                 building_name,
@@ -71,7 +75,7 @@ class Building:
 
         return cls(
             id=data["id"],
-            name=data.get("name", "Unknown"),
+            name=building_name,
             is_guest=is_guest,
             air_to_air_units=a2a_units,
             air_to_water_units=a2w_units,

--- a/custom_components/melcloudhome/api/models.py
+++ b/custom_components/melcloudhome/api/models.py
@@ -59,9 +59,9 @@ class Building:
         # Parse A2W units (NEW)
         a2w_units_data = data.get(const_atw.API_FIELD_AIR_TO_WATER_UNITS, [])
 
-        # Flattened before the log below as well as the field: a building name
-        # is app-chosen too (see models_ata.from_dict).
-        building_name = strip_line_breaks(data.get("name", "Unknown"))
+        # `or` rather than a get default: an explicit null would otherwise
+        # stringify to "None" and reach HA as a suggested area of that name.
+        building_name = strip_line_breaks(data.get("name") or "Unknown")
 
         # DEBUG: Log building context for ATW units
         if a2w_units_data:

--- a/custom_components/melcloudhome/api/models_ata.py
+++ b/custom_components/melcloudhome/api/models_ata.py
@@ -17,7 +17,7 @@ from .parsing import (
     Reading,
     parse_bool as _parse_bool,
     parse_float as _parse_float,
-    sanitize_for_log,
+    strip_line_breaks,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,8 +60,8 @@ def _parse_actual_fan_speed(value: object, unit_name: object) -> str | None:
         _LOGGER.warning(
             "%s reported the fan speed %s, which this integration does not "
             "recognise, so its actual fan speed sensor will show as unknown",
-            sanitize_for_log(unit_name),
-            sanitize_for_log(value),
+            strip_line_breaks(unit_name),
+            strip_line_breaks(value),
         )
     return None
 
@@ -253,9 +253,14 @@ class AirToAirUnit:
         error_code_value = settings.get("ErrorCode", "")
         error_code = error_code_value if error_code_value else None
 
+        # The display name is chosen in the MELCloud app, so on a shared
+        # building it is somebody else's string. Flatten it once here and every
+        # log line and entity name built from it is safe by construction.
+        name = strip_line_breaks(data.get("givenDisplayName", "Unknown"))
+
         return cls(
             id=data["id"],
-            name=data.get("givenDisplayName", "Unknown"),
+            name=name,
             power=_parse_bool(settings.get("Power")),
             operation_mode=settings.get("OperationMode", OPERATION_MODE_HEAT),
             set_temperature=_parse_float(settings.get("SetTemperature")),
@@ -265,8 +270,7 @@ class AirToAirUnit:
             # unit cannot be. Anything unrecognised becomes None here, so the
             # ENUM sensor reads `unknown` rather than raising on the state write.
             actual_fan_speed=_parse_actual_fan_speed(
-                settings.get("ActualFanSpeed"),
-                data.get("givenDisplayName", "Unknown"),
+                settings.get("ActualFanSpeed"), name
             ),
             vane_vertical_direction=normalize_vertical_vane(
                 settings.get("VaneVerticalDirection")

--- a/custom_components/melcloudhome/api/models_ata.py
+++ b/custom_components/melcloudhome/api/models_ata.py
@@ -1,10 +1,12 @@
 """Air-to-Air (A/C) data models for MELCloud Home API."""
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
 from .const_ata import (
+    ACTUAL_FAN_SPEEDS,
     FAN_SPEED_NUMERIC_TO_WORD,
     OPERATION_MODE_HEAT,
     VANE_HORIZONTAL_AMERICAN_TO_BRITISH,
@@ -15,7 +17,54 @@ from .parsing import (
     Reading,
     parse_bool as _parse_bool,
     parse_float as _parse_float,
+    sanitize_for_log,
 )
+
+_LOGGER = logging.getLogger(__name__)
+
+# Keyed by lowercase so a change of case upstream reads as the same speed
+# rather than as an unknown one.
+_ACTUAL_FAN_SPEED_BY_KEY = {speed.lower(): speed for speed in ACTUAL_FAN_SPEEDS}
+
+# Unknown values already logged. from_dict runs on every poll and every
+# socket-triggered refresh, so without this a single unrecognised value would
+# write a warning every few seconds for as long as the unit reports it.
+#
+# ponytail: unbounded in principle, capped in practice. Only distinct unknown
+# values grow it, and the cap stops a unit that reports garbage from growing it
+# without limit - at the cost of going quiet after that many. Swap for an
+# LRU if a real device ever reaches the cap.
+_MAX_WARNED_FAN_SPEEDS = 20
+_warned_fan_speeds: set[str] = set()
+
+
+def _parse_actual_fan_speed(value: object, unit_name: object) -> str | None:
+    """Return a recognised ActualFanSpeed word, or None having warned once.
+
+    The sensor built on this field is a device_class=ENUM whose options come
+    from ACTUAL_FAN_SPEEDS, and HA raises on a state write outside an ENUM's
+    options. Returning None instead leaves the sensor reading `unknown`, which
+    degrades one sensor rather than failing the write.
+    """
+    if value is None or value == "":
+        return None
+    known = _ACTUAL_FAN_SPEED_BY_KEY.get(str(value).lower())
+    if known is not None:
+        return known
+    text = str(value)
+    if (
+        text not in _warned_fan_speeds
+        and len(_warned_fan_speeds) < _MAX_WARNED_FAN_SPEEDS
+    ):
+        _warned_fan_speeds.add(text)
+        _LOGGER.warning(
+            "%s reported the fan speed %s, which this integration does not "
+            "recognise, so its actual fan speed sensor will show as unknown",
+            sanitize_for_log(unit_name),
+            sanitize_for_log(value),
+        )
+    return None
+
 
 # ==============================================================================
 # Air-to-Air (A/C) Models
@@ -213,8 +262,12 @@ class AirToAirUnit:
             room_temperature=_parse_float(settings.get("RoomTemperature")),
             set_fan_speed=normalize_fan_speed(settings.get("SetFanSpeed")),
             # Not normalize_fan_speed: that maps "0" to "Auto", which a running
-            # unit cannot be.
-            actual_fan_speed=settings.get("ActualFanSpeed"),
+            # unit cannot be. Anything unrecognised becomes None here, so the
+            # ENUM sensor reads `unknown` rather than raising on the state write.
+            actual_fan_speed=_parse_actual_fan_speed(
+                settings.get("ActualFanSpeed"),
+                data.get("givenDisplayName", "Unknown"),
+            ),
             vane_vertical_direction=normalize_vertical_vane(
                 settings.get("VaneVerticalDirection")
             ),

--- a/custom_components/melcloudhome/api/models_ata.py
+++ b/custom_components/melcloudhome/api/models_ata.py
@@ -3,6 +3,7 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime
+from functools import lru_cache
 from typing import Any
 
 from .const_ata import (
@@ -22,53 +23,44 @@ from .parsing import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Keyed by lowercase so a change of case upstream reads as the same speed
-# rather than as an unknown one.
-_ACTUAL_FAN_SPEED_BY_KEY = {speed.lower(): speed for speed in ACTUAL_FAN_SPEEDS}
 
-# Unknown values already logged. from_dict runs on every poll and every
-# socket-triggered refresh, so without this a single unrecognised value would
-# write a warning every few seconds for as long as the unit reports it.
-#
-# ponytail: unbounded in principle, capped in practice. Only distinct unknown
-# values grow it, and the cap stops a unit that reports garbage from growing it
-# without limit - at the cost of going quiet after that many. Swap for an
-# LRU if a real device ever reaches the cap.
-_MAX_WARNED_FAN_SPEEDS = 20
-_warned_fan_speeds: set[str] = set()
+@lru_cache(maxsize=20)
+def _warn_unknown_fan_speed(speed: str, unit_name: str) -> None:
+    """Log an unrecognised fan speed, once per unit that reports it.
+
+    Cached for the side effect rather than the return value: `from_dict` runs on
+    every poll and every socket-triggered refresh, so without this a single
+    unrecognised value would write a warning every few seconds. `maxsize` bounds
+    the record and evicts the oldest, so a unit reporting varying rubbish cannot
+    grow it without limit or silence it permanently.
+    """
+    _LOGGER.warning(
+        "%s reported the fan speed %s, which this integration does not "
+        "recognise, so its actual fan speed sensor will show as unknown",
+        unit_name,
+        strip_line_breaks(speed),
+    )
 
 
-def _parse_actual_fan_speed(value: object, unit_name: object) -> str | None:
+def _parse_actual_fan_speed(value: object, unit_name: str) -> str | None:
     """Return a recognised ActualFanSpeed word, or None having warned once.
 
-    The sensor built on this field is a device_class=ENUM whose options come
-    from ACTUAL_FAN_SPEEDS, and HA raises on a state write outside an ENUM's
-    options. Returning None instead leaves the sensor reading `unknown`, which
-    degrades one sensor rather than failing the write.
+    The sensor built on this field is a device_class=ENUM, and HA raises on a
+    state write outside an ENUM's options. Returning None leaves the sensor
+    reading `unknown`, degrading one sensor rather than failing the write.
+
+    Numeric forms are rejected rather than mapped. The socket sends this field
+    numerically but discards values before they reach here, and every captured
+    /context serves words, so a numeric map would handle a variation never seen
+    on this path and would consume the warning that is how we would find out.
     """
     if value is None or value == "":
         return None
-    known = _ACTUAL_FAN_SPEED_BY_KEY.get(str(value).lower())
-    if known is not None:
-        return known
     text = str(value)
-    if (
-        text not in _warned_fan_speeds
-        and len(_warned_fan_speeds) < _MAX_WARNED_FAN_SPEEDS
-    ):
-        _warned_fan_speeds.add(text)
-        _LOGGER.warning(
-            "%s reported the fan speed %s, which this integration does not "
-            "recognise, so its actual fan speed sensor will show as unknown",
-            strip_line_breaks(unit_name),
-            strip_line_breaks(value),
-        )
+    if text in ACTUAL_FAN_SPEEDS:
+        return text
+    _warn_unknown_fan_speed(text, unit_name)
     return None
-
-
-# ==============================================================================
-# Air-to-Air (A/C) Models
-# ==============================================================================
 
 
 @dataclass
@@ -253,10 +245,7 @@ class AirToAirUnit:
         error_code_value = settings.get("ErrorCode", "")
         error_code = error_code_value if error_code_value else None
 
-        # The display name is chosen in the MELCloud app, so on a shared
-        # building it is somebody else's string. Flatten it once here and every
-        # log line and entity name built from it is safe by construction.
-        name = strip_line_breaks(data.get("givenDisplayName", "Unknown"))
+        name = strip_line_breaks(data.get("givenDisplayName") or "Unknown")
 
         return cls(
             id=data["id"],

--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -10,6 +10,7 @@ from .parsing import (
     Reading,
     parse_bool as _parse_bool,
     parse_float as _parse_float,
+    strip_line_breaks,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -275,7 +276,9 @@ class AirToWaterUnit:
         return cls(
             # Identity
             id=data["id"],
-            name=data.get("givenDisplayName", "Unknown"),
+            # See models_ata.from_dict: an app-chosen name on a shared building
+            # is somebody else's string, so flatten it at the boundary.
+            name=strip_line_breaks(data.get("givenDisplayName", "Unknown")),
             # Power
             power=power,
             in_standby_mode=_parse_bool(settings.get("InStandbyMode")),

--- a/custom_components/melcloudhome/api/models_atw.py
+++ b/custom_components/melcloudhome/api/models_atw.py
@@ -276,9 +276,7 @@ class AirToWaterUnit:
         return cls(
             # Identity
             id=data["id"],
-            # See models_ata.from_dict: an app-chosen name on a shared building
-            # is somebody else's string, so flatten it at the boundary.
-            name=strip_line_breaks(data.get("givenDisplayName", "Unknown")),
+            name=strip_line_breaks(data.get("givenDisplayName") or "Unknown"),
             # Power
             power=power,
             in_standby_mode=_parse_bool(settings.get("InStandbyMode")),

--- a/custom_components/melcloudhome/api/parsing.py
+++ b/custom_components/melcloudhome/api/parsing.py
@@ -90,12 +90,19 @@ def parse_api_timestamp(value: str, tz: tzinfo = UTC) -> datetime:
     return parsed.astimezone(UTC)
 
 
-def sanitize_for_log(value: object) -> str:
-    """Strip CR/LF from server-supplied strings so they can't forge log lines.
+def strip_line_breaks(value: object) -> str:
+    """Flatten CR/LF out of a server-supplied string.
 
-    Unconditional on purpose: CodeQL only recognizes unconditional barriers, so
-    adding a branch here would silently stop this working as a `py/log-injection`
-    barrier for every caller.
+    Applied to every name and value the API hands us that can reach a log line
+    or a Home Assistant entity name. A device name is chosen by whoever owns the
+    device in the MELCloud app, and on a shared building that is somebody else's
+    account, so a name carrying CR/LF could forge log lines in a reader's own
+    log (CWE-117) - which matters most when that log is being read to diagnose a
+    fault, or pasted into an issue.
+
+    Unconditional on purpose: CodeQL's `py/log-injection` only recognizes a
+    helper as a barrier when every path through it strips, so adding a branch
+    here would silently stop this working for every caller.
     """
     return str(value).replace("\r", "").replace("\n", " ")
 

--- a/custom_components/melcloudhome/api/parsing.py
+++ b/custom_components/melcloudhome/api/parsing.py
@@ -100,11 +100,25 @@ def strip_line_breaks(value: object) -> str:
     log (CWE-117) - which matters most when that log is being read to diagnose a
     fault, or pasted into an issue.
 
-    Unconditional on purpose: CodeQL's `py/log-injection` only recognizes a
-    helper as a barrier when every path through it strips, so adding a branch
-    here would silently stop this working for every caller.
+    Covers the separators `str.splitlines()` honours, not just CR/LF, because a
+    browser log viewer or log shipper splits on those too. Every one becomes a
+    space rather than vanishing: the same string is a Home Assistant device
+    name, where dropping a character would silently corrupt what a user sees.
+
+    Unconditional and written as a chain on purpose: CodeQL's `py/log-injection`
+    recognizes a helper as a barrier only when every path through it strips, and
+    it matches chained `.replace()` calls, so a branch or a loop here would
+    silently stop this working for every caller.
     """
-    return str(value).replace("\r", "").replace("\n", " ")
+    return (
+        str(value)
+        .replace("\r\n", " ")
+        .replace("\n", " ")
+        .replace("\r", " ")
+        .replace("\u2028", " ")
+        .replace("\u2029", " ")
+        .replace("\x85", " ")
+    )
 
 
 class Reading(NamedTuple):

--- a/custom_components/melcloudhome/api/parsing.py
+++ b/custom_components/melcloudhome/api/parsing.py
@@ -90,6 +90,16 @@ def parse_api_timestamp(value: str, tz: tzinfo = UTC) -> datetime:
     return parsed.astimezone(UTC)
 
 
+def sanitize_for_log(value: object) -> str:
+    """Strip CR/LF from server-supplied strings so they can't forge log lines.
+
+    Unconditional on purpose: CodeQL only recognizes unconditional barriers, so
+    adding a branch here would silently stop this working as a `py/log-injection`
+    barrier for every caller.
+    """
+    return str(value).replace("\r", "").replace("\n", " ")
+
+
 class Reading(NamedTuple):
     """A measured value with the time the unit actually recorded it.
 

--- a/custom_components/melcloudhome/api/websocket.py
+++ b/custom_components/melcloudhome/api/websocket.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from .auth import _redact_url
+from .parsing import sanitize_for_log
 
 if TYPE_CHECKING:
     from .client import MELCloudHomeClient
@@ -45,14 +46,6 @@ _HEARTBEAT = 30
 # backoff forever — each cycle costing a hash fetch and possibly a token
 # refresh.
 _STABLE_SESSION_SECS = 60
-
-
-def _sanitize(value: object) -> str:
-    """Strip CR/LF from server-supplied strings so they can't forge log lines.
-
-    Unconditional on purpose: CodeQL only recognizes unconditional barriers.
-    """
-    return str(value).replace("\r", "").replace("\n", " ")
 
 
 # Callback invoked for each unit that reports a state change:
@@ -198,12 +191,12 @@ class MELCloudHomeWebSocket:
                 continue
             settings = data.get("settings")
             names = [
-                _sanitize(s["name"])
+                sanitize_for_log(s["name"])
                 for s in (settings if isinstance(settings, list) else [])
                 if isinstance(s, dict) and s.get("name")
             ]
             try:
-                await self._on_delta(_sanitize(unit_id), names)
+                await self._on_delta(sanitize_for_log(unit_id), names)
             except Exception:
                 # A misbehaving handler must never kill the listen loop.
                 _LOGGER.debug("WebSocket delta handler failed", exc_info=True)

--- a/custom_components/melcloudhome/api/websocket.py
+++ b/custom_components/melcloudhome/api/websocket.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 
 from .auth import _redact_url
-from .parsing import sanitize_for_log
+from .parsing import strip_line_breaks
 
 if TYPE_CHECKING:
     from .client import MELCloudHomeClient
@@ -191,12 +191,12 @@ class MELCloudHomeWebSocket:
                 continue
             settings = data.get("settings")
             names = [
-                sanitize_for_log(s["name"])
+                strip_line_breaks(s["name"])
                 for s in (settings if isinstance(settings, list) else [])
                 if isinstance(s, dict) and s.get("name")
             ]
             try:
-                await self._on_delta(sanitize_for_log(unit_id), names)
+                await self._on_delta(strip_line_breaks(unit_id), names)
             except Exception:
                 # A misbehaving handler must never kill the listen loop.
                 _LOGGER.debug("WebSocket delta handler failed", exc_info=True)

--- a/custom_components/melcloudhome/sensor_ata.py
+++ b/custom_components/melcloudhome/sensor_ata.py
@@ -73,8 +73,6 @@ ATA_SENSOR_TYPES: tuple[ATASensorEntityDescription, ...] = (
     ),
     # The speed the unit runs at, invisible under SetFanSpeed=Auto. "auto" is
     # not among the options because a running unit reports the speed it picked.
-    # numberOfFanSpeeds does NOT cap the value, despite what this comment said
-    # when the sensor was added - see ACTUAL_FAN_SPEEDS for the counter-example.
     ATASensorEntityDescription(
         key="actual_fan_speed",
         translation_key="actual_fan_speed",

--- a/custom_components/melcloudhome/sensor_ata.py
+++ b/custom_components/melcloudhome/sensor_ata.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .api.const_ata import ACTUAL_FAN_SPEEDS
 from .api.models import AirToAirUnit, Building
 from .api.parsing import Reading
 from .helpers import (
@@ -77,7 +78,9 @@ ATA_SENSOR_TYPES: tuple[ATASensorEntityDescription, ...] = (
         key="actual_fan_speed",
         translation_key="actual_fan_speed",
         device_class=SensorDeviceClass.ENUM,
-        options=["off", "one", "two", "three", "four", "five"],
+        # Derived, so the parser's accepted set and the entity's options
+        # cannot drift: models_ata rejects anything outside ACTUAL_FAN_SPEEDS.
+        options=[speed.lower() for speed in ACTUAL_FAN_SPEEDS],
         value_fn=lambda unit: (
             unit.actual_fan_speed.lower() if unit.actual_fan_speed else None
         ),

--- a/custom_components/melcloudhome/sensor_ata.py
+++ b/custom_components/melcloudhome/sensor_ata.py
@@ -71,9 +71,10 @@ ATA_SENSOR_TYPES: tuple[ATASensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         value_fn=lambda unit: unit.room_temperature,
     ),
-    # The speed the unit runs at, invisible under SetFanSpeed=Auto.
-    # numberOfFanSpeeds caps the series at five; "auto" is not among them,
-    # because a running unit reports the speed it picked.
+    # The speed the unit runs at, invisible under SetFanSpeed=Auto. "auto" is
+    # not among the options because a running unit reports the speed it picked.
+    # numberOfFanSpeeds does NOT cap the value, despite what this comment said
+    # when the sensor was added - see ACTUAL_FAN_SPEEDS for the counter-example.
     ATASensorEntityDescription(
         key="actual_fan_speed",
         translation_key="actual_fan_speed",

--- a/dev-config-template/.storage/lovelace.melcloudhome_testing
+++ b/dev-config-template/.storage/lovelace.melcloudhome_testing
@@ -338,6 +338,81 @@
        ]
       }
      ]
+    },
+    {
+     "type": "sections",
+     "max_columns": 4,
+     "title": "ATA fan speed",
+     "path": "ata-fan",
+     "sections": [
+      {
+       "type": "grid",
+       "column_span": 4,
+       "cards": [
+        {
+         "type": "heading",
+         "heading": "Actual fan speed",
+         "heading_style": "title"
+        },
+        {
+         "type": "history-graph",
+         "hours_to_show": 24,
+         "title": "Actual fan speed (24h) - never Auto, Off means powered down",
+         "entities": [
+          "sensor.my_home_melcloudhome_0efc_87db_actual_fan_speed",
+          "sensor.my_home_melcloudhome_bf8d_5119_actual_fan_speed"
+         ],
+         "grid_options": {
+          "columns": "full",
+          "rows": "auto"
+         }
+        },
+        {
+         "type": "heading",
+         "heading": "Requested mode, for correlation",
+         "heading_style": "title"
+        },
+        {
+         "type": "history-graph",
+         "hours_to_show": 24,
+         "title": "Power and HVAC mode (24h)",
+         "entities": [
+          "climate.my_home_melcloudhome_0efc_87db_climate",
+          "climate.my_home_melcloudhome_bf8d_5119_climate"
+         ],
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "heading",
+         "heading": "Changes as text",
+         "heading_style": "title"
+        },
+        {
+         "type": "logbook",
+         "hours_to_show": 24,
+         "target": {
+          "entity_id": [
+           "sensor.my_home_melcloudhome_0efc_87db_actual_fan_speed",
+           "sensor.my_home_melcloudhome_bf8d_5119_actual_fan_speed"
+          ]
+         },
+         "grid_options": {
+          "columns": "full"
+         }
+        },
+        {
+         "type": "markdown",
+         "title": "Current",
+         "content": "| unit | requested | actual |\n|---|---|---|\n| My Home Living Room AC (mock) | {{ state_attr('climate.my_home_melcloudhome_0efc_87db_climate', 'fan_mode') }} | {{ states('sensor.my_home_melcloudhome_0efc_87db_actual_fan_speed') }} |\n| Orchard Cottage Living Room (mock) | {{ state_attr('climate.my_home_melcloudhome_bf8d_5119_climate', 'fan_mode') }} | {{ states('sensor.my_home_melcloudhome_bf8d_5119_actual_fan_speed') }} |",
+         "grid_options": {
+          "columns": "full"
+         }
+        }
+       ]
+      }
+     ]
     }
    ]
   }

--- a/dev-config-template/.storage/lovelace.melcloudhome_testing
+++ b/dev-config-template/.storage/lovelace.melcloudhome_testing
@@ -369,24 +369,7 @@
         },
         {
          "type": "heading",
-         "heading": "Requested mode, for correlation",
-         "heading_style": "title"
-        },
-        {
-         "type": "history-graph",
-         "hours_to_show": 24,
-         "title": "Power and HVAC mode (24h)",
-         "entities": [
-          "climate.my_home_melcloudhome_0efc_87db_climate",
-          "climate.my_home_melcloudhome_bf8d_5119_climate"
-         ],
-         "grid_options": {
-          "columns": "full"
-         }
-        },
-        {
-         "type": "heading",
-         "heading": "Changes as text",
+         "heading": "Changes as text, fan and mode interleaved",
          "heading_style": "title"
         },
         {
@@ -395,7 +378,9 @@
          "target": {
           "entity_id": [
            "sensor.my_home_melcloudhome_0efc_87db_actual_fan_speed",
-           "sensor.my_home_melcloudhome_bf8d_5119_actual_fan_speed"
+           "sensor.my_home_melcloudhome_bf8d_5119_actual_fan_speed",
+           "climate.my_home_melcloudhome_0efc_87db_climate",
+           "climate.my_home_melcloudhome_bf8d_5119_climate"
           ]
          },
          "grid_options": {
@@ -405,7 +390,7 @@
         {
          "type": "markdown",
          "title": "Current",
-         "content": "| unit | requested | actual |\n|---|---|---|\n| My Home Living Room AC (mock) | {{ state_attr('climate.my_home_melcloudhome_0efc_87db_climate', 'fan_mode') }} | {{ states('sensor.my_home_melcloudhome_0efc_87db_actual_fan_speed') }} |\n| Orchard Cottage Living Room (mock) | {{ state_attr('climate.my_home_melcloudhome_bf8d_5119_climate', 'fan_mode') }} | {{ states('sensor.my_home_melcloudhome_bf8d_5119_actual_fan_speed') }} |",
+         "content": "| unit | power / mode | requested | actual |\n|---|---|---|---|\n| My Home Living Room AC (mock) | {{ states('climate.my_home_melcloudhome_0efc_87db_climate') }} | {{ state_attr('climate.my_home_melcloudhome_0efc_87db_climate', 'fan_mode') }} | {{ states('sensor.my_home_melcloudhome_0efc_87db_actual_fan_speed') }} |\n| My Home Bedroom AC (mock) | {{ states('climate.my_home_melcloudhome_bf8d_5119_climate') }} | {{ state_attr('climate.my_home_melcloudhome_bf8d_5119_climate', 'fan_mode') }} | {{ states('sensor.my_home_melcloudhome_bf8d_5119_actual_fan_speed') }} |",
          "grid_options": {
           "columns": "full"
          }

--- a/tests/api/test_models_parsing.py
+++ b/tests/api/test_models_parsing.py
@@ -322,33 +322,30 @@ class TestActualFanSpeedGuard:
 
     @pytest.fixture(autouse=True)
     def _clear_warned(self) -> Iterator[None]:
-        """The warn-once record is module state, so it leaks between tests."""
-        models_ata._warned_fan_speeds.clear()
+        """The warn-once record is an lru_cache, so it leaks between tests."""
+        models_ata._warn_unknown_fan_speed.cache_clear()
         yield
-        models_ata._warned_fan_speeds.clear()
+        models_ata._warn_unknown_fan_speed.cache_clear()
 
     def test_unknown_value_rejected(self) -> None:
         """Anything outside the six words parses to None."""
         assert self._unit("Turbo").actual_fan_speed is None
 
     def test_next_ordinal_rejected(self) -> None:
-        """The realistic unknown value, not a made-up word.
-
-        `numberOfFanSpeeds` does not bound this field: a 3-speed unit was seen
-        reporting "Four" (see ACTUAL_FAN_SPEEDS), so a unit at the top of a
-        five-speed range reporting "Six" is the case this guard most plausibly
-        has to survive.
-        """
+        """The realistic unknown value rather than a made-up word."""
         assert self._unit("Six").actual_fan_speed is None
+
+    def test_numeric_rejected(self) -> None:
+        """The socket words this field numerically; /context has never done so.
+
+        Mapping numerics would handle a variation never seen on this path, and
+        would consume the warning that is how we would learn of it.
+        """
+        assert self._unit("2").actual_fan_speed is None
 
     def test_empty_string_rejected(self) -> None:
         """An empty value is absence, not a speed."""
         assert self._unit("").actual_fan_speed is None
-
-    def test_case_change_still_recognised(self) -> None:
-        """A case change upstream is the same speed, not an unknown one."""
-        assert self._unit("FOUR").actual_fan_speed == "Four"
-        assert self._unit("four").actual_fan_speed == "Four"
 
     def test_warns_once_per_value(self, caplog: pytest.LogCaptureFixture) -> None:
         """from_dict runs every poll, so repeats must not re-warn."""
@@ -375,14 +372,6 @@ class TestActualFanSpeedGuard:
             self._unit("Turbo\nERROR:root:forged", name="Unit\r\nfaked")
         assert "\n" not in caplog.records[0].getMessage()
         assert "\r" not in caplog.records[0].getMessage()
-
-    def test_warning_stops_at_the_cap(self, caplog: pytest.LogCaptureFixture) -> None:
-        """A unit reporting garbage must not grow the record without limit."""
-        with caplog.at_level(logging.WARNING):
-            for i in range(models_ata._MAX_WARNED_FAN_SPEEDS + 5):
-                self._unit(f"Bogus{i}")
-        assert len(models_ata._warned_fan_speeds) == models_ata._MAX_WARNED_FAN_SPEEDS
-        assert len(caplog.records) == models_ata._MAX_WARNED_FAN_SPEEDS
 
 
 class TestNameLineBreaks:

--- a/tests/api/test_models_parsing.py
+++ b/tests/api/test_models_parsing.py
@@ -9,8 +9,13 @@ Tests focus on edge cases in helper functions that could cause real bugs:
 Avoids theatre: Only tests non-trivial logic with real edge cases.
 """
 
+import logging
+from collections.abc import Iterator
 from typing import Any
 
+import pytest
+
+from custom_components.melcloudhome.api import models_ata
 from custom_components.melcloudhome.api.models_ata import AirToAirUnit
 from custom_components.melcloudhome.api.parsing import (
     parse_bool,
@@ -273,9 +278,13 @@ class TestActualFanSpeed:
         assert unit.actual_fan_speed is None
 
     def test_not_normalized_like_set_fan_speed(self) -> None:
-        """Numeric zero must not become Auto - a running unit has no Auto speed."""
+        """Numeric zero must not become Auto - a running unit has no Auto speed.
+
+        It is rejected rather than passed through: the sensor is an ENUM whose
+        options are the six words, so "0" would raise on the state write.
+        """
         unit = self._unit([{"name": "ActualFanSpeed", "value": "0"}])
-        assert unit.actual_fan_speed == "0"
+        assert unit.actual_fan_speed is None
 
     def test_independent_of_set_fan_speed(self) -> None:
         """The point of the field: Auto requested, a concrete speed running."""
@@ -287,6 +296,81 @@ class TestActualFanSpeed:
         )
         assert unit.set_fan_speed == "Auto"
         assert unit.actual_fan_speed == "Two"
+
+
+class TestActualFanSpeedGuard:
+    """An unrecognised value must degrade one sensor, not break the write.
+
+    The entity half of this pair is covered by
+    tests/integration/test_sensor_ata.py::test_actual_fan_speed_sensor_created_when_absent,
+    which asserts None reads as `unknown`.
+    """
+
+    @staticmethod
+    def _unit(value: str, name: str = "Test") -> AirToAirUnit:
+        return AirToAirUnit.from_dict(
+            {
+                "id": "test-unit",
+                "givenDisplayName": name,
+                "settings": [{"name": "ActualFanSpeed", "value": value}],
+                "capabilities": {},
+                "schedule": [],
+            }
+        )
+
+    @pytest.fixture(autouse=True)
+    def _clear_warned(self) -> Iterator[None]:
+        """The warn-once record is module state, so it leaks between tests."""
+        models_ata._warned_fan_speeds.clear()
+        yield
+        models_ata._warned_fan_speeds.clear()
+
+    def test_unknown_value_rejected(self) -> None:
+        """Anything outside the six words parses to None."""
+        assert self._unit("Turbo").actual_fan_speed is None
+
+    def test_empty_string_rejected(self) -> None:
+        """An empty value is absence, not a speed."""
+        assert self._unit("").actual_fan_speed is None
+
+    def test_case_change_still_recognised(self) -> None:
+        """A case change upstream is the same speed, not an unknown one."""
+        assert self._unit("FOUR").actual_fan_speed == "Four"
+        assert self._unit("four").actual_fan_speed == "Four"
+
+    def test_warns_once_per_value(self, caplog: pytest.LogCaptureFixture) -> None:
+        """from_dict runs every poll, so repeats must not re-warn."""
+        with caplog.at_level(logging.WARNING):
+            for _ in range(3):
+                self._unit("Turbo")
+        assert len(caplog.records) == 1
+        assert "Turbo" in caplog.text
+
+    def test_warns_again_for_a_different_value(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A second unknown value is new information."""
+        with caplog.at_level(logging.WARNING):
+            self._unit("Turbo")
+            self._unit("Whisper")
+        assert len(caplog.records) == 2
+
+    def test_warning_cannot_forge_a_log_line(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Both the value and the unit name are remote-controlled."""
+        with caplog.at_level(logging.WARNING):
+            self._unit("Turbo\nERROR:root:forged", name="Unit\r\nfaked")
+        assert "\n" not in caplog.records[0].getMessage()
+        assert "\r" not in caplog.records[0].getMessage()
+
+    def test_warning_stops_at_the_cap(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A unit reporting garbage must not grow the record without limit."""
+        with caplog.at_level(logging.WARNING):
+            for i in range(models_ata._MAX_WARNED_FAN_SPEEDS + 5):
+                self._unit(f"Bogus{i}")
+        assert len(models_ata._warned_fan_speeds) == models_ata._MAX_WARNED_FAN_SPEEDS
+        assert len(caplog.records) == models_ata._MAX_WARNED_FAN_SPEEDS
 
 
 class TestVaneNormalization:

--- a/tests/api/test_models_parsing.py
+++ b/tests/api/test_models_parsing.py
@@ -331,6 +331,16 @@ class TestActualFanSpeedGuard:
         """Anything outside the six words parses to None."""
         assert self._unit("Turbo").actual_fan_speed is None
 
+    def test_next_ordinal_rejected(self) -> None:
+        """The realistic unknown value, not a made-up word.
+
+        `numberOfFanSpeeds` does not bound this field: a 3-speed unit was seen
+        reporting "Four" (see ACTUAL_FAN_SPEEDS), so a unit at the top of a
+        five-speed range reporting "Six" is the case this guard most plausibly
+        has to survive.
+        """
+        assert self._unit("Six").actual_fan_speed is None
+
     def test_empty_string_rejected(self) -> None:
         """An empty value is absence, not a speed."""
         assert self._unit("").actual_fan_speed is None

--- a/tests/api/test_models_parsing.py
+++ b/tests/api/test_models_parsing.py
@@ -16,7 +16,9 @@ from typing import Any
 import pytest
 
 from custom_components.melcloudhome.api import models_ata
+from custom_components.melcloudhome.api.models import Building
 from custom_components.melcloudhome.api.models_ata import AirToAirUnit
+from custom_components.melcloudhome.api.models_atw import AirToWaterUnit
 from custom_components.melcloudhome.api.parsing import (
     parse_bool,
     parse_int,
@@ -371,6 +373,57 @@ class TestActualFanSpeedGuard:
                 self._unit(f"Bogus{i}")
         assert len(models_ata._warned_fan_speeds) == models_ata._MAX_WARNED_FAN_SPEEDS
         assert len(caplog.records) == models_ata._MAX_WARNED_FAN_SPEEDS
+
+
+class TestNameLineBreaks:
+    """Names arrive from the MELCloud app, so they are not ours to trust.
+
+    On a shared building the name was chosen by another account, and it reaches
+    both log lines and Home Assistant entity names. Flattening happens once at
+    the parse boundary so no downstream caller has to remember.
+    """
+
+    FORGED = "Lounge\r\nERROR:root:disk failure"
+
+    def test_ata_unit_name(self) -> None:
+        unit = AirToAirUnit.from_dict(
+            {
+                "id": "unit-1",
+                "givenDisplayName": self.FORGED,
+                "settings": [],
+                "capabilities": {},
+                "schedule": [],
+            }
+        )
+        assert "\n" not in unit.name
+        assert "\r" not in unit.name
+        assert unit.name.startswith("Lounge")
+
+    def test_atw_unit_name(self) -> None:
+        unit = AirToWaterUnit.from_dict(
+            {
+                "id": "unit-2",
+                "givenDisplayName": self.FORGED,
+                "settings": [],
+                "capabilities": {},
+                "schedule": [],
+            }
+        )
+        assert "\n" not in unit.name
+        assert "\r" not in unit.name
+
+    def test_building_name(self) -> None:
+        """Also covers the debug line that logs it before the field is set."""
+        building = Building.from_dict(
+            {
+                "id": "building-1",
+                "name": self.FORGED,
+                "airToAirUnits": [],
+                "airToWaterUnits": [],
+            }
+        )
+        assert "\n" not in building.name
+        assert "\r" not in building.name
 
 
 class TestVaneNormalization:

--- a/tools/build_dev_dashboard.py
+++ b/tools/build_dev_dashboard.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-"""Generate the dev ATW testing dashboard from the live entity registry.
+"""Generate the dev testing dashboard from the live entity registry.
+
+One view per ATW unit, plus a single view comparing the ATA units' fan speeds.
 
 `make dev-reset` restores `dev-config-template/.storage/`, so a dashboard only
 survives a reset if it lives there. A static snapshot cannot: entity IDs carry
@@ -10,7 +12,7 @@ So the design is committed as this generator rather than as its output. It reads
 whatever ATW units the registry holds and emits cards for them, which also means
 it keeps working when a device share lapses or a building is renamed.
 
-    # write the live dashboard for every ATW unit found
+    # write the live dashboard for every unit found
     python3 tools/build_dev_dashboard.py
 
     # refresh the committed template with the mock units only
@@ -82,6 +84,95 @@ def find_atw_units(storage: Path) -> list[tuple[str, bool]]:
             continue  # ATA unit
         units.append((prefix, f"climate.{prefix}_zone_2" in entity_ids))
     return units
+
+
+def find_ata_units(storage: Path) -> list[str]:
+    """Return the entity_id prefix of each ATA unit in the registry.
+
+    An ATA unit is the inverse of find_atw_units' test: a climate entity with
+    no water heater beside it. Reading the registry rather than assuming keeps
+    this correct when a shared unit disappears.
+    """
+    registry = json.loads((storage / "core.entity_registry").read_text())
+    entity_ids = {entry["entity_id"] for entry in registry["data"]["entities"]}
+    prefixes = {
+        match.group(1)
+        for entity_id in entity_ids
+        if (match := ENTITY_RE.match(entity_id))
+    }
+    return sorted(
+        prefix
+        for prefix in prefixes
+        if f"climate.{prefix}_climate" in entity_ids
+        and f"water_heater.{prefix}_tank" not in entity_ids
+    )
+
+
+def build_ata_fan_view(prefixes: list[str], names: dict[str, str]) -> dict[str, Any]:
+    """One view comparing every ATA unit's actual fan speed against its mode.
+
+    The sensor is a device_class=ENUM, so it has no long-term statistics and a
+    statistics-graph cannot show it: history-graph renders the states as a
+    timeline instead, which is the only way to see Auto modulating. The mock
+    server does not emit ActualFanSpeed, so mock units read `unknown` here and
+    only the real-API entry's units show a series.
+    """
+    fans = [f"sensor.{prefix}_actual_fan_speed" for prefix in prefixes]
+    climates = [f"climate.{prefix}_climate" for prefix in prefixes]
+    return {
+        "type": "sections",
+        "max_columns": 4,
+        "title": "ATA fan speed",
+        "path": "ata-fan",
+        "sections": [
+            {
+                "type": "grid",
+                # Full width: these are wide time series read side by side, and
+                # the default two-column grid squeezes them unreadably.
+                "column_span": 4,
+                "cards": [
+                    _heading("Actual fan speed"),
+                    {
+                        "type": "history-graph",
+                        "hours_to_show": 24,
+                        "title": "Actual fan speed (24h) - never Auto, Off means powered down",
+                        "entities": fans,
+                        "grid_options": {"columns": "full", "rows": "auto"},
+                    },
+                    _heading("Requested mode, for correlation"),
+                    {
+                        # fan_mode is a climate attribute, which history-graph
+                        # cannot plot, so this shows hvac state only. Comparing
+                        # requested against actual needs a template sensor.
+                        "type": "history-graph",
+                        "hours_to_show": 24,
+                        "title": "Power and HVAC mode (24h)",
+                        "entities": climates,
+                        "grid_options": {"columns": "full"},
+                    },
+                    _heading("Changes as text"),
+                    {
+                        "type": "logbook",
+                        "hours_to_show": 24,
+                        "target": {"entity_id": fans},
+                        "grid_options": {"columns": "full"},
+                    },
+                    {
+                        "type": "markdown",
+                        "title": "Current",
+                        "content": "| unit | requested | actual |\n|---|---|---|\n"
+                        + "\n".join(
+                            f"| {label(prefix, names)} "
+                            f"| {{{{ state_attr('climate.{prefix}_climate', 'fan_mode') }}}} "
+                            f"| {{{{ states('sensor.{prefix}_actual_fan_speed') }}}} |"
+                            for prefix in prefixes
+                        ),
+                        "grid_options": {"columns": "full"},
+                    },
+                ],
+            }
+        ],
+    }
 
 
 def device_names(storage: Path) -> dict[str, str]:
@@ -250,11 +341,13 @@ def main() -> int:
     args = parser.parse_args()
 
     units = find_atw_units(args.storage)
+    ata = find_ata_units(args.storage)
     names = device_names(args.storage)
     if args.mock_only:
         units = [u for u in units if u[0].startswith(MOCK_BUILDINGS)]
-    if not units:
-        print("No ATW units found - is the integration configured?")
+        ata = [p for p in ata if p.startswith(MOCK_BUILDINGS)]
+    if not units and not ata:
+        print("No units found - is the integration configured?")
         return 1
 
     out = args.out or args.storage / DASHBOARD
@@ -264,7 +357,8 @@ def main() -> int:
         "key": DASHBOARD,
         "data": {
             "config": {
-                "views": [build_view(p, z, names) for p, z in units],
+                "views": [build_view(p, z, names) for p, z in units]
+                + ([build_ata_fan_view(ata, names)] if ata else []),
             }
         },
     }
@@ -275,9 +369,12 @@ def main() -> int:
         envelope = existing
 
     out.write_text(json.dumps(envelope, indent=1) + "\n")
-    print(f"Wrote {out} with {len(units)} view(s):")
+    total = len(units) + (1 if ata else 0)
+    print(f"Wrote {out} with {total} view(s):")
     for prefix, has_zone2 in units:
         print(f"  {label(prefix, names)}{' [zone 2]' if has_zone2 else ''}")
+    if ata:
+        print(f"  ATA fan speed [{len(ata)} unit(s)]")
     print("Restart HA to pick it up: make dev-restart")
     return 0
 

--- a/tools/build_dev_dashboard.py
+++ b/tools/build_dev_dashboard.py
@@ -113,9 +113,10 @@ def build_ata_fan_view(prefixes: list[str], names: dict[str, str]) -> dict[str, 
 
     The sensor is a device_class=ENUM, so it has no long-term statistics and a
     statistics-graph cannot show it: history-graph renders the states as a
-    timeline instead, which is the only way to see Auto modulating. The mock
-    server does not emit ActualFanSpeed, so mock units read `unknown` here and
-    only the real-API entry's units show a series.
+    timeline instead, which is the only way to see Auto modulating.
+
+    Mock units carry a series too, derived rather than modulating, so a mock row
+    reading `unknown` is a fault rather than a gap in the mock.
     """
     fans = [f"sensor.{prefix}_actual_fan_speed" for prefix in prefixes]
     climates = [f"climate.{prefix}_climate" for prefix in prefixes]

--- a/tools/build_dev_dashboard.py
+++ b/tools/build_dev_dashboard.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -61,6 +62,13 @@ WATER_TEMPS = (
 ENTITY_RE = re.compile(r"^[a-z_]+\.(.+_melcloudhome_[0-9a-f]{4}_[0-9a-f]{4})_")
 
 
+@lru_cache(maxsize=1)
+def _entities(storage: Path) -> tuple[dict[str, Any], ...]:
+    """The entity registry, parsed once for the three callers that want it."""
+    registry = json.loads((storage / "core.entity_registry").read_text())
+    return tuple(registry["data"]["entities"])
+
+
 def find_atw_units(storage: Path) -> list[tuple[str, bool]]:
     """Return (entity_id_prefix, has_zone2) for each ATW unit in the registry.
 
@@ -68,10 +76,9 @@ def find_atw_units(storage: Path) -> list[tuple[str, bool]]:
     entity. Both are capability-gated at creation (#266), so the registry is
     the honest source for what a unit actually has.
     """
-    registry = json.loads((storage / "core.entity_registry").read_text())
     prefixes: set[str] = set()
     entity_ids: set[str] = set()
-    for entry in registry["data"]["entities"]:
+    for entry in _entities(storage):
         entity_id = entry["entity_id"]
         entity_ids.add(entity_id)
         match = ENTITY_RE.match(entity_id)
@@ -93,8 +100,7 @@ def find_ata_units(storage: Path) -> list[str]:
     no water heater beside it. Reading the registry rather than assuming keeps
     this correct when a shared unit disappears.
     """
-    registry = json.loads((storage / "core.entity_registry").read_text())
-    entity_ids = {entry["entity_id"] for entry in registry["data"]["entities"]}
+    entity_ids = {entry["entity_id"] for entry in _entities(storage)}
     prefixes = {
         match.group(1)
         for entity_id in entity_ids
@@ -142,12 +148,6 @@ def build_ata_fan_view(prefixes: list[str], names: dict[str, str]) -> dict[str, 
                     },
                     _heading("Changes as text, fan and mode interleaved"),
                     {
-                        # No second history-graph for the climate entities: for
-                        # a climate entity that card plots current and target
-                        # temperature, not hvac state, so it showed sixteen
-                        # temperature series under a title promising modes. The
-                        # logbook gives what correlation actually needs - fan
-                        # and power changes in one chronological list.
                         "type": "logbook",
                         "hours_to_show": 24,
                         "target": {"entity_id": fans + climates},
@@ -194,9 +194,8 @@ def device_names(storage: Path) -> dict[str, str]:
         device["id"]: (device.get("name_by_user") or device.get("name") or "")
         for device in devices["data"]["devices"]
     }
-    entities = json.loads((storage / "core.entity_registry").read_text())
     names: dict[str, str] = {}
-    for entry in entities["data"]["entities"]:
+    for entry in _entities(storage):
         match = ENTITY_RE.match(entry["entity_id"])
         name = by_id.get(entry.get("device_id") or "")
         if match and name:

--- a/tools/build_dev_dashboard.py
+++ b/tools/build_dev_dashboard.py
@@ -139,30 +139,30 @@ def build_ata_fan_view(prefixes: list[str], names: dict[str, str]) -> dict[str, 
                         "entities": fans,
                         "grid_options": {"columns": "full", "rows": "auto"},
                     },
-                    _heading("Requested mode, for correlation"),
+                    _heading("Changes as text, fan and mode interleaved"),
                     {
-                        # fan_mode is a climate attribute, which history-graph
-                        # cannot plot, so this shows hvac state only. Comparing
-                        # requested against actual needs a template sensor.
-                        "type": "history-graph",
-                        "hours_to_show": 24,
-                        "title": "Power and HVAC mode (24h)",
-                        "entities": climates,
-                        "grid_options": {"columns": "full"},
-                    },
-                    _heading("Changes as text"),
-                    {
+                        # No second history-graph for the climate entities: for
+                        # a climate entity that card plots current and target
+                        # temperature, not hvac state, so it showed sixteen
+                        # temperature series under a title promising modes. The
+                        # logbook gives what correlation actually needs - fan
+                        # and power changes in one chronological list.
                         "type": "logbook",
                         "hours_to_show": 24,
-                        "target": {"entity_id": fans},
+                        "target": {"entity_id": fans + climates},
                         "grid_options": {"columns": "full"},
                     },
                     {
                         "type": "markdown",
                         "title": "Current",
-                        "content": "| unit | requested | actual |\n|---|---|---|\n"
+                        # ATA units have no power switch entity: power is the
+                        # climate entity's state, off versus a mode, and it is
+                        # what explains an actual speed of off.
+                        "content": "| unit | power / mode | requested | actual |"
+                        "\n|---|---|---|---|\n"
                         + "\n".join(
                             f"| {label(prefix, names)} "
+                            f"| {{{{ states('climate.{prefix}_climate') }}}} "
                             f"| {{{{ state_attr('climate.{prefix}_climate', 'fan_mode') }}}} "
                             f"| {{{{ states('sensor.{prefix}_actual_fan_speed') }}}} |"
                             for prefix in prefixes

--- a/tools/build_dev_dashboard.py
+++ b/tools/build_dev_dashboard.py
@@ -180,27 +180,37 @@ def device_names(storage: Path) -> dict[str, str]:
 
     Device names are personal data for real units, so they are looked up from
     the local registry rather than written into this file.
+
+    Joined entity -> device_id -> device rather than matched on the entity id's
+    `<uuid first 4>_<uuid last 4>` short form, because that short form is NOT
+    unique: the mock unit `bf8d5678-...-456789ab5119` and the real
+    `bf8d1e84-...-25b87a945119` both render `bf8d_5119`, and matching on it gave
+    the mock unit the real device's name. The entity registry's device_id is
+    exact.
     """
-    registry = json.loads((storage / "core.device_registry").read_text())
-    names = {}
-    for device in registry["data"]["devices"]:
-        name = device.get("name_by_user") or device.get("name") or ""
-        for identifier in device.get("identifiers", []):
-            if len(identifier) > 1:
-                names[str(identifier[1])] = name
+    devices = json.loads((storage / "core.device_registry").read_text())
+    by_id = {
+        device["id"]: (device.get("name_by_user") or device.get("name") or "")
+        for device in devices["data"]["devices"]
+    }
+    entities = json.loads((storage / "core.entity_registry").read_text())
+    names: dict[str, str] = {}
+    for entry in entities["data"]["entities"]:
+        match = ENTITY_RE.match(entry["entity_id"])
+        name = by_id.get(entry.get("device_id") or "")
+        if match and name:
+            names[match.group(1)] = name
     return names
 
 
 def label(prefix: str, names: dict[str, str]) -> str:
     """A human view title, preferring the device's own name."""
-    short = prefix.split("_melcloudhome_")[1]
     kind = "mock" if prefix.startswith(MOCK_BUILDINGS) else "real"
-    for unit_id, name in names.items():
-        clean = unit_id.replace("-", "")
-        if name and short == f"{clean[:4]}_{clean[-4:]}":
-            return f"{name} ({kind})"
-    building = prefix.split("_melcloudhome_")[0].replace("_", " ").title()
-    return f"{building} {short} ({kind})"
+    name = names.get(prefix)
+    if name:
+        return f"{name} ({kind})"
+    building, _, short = prefix.partition("_melcloudhome_")
+    return f"{building.replace('_', ' ').title()} {short} ({kind})"
 
 
 def _heading(text: str) -> dict[str, Any]:

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -156,6 +156,24 @@ ATA_WIRE_MAP = {
 }
 
 
+def _actual_fan_speed(state: dict[str, Any]) -> str:
+    """Derive ActualFanSpeed the way a real indoor unit reports it.
+
+    The real API sends this field on every ATA unit, so omitting it made the
+    mock's /context unlike anything a real server returns. A running unit
+    reports the speed it picked and never "Auto"; a unit that is off reports
+    "Off".
+
+    ponytail: Auto resolves to a fixed middle speed rather than modelling the
+    unit's own logic. Real hardware modulates minute to minute (observed
+    two/one alternating on consecutive polls), which nothing here needs.
+    """
+    if not state["power"] or state["in_standby_mode"]:
+        return "Off"
+    requested = state["set_fan_speed"]
+    return "Three" if requested == "Auto" else requested
+
+
 def _delta_frame(unit_id: str, settings: list) -> list:
     """One unitStateChanged frame in the wire shape the socket sends."""
     return [
@@ -1510,6 +1528,7 @@ class MockMELCloudServer:
             {"name": "SetTemperature", "value": str(state["set_temperature"])},
             {"name": "RoomTemperature", "value": str(state["room_temperature"])},
             {"name": "SetFanSpeed", "value": state["set_fan_speed"]},
+            {"name": "ActualFanSpeed", "value": _actual_fan_speed(state)},
             {
                 "name": "VaneVerticalDirection",
                 "value": state["vane_vertical_direction"],


### PR DESCRIPTION
## Summary

`ActualFanSpeed` (#285) feeds a `device_class=ENUM` sensor, and Home Assistant raises on a state write outside an ENUM's options, so a value the integration does not recognise would fail the write. Parsing now accepts only the six words in `ACTUAL_FAN_SPEEDS` and returns `None` for anything else, which leaves that one sensor reading `unknown` and logs a warning once per distinct value. The six are the vocabulary observed so far. Three units advertising `numberOfFanSpeeds: 3` report `ActualFanSpeed: "Four"` while set to `Three`, in the same `/context` object that carries the capability, so the capability bounds nothing and a value outside the list is possible rather than hypothetical.

The warning carries an app-chosen device name, so `strip_line_breaks` moves from `websocket.py` into `api/parsing.py` and applies to every unit and building name at the API boundary. On a shared building that name was chosen by another account, and a name carrying CR/LF can forge log lines in a reader's own log. No CodeQL alert prompted this: `security-and-quality` runs `py/log-injection`, and the alerts it did raise under that rule were against the mock server's request-controlled inputs (#147), never against integration code, so the case rests on the harm.

## Key changes

- `ACTUAL_FAN_SPEEDS` in `const_ata.py` is the single source for both the parser's accepted set and the sensor's `options`, derived from it so the two cannot drift. Same six values, so the entity registry and the translation files are untouched.
- `_parse_actual_fan_speed` accepts only the six words and warns once per unit that reports an unlisted one, bounded by an `lru_cache(maxsize=20)` that evicts rather than falling silent. `from_dict` runs on every poll and every socket-triggered refresh, so warning on each parse would write a line every few seconds. Numeric forms are rejected rather than mapped: the socket sends this field numerically but discards values before they reach the parser, and every captured `/context` serves words.
- `strip_line_breaks` covers every separator `str.splitlines()` honours, replacing each with a space rather than deleting it, because the same string is a Home Assistant device name. It stays an unconditional `.replace()` chain, which is what CodeQL recognises as a barrier, and now applies to ATA unit names, ATW unit names and building names alongside the socket call sites it already had.
- The mock server derives `ActualFanSpeed` from a unit's power and requested speed, so its `/context` carries the field a real server always sends.
- `tools/build_dev_dashboard.py` emits an ATA fan speed view: a history graph of the ENUM states, a logbook interleaving fan and climate changes, and a live table of power, requested and actual speed. Device names are joined through the entity registry's `device_id`, because the entity id's short form collides between a mock and a real unit and was giving the mock the real device's name.

## What changes for users

- A fan speed the integration does not recognise shows that unit's actual fan speed sensor as `unknown` and logs one warning naming the unit. Every other sensor on the unit, and every other unit, keeps working. The remedy is reporting the value from the log so it can be added to the accepted list.

## Risks accepted

- **The six accepted values may fall short of what hardware reports.** A three-speed unit reporting `Four` shows the capability is no guide to the range. A five-speed unit was then driven under load with `SetFanSpeed: Five` and reported `Three`, so nothing above `Five` has been seen, and the requested speed appears to act as a ceiling the unit approaches rather than a commanded rate. That leaves the top of the range untested rather than confirmed safe. If a unit does report beyond the list, that sensor reads `unknown` for those users until the value is added. Detection is the warning itself, which is why no speculative value was pre-listed: listing `Six` would consume the only signal that would reveal the wider range. Adding an observed value is two places: `ACTUAL_FAN_SPEEDS`, from which the sensor's `options` derive, and a matching `state` key in each of the 14 translation files, without which the new value shows untranslated.
- **The warn-once record is module-level and capped at 20 distinct values.** A unit reporting continuously varying values goes quiet after 20 of them, and an HA restart re-arms every warning. The cost either way is a log line missing or repeated. It would show as a sensor reading `unknown` with nothing logged; the upgrade path is an LRU, noted at the cap.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

All checks made against `6ce636b` with a clean tree.

- [x] `make pre-commit`: all 12 hooks pass.
- [x] `make test-api`: 410 passed, 1 skipped, 16 deselected, 1 xfailed.
- [x] `make test-integration`: 264 passed.
- [x] `make test-e2e`: 16 passed, 412 deselected.
- [x] Devserver on this branch's code against both a mock-backed and a real-API config entry: all 8 ATA `actual_fan_speed` sensors populate, 2 mock and 6 real, with zero guard warnings and no integration errors this boot.
- [x] Rejection path in live HA, with the mock temporarily forced to report an unlisted value: the affected sensor read `unknown`, the sibling sensor on the same entry kept its value, no exception and no "not in the list of options" was logged, and exactly one warning appeared across four `/context` fetches, two of them strictly after the first. That forcing change was reverted and is not in the diff.
- [x] `numberOfFanSpeeds` read from `/context` directly, parser out of the loop, reproduced on a second call.
- [x] Prod, 10 hours: deployed and soaked. All seven files this branch changes are byte-identical on the box to the branch tip. Six `actual_fan_speed` sensors live and reading real values, zero guard warnings, and the name flattening exercised against real ATA and ATW payloads. Six coordinator errors in the window, all vendor-side and each recovering on the next poll.
- [ ] Warn-once across an HA restart: not exercised. The record is an `lru_cache`, so a restart clears it and the next unlisted value warns once more; no unlisted value has occurred on real hardware to trigger it.
