### PR TITLE
docs(skill): compose and format pr-body prose unwrapped

### DIFF
--- a/.claude/skills/pr-body/SKILL.md
+++ b/.claude/skills/pr-body/SKILL.md
@@ -52,6 +52,11 @@ The file opens with the title as an H1, so the one line a reviewer reads first
 is reviewed and versioned with the body rather than improvised at the command
 line.
 
+Write every paragraph, bullet and checkbox as one unwrapped line. GitHub
+renders a newline inside a paragraph as a line break, so hard-wrapped prose
+ships its wrapping to the reviewer; the prettier step in `handoff.md` repairs
+it, but composing unwrapped is what keeps the diff of a later edit readable.
+
 **Write the title last, from the finished body.** Composing the body is what
 establishes what the change is; a title written first frames the body instead,
 and you cannot tell whether a title merely repeats the Summary's opening
@@ -203,5 +208,6 @@ in front of them.
 | Explaining why a card, flag or graph exists                                                                 | Put it in the docstring                                                                                                        |
 | Arguing for the method instead of reporting what ran                                                        | Say what ran and what it showed. A Testing preamble that defends the approach is commentary                                    |
 | An em dash                                                                                                  | A colon where it introduces an elaboration, commas or brackets where it wraps an aside. A body full of them reads as generated |
+| Hard-wrapping paragraphs or bullets                                                                         | One line each; GitHub renders the wrap as line breaks                                                                          |
 | Every box checked when verification is partial                                                              | Leave the box unchecked and say why                                                                                            |
 | Overwriting a body that was handed over for editing                                                         | Read it first, keep the author's wording, report the change                                                                    |

--- a/.claude/skills/pr-body/handoff.md
+++ b/.claude/skills/pr-body/handoff.md
@@ -132,15 +132,18 @@ sibling branch's body, carries no information about this body at all.
 Before handing it over, format it and check it:
 
 ```bash
-npx --yes prettier@3 --prose-wrap preserve --write _claude/pr-bodies/<name>.md
+npx --yes prettier@3 --prose-wrap never --write _claude/pr-bodies/<name>.md
 grep -n '—' _claude/pr-bodies/<name>.md   # em dashes: rewrite, see SKILL.md
 ```
 
-`--prose-wrap preserve` is deliberate. It fixes list spacing, trailing
-whitespace, table alignment and the final newline while leaving long lines
-alone, because GitHub reflows paragraphs and a hard-wrapped body reads badly
-there. Do not run markdownlint on a body: its line-length rule fires on prose
-that is meant to be unwrapped, and following it would break the convention.
+`--prose-wrap never` is deliberate: it joins every paragraph, bullet and
+checkbox back onto one line, which is the convention GitHub expects. GitHub
+renders a newline inside a paragraph as a line break, so a body composed
+hard-wrapped ships its wrapping to the reviewer; `preserve` would ratify that
+instead of repairing it. It also fixes list spacing, trailing whitespace,
+table alignment and the final newline. Do not run markdownlint on a body: its
+line-length rule fires on prose that is meant to be unwrapped, and following
+it would break the convention.
 
 ## Creating the PR from the file
 


### PR DESCRIPTION
## Summary

Stacked on #300; nothing here depends on that change. #300's body shipped hard-wrapped and had to be repaired in place after posting, because the pr-body skill's prettier step used `--prose-wrap preserve`, which leaves a hard-wrapped line as GitHub sees it rather than joining it. `SKILL.md` now instructs composing every paragraph, bullet and checkbox as one unwrapped line, and the `handoff.md` prettier command switches to `--prose-wrap never`, which folds a wrapped line back to one regardless of how it was composed.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

All checks below made against `2a58e13` with a clean tree.

- [x] `make pre-commit`: passed; every Python-facing hook skipped, the diff is two markdown files.
- [x] `npx prettier@3 --prose-wrap never` verified on a deliberately hard-wrapped sample (a paragraph, a wrapped bullet, a wrapped checkbox with continuation indent): all three came back as single lines.
- [ ] `make test-api` / `make test-integration` / `make test-e2e`: not run; the diff touches only `.claude/skills/pr-body/SKILL.md` and `handoff.md`, no path any suite reaches.
