### PR TITLE
fix(energy): keep the request window inside the server's 24-hour cap

### DIFF
--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -29,21 +29,11 @@ DEFAULT_ENABLE_WEBSOCKET = True
 
 # Energy polling configuration
 UPDATE_INTERVAL_ENERGY = timedelta(minutes=30)
-# The energy endpoint truncates its response to 24 hours from "from" and drops
-# everything after it, with no error and no marker. A 48-hour window therefore
-# never returned the most recent 24 hours at all: the per-hour ledger stopped
-# gaining entries, no delta was ever added, and the cumulative total froze while
-# the sensor stayed available and the poll kept succeeding.
-#
-# Measured 2026-08-29 against one unit, same minute, only the window varying:
-#   48h -> newest bucket 08-28 07:00     36h -> 08-28 19:00
-#   30h -> 08-29 01:00                   24h -> 08-29 07:00
-#   23h -> 08-29 08:00 (the current hour)
-# In every case the newest bucket sits 24 hours after "from".
-#
-# 23, not 24: "from" is floored to the hour, so at 24 the cap lands exactly on
-# the current hour's start and the in-progress hour is dropped. 23 keeps the cap
-# past it for the whole hour.
+# The endpoint truncates its response 24 hours after "from" and drops the rest,
+# with no error and no marker, so a wider window silently loses the newest hours
+# and the cumulative total stops growing. 23 rather than 24 because "from" is
+# floored to the hour: at 24 the cut lands on the current hour's start and drops
+# the hour in progress. Measured 2026-08-29, see #292.
 DATA_LOOKBACK_HOURS_ENERGY = 23
 
 # Sanity ceiling for a single hourly energy reading (kWh). The MELCloud cloud

--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -33,7 +33,7 @@ UPDATE_INTERVAL_ENERGY = timedelta(minutes=30)
 # with no error and no marker, so a wider window silently loses the newest hours
 # and the cumulative total stops growing. 23 rather than 24 because "from" is
 # floored to the hour: at 24 the cut lands on the current hour's start and drops
-# the hour in progress. Measured 2026-08-29, see #292.
+# the hour in progress. See #294 for the measurements.
 DATA_LOOKBACK_HOURS_ENERGY = 23
 
 # Sanity ceiling for a single hourly energy reading (kWh). The MELCloud cloud

--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -29,7 +29,22 @@ DEFAULT_ENABLE_WEBSOCKET = True
 
 # Energy polling configuration
 UPDATE_INTERVAL_ENERGY = timedelta(minutes=30)
-DATA_LOOKBACK_HOURS_ENERGY = 48
+# The energy endpoint truncates its response to 24 hours from "from" and drops
+# everything after it, with no error and no marker. A 48-hour window therefore
+# never returned the most recent 24 hours at all: the per-hour ledger stopped
+# gaining entries, no delta was ever added, and the cumulative total froze while
+# the sensor stayed available and the poll kept succeeding.
+#
+# Measured 2026-08-29 against one unit, same minute, only the window varying:
+#   48h -> newest bucket 08-28 07:00     36h -> 08-28 19:00
+#   30h -> 08-29 01:00                   24h -> 08-29 07:00
+#   23h -> 08-29 08:00 (the current hour)
+# In every case the newest bucket sits 24 hours after "from".
+#
+# 23, not 24: "from" is floored to the hour, so at 24 the cap lands exactly on
+# the current hour's start and the in-progress hour is dropped. 23 keeps the cap
+# past it for the whole hour.
+DATA_LOOKBACK_HOURS_ENERGY = 23
 
 # Sanity ceiling for a single hourly energy reading (kWh). The MELCloud cloud
 # API has been observed to occasionally return corrupt values around 65536 *

--- a/tests/integration/test_coordinator_energy.py
+++ b/tests/integration/test_coordinator_energy.py
@@ -1255,7 +1255,12 @@ def test_energy_window_normalises_to_utc() -> None:
 
     assert (from_utc, to_utc) == (from_local, to_local)
     assert from_utc.utcoffset() == timedelta(0)
-    assert from_utc.hour == 7  # floored in UTC, not in +02:00
+    # Derived, not a literal: this previously hard-coded the hour that a
+    # 48-hour lookback produced, so changing the constant failed the test for a
+    # reason that had nothing to do with what it checks.
+    assert from_utc == (instant - timedelta(hours=DATA_LOOKBACK_HOURS_ENERGY)).replace(
+        minute=0, second=0, microsecond=0
+    )
 
     with pytest.raises(ValueError, match="aware datetime"):
         EnergyTrackerBase._energy_window(datetime(2026, 8, 25, 7, 51))


### PR DESCRIPTION
Builds on #291

Energy totals silently stopped growing. The endpoint truncates its response 24 hours after `from` and drops the rest, with no error and no marker, so the 48-hour window never returned the most recent 24 hours (#294). Every poll then saw only hours already in the per-hour ledger, added no delta, and the total froze while the sensor stayed available and each poll reported success. 23 rather than 24 because `from` is floored to the hour, so at 24 the cut lands on the current hour's start.

Both a prod and a dev instance froze at the identical hour with no client change on either, which points at a server-side change rather than anything in this repo.

## What changes for users

- Energy sensors that had stopped increasing resume, and recover what accumulated while frozen rather than losing it: a unit stuck for 19 hours picked up the missing 6.3 kWh on the first poll.

## Risks accepted

- **`HOUR_VALUE_RETENTION_HOURS` derives from this constant and falls from 144 to 69 hours.** Still three times the request window, so no stored hour can be pruned and later re-seen, which would double-count it. The buffer for extended Home Assistant downtime shrinks from six days to under three; an instance offline longer loses delta state for hours it can no longer request anyway.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

All checks made against `e5e340d` with a clean tree.

- [x] `make pre-commit`: all 12 hooks pass.
- [x] `make test-api`: 409 passed, 1 skipped, 1 xfailed.
- [x] `make test-integration`: 264 passed.
- [x] `make test-e2e`: 16 passed.
- [x] Devserver: a ledger stuck at `2026-08-28 13:00` advanced to the current hour on the first poll, cumulative 82.3 to 88.6 kWh.
- [x] Prod, 10 hours: energy tracking across every hour boundary, ten delta lines where there had been none all day. Six errors in the window, all vendor-side (four HTTP 503, one DNS timeout), each recovering on the next poll.
