### PR TITLE
fix(coordinator): never cancel an in-flight refresh from the debounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - One or two failed requests to MELCloud no longer make every entity "unavailable" for a minute or two. Once a minute the integration asks MELCloud for the current state of all devices, and when that request timed out, dropped, or got a server error, every sensor and climate entity went unavailable until the next request succeeded. The integration now keeps the last known values across up to two consecutive failed requests of any kind and logs a warning each time; the third failure in a row marks entities unavailable, so a real outage still shows and server errors still back off as before once that happens. The 30 second request timeout is unchanged. (#309)
+- A change arriving from the MELCloud app or remote control while Home Assistant was already fetching the previous one could silently abort that fetch. The log then showed "Fetching melcloudhome data recovered" with nothing to recover from, and any entity that happened to update in the next few seconds briefly read unavailable. The fetch now always runs to completion; a new change only restarts the short wait before it.
 
 ## [2.5.0] - 2026-09-02
 

--- a/custom_components/melcloudhome/const.py
+++ b/custom_components/melcloudhome/const.py
@@ -20,7 +20,6 @@ UPDATE_INTERVAL = timedelta(seconds=60)
 # unavailable. MELCloud slow patches seen on three installs mostly took two
 # polls in a row (#309); the third failure is treated as a real outage.
 MAX_TOLERATED_POLL_FAILURES = 2
-PLATFORMS = ["climate"]
 
 # Configuration keys
 CONF_DEBUG_MODE = "debug_mode"
@@ -107,7 +106,7 @@ __all__ = [
     "DOMAIN",
     "HOUR_VALUE_RETENTION_HOURS",
     "MAX_PLAUSIBLE_HOURLY_ENERGY_KWH",
-    "PLATFORMS",
+    "MAX_TOLERATED_POLL_FAILURES",
     "UPDATE_INTERVAL",
     "UPDATE_INTERVAL_ENERGY",
     "UPDATE_INTERVAL_OUTDOOR_TEMP",

--- a/custom_components/melcloudhome/control_client_base.py
+++ b/custom_components/melcloudhome/control_client_base.py
@@ -45,7 +45,12 @@ class ControlClientBase:
             """Wait then refresh."""
             await asyncio.sleep(delay)
             _LOGGER.debug("Debounced refresh executing after %.1fs delay", delay)
-            await self._async_request_refresh()  # type: ignore[attr-defined]
+            # Only the wait is cancellable. Cancelling this task once the
+            # refresh has started would cancel the refresh itself, which HA's
+            # coordinator records as a silent failure (last_update_success
+            # False, no log, no listener update) followed by a bogus
+            # "recovered" on the next poll.
+            await asyncio.shield(self._async_request_refresh())  # type: ignore[attr-defined]
 
         self._refresh_debounce_task = self._hass.async_create_task(_delayed_refresh())
 

--- a/tests/integration/test_coordinator_retry.py
+++ b/tests/integration/test_coordinator_retry.py
@@ -402,3 +402,40 @@ async def test_deduplication_sends_different_value(coordinator):
 
     # SHOULD call API
     assert coordinator.client.ata.set_power.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_new_debounce_request_does_not_cancel_in_flight_refresh(
+    coordinator, hass
+):
+    """A second debounced request must not kill a refresh already running.
+
+    Seen on prod: a WebSocket delta landing while the previous delta's refresh
+    was mid-request cancelled that refresh. HA's coordinator treats a cancelled
+    refresh as a silent failure (last_update_success=False, no log, no listener
+    update), followed by a bogus "recovered" on the next poll.
+    """
+    from custom_components.melcloudhome.api.models import UserContext
+
+    mock_context = AsyncMock(spec=UserContext)
+    mock_context.buildings = []
+    coordinator.client.restore_tokens("token", "refresh", time.time() + 3600)
+
+    started = asyncio.Event()
+    gate = asyncio.Event()
+
+    async def slow_context() -> UserContext:
+        started.set()
+        await gate.wait()
+        return mock_context
+
+    coordinator.client.get_user_context = slow_context
+    await coordinator.async_request_refresh_debounced(delay=0.01)
+    await started.wait()  # first refresh is now mid-request
+
+    await coordinator.async_request_refresh_debounced(delay=0.01)  # a new delta
+    gate.set()
+    await asyncio.sleep(0.05)
+    await hass.async_block_till_done()
+
+    assert coordinator.last_update_success is True


### PR DESCRIPTION
## Summary

Stacked on #314; this fix is independent of that PR's poll-tolerance logic and shares only its history. HA's request Debouncer runs a refresh inline, so once `ControlClientBase`'s debounce sleep elapses, the task awaiting `_async_request_refresh()` is the refresh itself, and a second trigger arriving during that request cancelled it. `DataUpdateCoordinator` treats a cancelled refresh as a silent failure: `last_update_success` flips to `False` with no log line and no listener update, so entities keep their state while the flag lies, and the next successful poll logs a "recovered" with no visible failure before it. Prod debug captures on 2026-09-07 show three instances of this shape, each a WebSocket delta landing while the previous delta's refresh was mid-request; no issue is filed for it yet. Sequence and timestamps: `_claude/github_issues/debounce-cancels-in-flight-refresh.md`. `_delayed_refresh` now wraps the refresh in `asyncio.shield`, so cancelling the debounce task only ever cancels the wait; two refreshes can briefly overlap, which HA's own request Debouncer already coalesces.

Also in this PR, unrelated to the refresh: `const.py` loses the dead `PLATFORMS` constant, which read `["climate"]` while `__init__.py` builds its own list of five platforms in both setup and unload, and gains `MAX_TOLERATED_POLL_FAILURES` in `__all__` alongside every other tuning constant in the file.

## What changes for users

- The log line "Fetching melcloudhome data recovered" no longer appears without a real failure before it.
- Entities no longer briefly read unavailable in the seconds after two MELCloud-side changes land in quick succession.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [ ] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

- [x] `make pre-commit` at tip `2763090`: all hooks passed.
- [x] `make test-api` at tip `2763090`: 409 passed, 1 skipped, 16 deselected, 1 xfailed.
- [x] `make test-integration` at tip `2763090`: 279 passed, 1 warning, including the new white-box test `test_new_debounce_request_does_not_cancel_in_flight_refresh` in `tests/integration/test_coordinator_retry.py`, which fails with `assert False is True` before the one-line change and passes after.
- [x] `make test-e2e` at tip `2763090`: 16 passed, 411 deselected.
- [ ] Devserver deployment: not done at this tip. Reproducing the bug needs two WebSocket deltas inside one request window, which the devserver's mock cannot be made to produce on demand.
- [x] Production deployment and soak, deployed 2026-09-08 08:00 UTC at tip `7184760` with debug logging on: at 11:27:37 UTC a WebSocket delta landed 122 ms into a debounced refresh and cancelled the debounce, and that refresh finished `success: True`. The same shape logged `success: False` three times before the fix (2026-09-07 23:05, 23:16, 23:28 UTC). No `Fetching melcloudhome data recovered` without a real failure since the deploy.
