### PR TITLE
chore: renumber the unreleased 2.4.2 cycle to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-      # Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.4.2] - unreleased
+## [2.5.0] - 2026-09-02
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Home Assistant custom integration for **MELCloud Home**.
 
-## What's New in v2.4.2
+## What's New in v2.5.0
 
 **A new "Actual fan speed" sensor for air conditioning units.** It shows the speed a unit is really running at, which on units set to "Auto" was not visible anywhere before. It follows the fan rather than the compressor, so a low speed does not mean cooling has stopped. Contributed by [@lackas](https://github.com/lackas).
 

--- a/custom_components/melcloudhome/manifest.json
+++ b/custom_components/melcloudhome/manifest.json
@@ -13,5 +13,5 @@
     "custom_components.melcloudhome"
   ],
   "requirements": [],
-  "version": "2.4.2"
+  "version": "2.5.0"
 }


### PR DESCRIPTION
## Summary

Stacked on #301; nothing here depends on that change. Renumbers the unreleased changelog cycle to 2.5.0, since it adds a new sensor entity, last-reading timestamps, automation-visible behaviour changes and entity removals, which the changelog's declared semver adherence makes a minor release, and restores the changelog H1, which #295 left indented into a code block.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

All checks below made against `16d76d3` with a clean tree.

- [x] `make pre-commit`: passed; the check-json hook passed on manifest.json, every Python-facing hook skipped, the diff is two markdown files and a manifest version string.
- [ ] `make test-api` / `make test-integration` / `make test-e2e`: not run; the diff touches only CHANGELOG.md, README.md and the version string in manifest.json, no path any suite reaches.
