### PR TITLE
fix(coordinator): keep last data across two consecutive failed polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- One or two failed requests to MELCloud no longer make every entity "unavailable" for a minute or two. Once a minute the integration asks MELCloud for the current state of all devices, and when that request timed out or dropped, every sensor and climate entity went unavailable until the next request succeeded. The integration now keeps the last known values across up to two consecutive failed requests and logs a warning each time; the third failure in a row marks entities unavailable, so a real outage still shows. The 30 second request timeout is unchanged. (#309)
+- One or two failed requests to MELCloud no longer make every entity "unavailable" for a minute or two. Once a minute the integration asks MELCloud for the current state of all devices, and when that request timed out, dropped, or got a server error, every sensor and climate entity went unavailable until the next request succeeded. The integration now keeps the last known values across up to two consecutive failed requests of any kind and logs a warning each time; the third failure in a row marks entities unavailable, so a real outage still shows and server errors still back off as before once that happens. The 30 second request timeout is unchanged. (#309)
 
 ## [2.5.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A single failed request to MELCloud no longer makes every entity "unavailable" for a minute or two. Once a minute the integration asks MELCloud for the current state of all devices, and when that one request timed out or dropped, every sensor and climate entity went unavailable until the next request succeeded. The integration now keeps the last known values across one failed request and logs a warning; only a second consecutive failure marks entities unavailable, so a real outage still shows. The 30 second request timeout is unchanged. (#309)
+
 ## [2.5.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A single failed request to MELCloud no longer makes every entity "unavailable" for a minute or two. Once a minute the integration asks MELCloud for the current state of all devices, and when that one request timed out or dropped, every sensor and climate entity went unavailable until the next request succeeded. The integration now keeps the last known values across one failed request and logs a warning; only a second consecutive failure marks entities unavailable, so a real outage still shows. The 30 second request timeout is unchanged. (#309)
+- One or two failed requests to MELCloud no longer make every entity "unavailable" for a minute or two. Once a minute the integration asks MELCloud for the current state of all devices, and when that request timed out or dropped, every sensor and climate entity went unavailable until the next request succeeded. The integration now keeps the last known values across up to two consecutive failed requests and logs a warning each time; the third failure in a row marks entities unavailable, so a real outage still shows. The 30 second request timeout is unchanged. (#309)
 
 ## [2.5.0] - 2026-09-02
 

--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 # Domain and update interval (shared by all device types)
 DOMAIN = "melcloudhome"
 UPDATE_INTERVAL = timedelta(seconds=60)
+# Consecutive failed polls carried on the previous data before entities go
+# unavailable. MELCloud slow patches seen on three installs mostly took two
+# polls in a row (#309); the third failure is treated as a real outage.
+MAX_TOLERATED_POLL_FAILURES = 2
 PLATFORMS = ["climate"]
 
 # Configuration keys

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -166,6 +166,31 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             data={**self._config_entry.data, **self.client.get_token_snapshot()},
         )
 
+    def _tolerate_poll_failure(self, err: BaseException) -> UserContext | None:
+        """Return the previous data if this failed poll should be ridden out.
+
+        One timed-out, dropped or 5xx poll used to mark every entity
+        unavailable until the next poll succeeded 60 s later (#309). The
+        first MAX_TOLERATED_POLL_FAILURES consecutive failures keep the last
+        data; the one after is a real outage and the caller propagates it.
+        None means "do not tolerate": no data held yet, or budget spent.
+        """
+        previous: UserContext | None = self.data
+        if (
+            previous is None
+            or self._transient_poll_failures >= MAX_TOLERATED_POLL_FAILURES
+        ):
+            return None
+        self._transient_poll_failures += 1
+        _LOGGER.warning(
+            "MELCloud poll failed (%s); keeping the last data until the next poll"
+            " (%d of %d tolerated)",
+            str(err) or type(err).__name__,
+            self._transient_poll_failures,
+            MAX_TOLERATED_POLL_FAILURES,
+        )
+        return previous
+
     async def _async_update_data(self) -> UserContext:
         """Fetch data from API endpoint."""
         try:
@@ -176,6 +201,8 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 "coordinator_update",
             )
         except ServiceUnavailableError as err:
+            if (previous := self._tolerate_poll_failure(err)) is not None:
+                return previous
             self._outage_retry_count += 1
             retry_after = min(120 * 2 ** (self._outage_retry_count - 1), 900)
             _LOGGER.warning(
@@ -187,25 +214,9 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         except ConfigEntryAuthFailed:
             raise
         except (TimeoutError, HomeAssistantError) as err:
-            # One timed-out or dropped poll used to mark every entity
-            # unavailable until the next poll succeeded 60 s later (#309).
-            # Carry the previous data across the tolerated failures; the one
-            # after is a real outage and propagates as before.
-            previous: UserContext | None = self.data
-            if (
-                previous is None
-                or self._transient_poll_failures >= MAX_TOLERATED_POLL_FAILURES
-            ):
-                raise
-            self._transient_poll_failures += 1
-            _LOGGER.warning(
-                "MELCloud poll failed (%s); keeping the last data until the next poll"
-                " (%d of %d tolerated)",
-                str(err) or type(err).__name__,
-                self._transient_poll_failures,
-                MAX_TOLERATED_POLL_FAILURES,
-            )
-            return previous
+            if (previous := self._tolerate_poll_failure(err)) is not None:
+                return previous
+            raise
 
         self._outage_retry_count = 0
         if self._transient_poll_failures:

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -196,7 +196,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             self._transient_poll_failures += 1
             _LOGGER.warning(
                 "MELCloud poll failed (%s); keeping the last data until the next poll",
-                err or type(err).__name__,
+                str(err) or type(err).__name__,
             )
             return previous
 

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_ENABLE_WEBSOCKET,
     DEFAULT_ENABLE_WEBSOCKET,
     DOMAIN,
+    MAX_TOLERATED_POLL_FAILURES,
     UPDATE_INTERVAL,
     UPDATE_INTERVAL_ENERGY,
     UPDATE_INTERVAL_OUTDOOR_TEMP,
@@ -188,22 +189,28 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
         except (TimeoutError, HomeAssistantError) as err:
             # One timed-out or dropped poll used to mark every entity
             # unavailable until the next poll succeeded 60 s later (#309).
-            # Carry the previous data across a single failure; a second
-            # consecutive one is a real outage and propagates as before.
+            # Carry the previous data across the tolerated failures; the one
+            # after is a real outage and propagates as before.
             previous: UserContext | None = self.data
-            if previous is None or self._transient_poll_failures >= 1:
+            if (
+                previous is None
+                or self._transient_poll_failures >= MAX_TOLERATED_POLL_FAILURES
+            ):
                 raise
             self._transient_poll_failures += 1
             _LOGGER.warning(
-                "MELCloud poll failed (%s); keeping the last data until the next poll",
+                "MELCloud poll failed (%s); keeping the last data until the next poll"
+                " (%d of %d tolerated)",
                 str(err) or type(err).__name__,
+                self._transient_poll_failures,
+                MAX_TOLERATED_POLL_FAILURES,
             )
             return previous
 
         self._outage_retry_count = 0
         if self._transient_poll_failures:
             _LOGGER.info(
-                "MELCloud poll recovered after %d failed poll",
+                "MELCloud poll recovered after %d failed poll(s)",
                 self._transient_poll_failures,
             )
             self._transient_poll_failures = 0

--- a/custom_components/melcloudhome/coordinator.py
+++ b/custom_components/melcloudhome/coordinator.py
@@ -127,6 +127,7 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
 
         # Outage backoff: tracks consecutive 5xx failures for retry spacing
         self._outage_retry_count: int = 0
+        self._transient_poll_failures: int = 0
 
         # Outdoor temperature tracking for ATA devices
         self._last_outdoor_temp_poll: dict[
@@ -182,8 +183,30 @@ class MELCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
             if _UPDATE_FAILED_HAS_RETRY_AFTER:
                 raise UpdateFailed(str(err), retry_after=retry_after) from err
             raise UpdateFailed(str(err)) from err
+        except ConfigEntryAuthFailed:
+            raise
+        except (TimeoutError, HomeAssistantError) as err:
+            # One timed-out or dropped poll used to mark every entity
+            # unavailable until the next poll succeeded 60 s later (#309).
+            # Carry the previous data across a single failure; a second
+            # consecutive one is a real outage and propagates as before.
+            previous: UserContext | None = self.data
+            if previous is None or self._transient_poll_failures >= 1:
+                raise
+            self._transient_poll_failures += 1
+            _LOGGER.warning(
+                "MELCloud poll failed (%s); keeping the last data until the next poll",
+                err or type(err).__name__,
+            )
+            return previous
 
         self._outage_retry_count = 0
+        if self._transient_poll_failures:
+            _LOGGER.info(
+                "MELCloud poll recovered after %d failed poll",
+                self._transient_poll_failures,
+            )
+            self._transient_poll_failures = 0
 
         # Debug logging: Log verbose device states (controlled by HA logger config)
         for building in context.buildings:

--- a/tests/integration/test_binary_sensor_ata.py
+++ b/tests/integration/test_binary_sensor_ata.py
@@ -115,8 +115,8 @@ async def test_connection_state_sensor_reflects_coordinator_status(
     from custom_components.melcloudhome.const import DOMAIN
 
     mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
-    # One failed poll keeps the last data (#309); the second marks the outage.
-    for _ in range(2):
+    # Two failed polls keep the last data (#309); the third marks the outage.
+    for _ in range(3):
         await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
         await hass.async_block_till_done()
 
@@ -138,8 +138,8 @@ async def test_error_sensor_unavailable_when_coordinator_fails(
     from custom_components.melcloudhome.const import DOMAIN
 
     mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
-    # One failed poll keeps the last data (#309); the second marks the outage.
-    for _ in range(2):
+    # Two failed polls keep the last data (#309); the third marks the outage.
+    for _ in range(3):
         await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
         await hass.async_block_till_done()
 
@@ -156,8 +156,8 @@ async def test_connection_sensor_always_available(hass: HomeAssistant) -> None:
     from custom_components.melcloudhome.const import DOMAIN
 
     mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
-    # One failed poll keeps the last data (#309); the second marks the outage.
-    for _ in range(2):
+    # Two failed polls keep the last data (#309); the third marks the outage.
+    for _ in range(3):
         await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
         await hass.async_block_till_done()
 

--- a/tests/integration/test_binary_sensor_ata.py
+++ b/tests/integration/test_binary_sensor_ata.py
@@ -115,8 +115,10 @@ async def test_connection_state_sensor_reflects_coordinator_status(
     from custom_components.melcloudhome.const import DOMAIN
 
     mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
-    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
-    await hass.async_block_till_done()
+    # One failed poll keeps the last data (#309); the second marks the outage.
+    for _ in range(2):
+        await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+        await hass.async_block_till_done()
 
     assert hass.states.get(connection_sensor_id).state == STATE_OFF
 
@@ -136,8 +138,10 @@ async def test_error_sensor_unavailable_when_coordinator_fails(
     from custom_components.melcloudhome.const import DOMAIN
 
     mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
-    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
-    await hass.async_block_till_done()
+    # One failed poll keeps the last data (#309); the second marks the outage.
+    for _ in range(2):
+        await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+        await hass.async_block_till_done()
 
     assert hass.states.get(error_sensor_id).state == "unavailable"
 
@@ -152,8 +156,10 @@ async def test_connection_sensor_always_available(hass: HomeAssistant) -> None:
     from custom_components.melcloudhome.const import DOMAIN
 
     mock_client.get_user_context = AsyncMock(side_effect=ApiError("Connection failed"))
-    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
-    await hass.async_block_till_done()
+    # One failed poll keeps the last data (#309); the second marks the outage.
+    for _ in range(2):
+        await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+        await hass.async_block_till_done()
 
     connection_sensor_id = "binary_sensor.melcloudhome_a1b2_9abc_connection_state"
     connection_state = hass.states.get(connection_sensor_id)

--- a/tests/integration/test_coordinator_transient_failure.py
+++ b/tests/integration/test_coordinator_transient_failure.py
@@ -58,10 +58,14 @@ async def test_single_timed_out_poll_keeps_entities_available(
 
     assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
     assert hass.states.get(_ROOM_TEMP_ENTITY).state == "20.0"
-    assert any(
-        r.levelno == logging.WARNING and "keeping" in r.message.lower()
+    warnings = [
+        r.message
         for r in caplog.records
-    ), "a tolerated failure must be visible in the log"
+        if r.levelno == logging.WARNING and "keeping" in r.message.lower()
+    ]
+    assert warnings, "a tolerated failure must be visible in the log"
+    # A bare TimeoutError has an empty str(); the line must still say what failed.
+    assert "TimeoutError" in warnings[0]
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_coordinator_transient_failure.py
+++ b/tests/integration/test_coordinator_transient_failure.py
@@ -1,0 +1,115 @@
+"""One failed poll must not take every entity unavailable (issue #309).
+
+A single /context request that times out or fails on the network used to mark
+the whole integration failed, so all entities read "unavailable" until the next
+poll succeeded 60 s later. The coordinator now carries the previous data across
+one failed poll and only gives up on the second consecutive failure.
+
+Tested through hass.states only.
+
+Reference: docs/testing-best-practices.md
+Run with: make test-integration
+"""
+
+import logging
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.components.climate import HVACMode
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.melcloudhome.api.exceptions import ApiError
+from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET
+
+from .conftest import create_mock_ata_user_context, setup_ata_integration_custom
+
+_CLIMATE_ENTITY = "climate.melcloudhome_a1b2_9abc_climate"
+_ROOM_TEMP_ENTITY = "sensor.melcloudhome_a1b2_9abc_room_temperature"
+
+
+async def _setup(hass: HomeAssistant):
+    mock_context = create_mock_ata_user_context()
+    _entry, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, options={CONF_ENABLE_WEBSOCKET: False}
+    )
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
+    return mock_context, mock_client
+
+
+async def _next_poll(hass: HomeAssistant) -> None:
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=61))
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+
+@pytest.mark.asyncio
+async def test_single_timed_out_poll_keeps_entities_available(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """One timeout keeps the last known values and says so in the log."""
+    _context, mock_client = await _setup(hass)
+    mock_client.get_user_context = AsyncMock(side_effect=TimeoutError())
+
+    with caplog.at_level(logging.WARNING):
+        await _next_poll(hass)
+
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
+    assert hass.states.get(_ROOM_TEMP_ENTITY).state == "20.0"
+    assert any(
+        r.levelno == logging.WARNING and "keeping" in r.message.lower()
+        for r in caplog.records
+    ), "a tolerated failure must be visible in the log"
+
+
+@pytest.mark.asyncio
+async def test_single_network_error_keeps_entities_available(
+    hass: HomeAssistant,
+) -> None:
+    """A network error is tolerated the same way as a timeout."""
+    _context, mock_client = await _setup(hass)
+    mock_client.get_user_context = AsyncMock(
+        side_effect=ApiError("Network error: connection reset")
+    )
+
+    await _next_poll(hass)
+
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
+
+
+@pytest.mark.asyncio
+async def test_second_consecutive_failure_marks_unavailable_then_recovers(
+    hass: HomeAssistant,
+) -> None:
+    """Two failures in a row is a real outage; the next success restores state."""
+    mock_context, mock_client = await _setup(hass)
+    mock_client.get_user_context = AsyncMock(side_effect=TimeoutError())
+
+    await _next_poll(hass)
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
+
+    await _next_poll(hass)
+    assert hass.states.get(_CLIMATE_ENTITY).state == STATE_UNAVAILABLE
+
+    mock_client.get_user_context = AsyncMock(return_value=mock_context)
+    await _next_poll(hass)
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
+
+
+@pytest.mark.asyncio
+async def test_failure_tolerance_resets_after_a_good_poll(
+    hass: HomeAssistant,
+) -> None:
+    """Fail, succeed, fail: the second failure is a fresh single failure."""
+    mock_context, mock_client = await _setup(hass)
+
+    mock_client.get_user_context = AsyncMock(side_effect=TimeoutError())
+    await _next_poll(hass)
+    mock_client.get_user_context = AsyncMock(return_value=mock_context)
+    await _next_poll(hass)
+    mock_client.get_user_context = AsyncMock(side_effect=TimeoutError())
+    await _next_poll(hass)
+
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT

--- a/tests/integration/test_coordinator_transient_failure.py
+++ b/tests/integration/test_coordinator_transient_failure.py
@@ -1,6 +1,6 @@
 """One failed poll must not take every entity unavailable (issue #309).
 
-A single /context request that times out or fails on the network used to mark
+A single /context request that times out, fails on the network or gets a 5xx used to mark
 the whole integration failed, so all entities read "unavailable" until the next
 poll succeeded 60 s later. The coordinator now carries the previous data across
 up to two consecutive failed polls and only gives up on the third.
@@ -22,7 +22,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
-from custom_components.melcloudhome.api.exceptions import ApiError
+from custom_components.melcloudhome.api.exceptions import (
+    ApiError,
+    ServiceUnavailableError,
+)
 from custom_components.melcloudhome.const import CONF_ENABLE_WEBSOCKET
 
 from .conftest import create_mock_ata_user_context, setup_ata_integration_custom
@@ -122,3 +125,28 @@ async def test_failure_tolerance_resets_after_a_good_poll(
     await _next_poll(hass)
 
     assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
+
+
+@pytest.mark.asyncio
+async def test_single_503_keeps_entities_available(hass: HomeAssistant) -> None:
+    """A server-side 5xx is tolerated like a timeout while data is held."""
+    _context, mock_client = await _setup(hass)
+    mock_client.get_user_context = AsyncMock(side_effect=ServiceUnavailableError(503))
+
+    await _next_poll(hass)
+
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
+
+
+@pytest.mark.asyncio
+async def test_third_503_marks_unavailable(hass: HomeAssistant) -> None:
+    """Three 5xx in a row is an outage and still reads unavailable."""
+    _context, mock_client = await _setup(hass)
+    mock_client.get_user_context = AsyncMock(side_effect=ServiceUnavailableError(503))
+
+    await _next_poll(hass)
+    await _next_poll(hass)
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
+
+    await _next_poll(hass)
+    assert hass.states.get(_CLIMATE_ENTITY).state == STATE_UNAVAILABLE

--- a/tests/integration/test_coordinator_transient_failure.py
+++ b/tests/integration/test_coordinator_transient_failure.py
@@ -3,7 +3,7 @@
 A single /context request that times out or fails on the network used to mark
 the whole integration failed, so all entities read "unavailable" until the next
 poll succeeded 60 s later. The coordinator now carries the previous data across
-one failed poll and only gives up on the second consecutive failure.
+up to two consecutive failed polls and only gives up on the third.
 
 Tested through hass.states only.
 
@@ -84,12 +84,15 @@ async def test_single_network_error_keeps_entities_available(
 
 
 @pytest.mark.asyncio
-async def test_second_consecutive_failure_marks_unavailable_then_recovers(
+async def test_third_consecutive_failure_marks_unavailable_then_recovers(
     hass: HomeAssistant,
 ) -> None:
-    """Two failures in a row is a real outage; the next success restores state."""
+    """Three failures in a row is a real outage; the next success restores state."""
     mock_context, mock_client = await _setup(hass)
     mock_client.get_user_context = AsyncMock(side_effect=TimeoutError())
+
+    await _next_poll(hass)
+    assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
 
     await _next_poll(hass)
     assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT
@@ -106,14 +109,16 @@ async def test_second_consecutive_failure_marks_unavailable_then_recovers(
 async def test_failure_tolerance_resets_after_a_good_poll(
     hass: HomeAssistant,
 ) -> None:
-    """Fail, succeed, fail: the second failure is a fresh single failure."""
+    """Fail twice, succeed, fail twice: the count restarts at the good poll."""
     mock_context, mock_client = await _setup(hass)
 
     mock_client.get_user_context = AsyncMock(side_effect=TimeoutError())
     await _next_poll(hass)
+    await _next_poll(hass)
     mock_client.get_user_context = AsyncMock(return_value=mock_context)
     await _next_poll(hass)
     mock_client.get_user_context = AsyncMock(side_effect=TimeoutError())
+    await _next_poll(hass)
     await _next_poll(hass)
 
     assert hass.states.get(_CLIMATE_ENTITY).state == HVACMode.HEAT

--- a/tools/mock_melcloud_server.py
+++ b/tools/mock_melcloud_server.py
@@ -236,6 +236,8 @@ class MockMELCloudServer:
         self.ws_clients: set[web.WebSocketResponse] = set()
         self.ws_accept_then_close = False
         self.ws_reject_hash = False
+        # Test-only: HTTP statuses the next /context calls answer with, in order
+        self.context_fail_queue: list[int] = []
 
     def _init_ata_devices(self) -> dict[str, dict[str, Any]]:
         """Initialize default ATA (Air-to-Air) device states.
@@ -547,6 +549,12 @@ class MockMELCloudServer:
         elif action == "clear":
             self.ws_accept_then_close = False
             self.ws_reject_hash = False
+            self.context_fail_queue = []
+        elif action == "fail-context":
+            # Next `count` /context calls answer with `status` (default one 503)
+            self.context_fail_queue = [int(body.get("status", 503))] * int(
+                body.get("count", 1)
+            )
         elif action == "emit-delta":
             if "unit_id" not in body or "settings" not in body:
                 return web.json_response(
@@ -671,6 +679,10 @@ class MockMELCloudServer:
         - buildings: Owned buildings (full access)
         - guestBuildings: Shared buildings (guest access, full control)
         """
+        if self.context_fail_queue:
+            status = self.context_fail_queue.pop(0)
+            logger.info("🎛️  User Context Request answered with injected %d", status)
+            return web.Response(status=status)
         logger.info("📋 User Context Request")
 
         buildings_response = []


### PR DESCRIPTION
## Summary

`DataUpdateCoordinator` treats any exception from `_async_update_data` as a full failure, so a single failed `/context` poll marks every entity of the integration unavailable until the next poll succeeds, 60 to 120 seconds later (#309). `_async_update_data` in `custom_components/melcloudhome/coordinator.py` now routes `TimeoutError`, the `HomeAssistantError` that a network failure raises, and the 5xx `ServiceUnavailableError` through one helper, `_tolerate_poll_failure`, which for the first two consecutive failures with data already held logs a warning and returns the previous data instead of raising. The third consecutive failure raises as before, so a real outage still reads unavailable, and the counter resets on the next successful poll. The tolerance is `MAX_TOLERATED_POLL_FAILURES` in `const.py`; two because the episodes reported on three installs were mostly two polls long. Once the budget is spent a 5xx takes the existing escalating backoff exactly as before, and `ConfigEntryAuthFailed` is untouched. Prod on 2026-09-07 showed 503s as often as timeouts, which is why 5xx is in the budget. The request timeout is unchanged: the client's own session already sets `ClientTimeout(total=30)` in `api/auth.py`, well above the 80 to 250 ms a normal poll takes.

## Key changes

- `coordinator.py`: `_tolerate_poll_failure` returns the previous data for the first `MAX_TOLERATED_POLL_FAILURES` consecutive failed polls and logs a WARNING with the count; both the 5xx and the timeout/network except blocks call it, and the 5xx backoff runs only once the budget is spent. An INFO line marks recovery.
- `const.py`: `MAX_TOLERATED_POLL_FAILURES = 2`, with the reason in a comment.
- `tests/integration/test_coordinator_transient_failure.py`: six `hass.states` tests covering a single timeout, a single network error, a single 503, the third failure marking unavailable then recovering (timeout and 503), and the counter resetting after a good poll.
- `tests/integration/test_binary_sensor_ata.py`: the three tests that fail a poll to observe the outage now fail it three times.
- `tools/mock_melcloud_server.py`: `fail-context` action on the existing bearer-checked `/_mock/ws` control endpoint makes the next N `/context` responses return a chosen status, so the 5xx path can be driven on the devserver.
- `CHANGELOG.md`: Unreleased entry.

## What changes for users

- After one or two failed polls of any kind (timeout, network error, or MELCloud 5xx), every entity keeps its last known state instead of going unavailable; values shown during that gap can be up to about three and a half minutes old.
- A WARNING log line reports each tolerated failure with its count, and an INFO line reports recovery.
- The third consecutive failed poll marks entities unavailable, as any single failure did before; for a 5xx the escalating retry backoff starts there too.
- The connection-state binary sensor stays "on" through the tolerated polls, since it reads `coordinator.last_update_success`; a single failure used to switch it "off".

## Risks accepted

Entities can show data up to about three and a half minutes stale during a real outage before the third failure flips them unavailable, since the coordinator no longer surfaces the first two failed polls. An automation reading a value in that window acts on data one minute older than it would with a tolerance of one. Detectable from the WARNING lines, which carry the failure count, or from LTSS if unavailable episodes stop appearing where failed polls still occur. Undone by lowering `MAX_TOLERATED_POLL_FAILURES`.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [ ] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

- [x] `make pre-commit` at tip `00d4d97`: all hooks passed (ruff check, ruff format, mypy, codespell, gitleaks, file hygiene).
- [x] `make test-api` at tip `00d4d97`: 409 passed, 1 skipped, 16 deselected, 1 xfailed.
- [x] `make test-integration` at tip `00d4d97`: 278 passed, 1 warning, including the 6 tests in `tests/integration/test_coordinator_transient_failure.py` (each written first and watched fail with `'unavailable' == 'heat'` before its change: the original tolerance, the move to two, and the 5xx budget) and the 3 tests in `tests/integration/test_binary_sensor_ata.py` updated to fail the poll three times. The existing white-box backoff tests in `test_coordinator_retry.py` pass unchanged because they start with no data held.
- [x] `make test-e2e` at tip `00d4d97`: 16 passed, 411 deselected. The e2e mock image was not rebuilt, so the new `fail-context` action is not exercised there.
- [x] Devserver, timeout path (`make dev-restart`, mock plus a live-API entry): a paused mock produced "1 of 2" and "2 of 2 tolerated" with no state row written for the mock unit's climate or connection-state entities; the third failure produced `Timeout fetching melcloudhome data`, `unavailable` and connection `off`; recovery one poll after unpausing restored `heat` and `on`. The live-API entry tolerated a real DNS timeout and a real 404 in the same window.
- [x] Devserver, 5xx path (`make dev-rebuild`, then `fail-context`): two injected 503s were tolerated with no state row written; three injected 503s took the backoff path on the third (`retrying in 120s`), `unavailable` and connection `off`, and recovered exactly 120 s later with `heat` and `on` restored. Details in the fix notes linked above.
- [x] Production soak, started 2026-09-07 17:18 UTC at tip `00d4d97`: the first real MELCloud timeout at 18:14:07 UTC (a `/context` poll that hung the full 30 s) was tolerated as "1 of 2", recovered on the next poll 60 s later, and LTSS recorded no `unavailable` row for any entity. The same event earlier that day took every entity unavailable for 60 s. Still running 2026-09-09: LTSS records no `unavailable` episode for any entity since the deploy, against 15 in an equal-length window on the release beforehand. Every real failure since has been tolerated and recovered, including a double failure at 02:19 UTC on 2026-09-09 that used both slots and recovered on the third poll, and one network error rather than a timeout. The 5xx budget has not yet been exercised against a real 503.
