### PR TITLE
feat(ata): add a fan entity for speed, vane and unit power

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The integration creates the following entities for each device:
 
 **Complete entity reference:** See [docs/entities.md](docs/entities.md) for detailed entity IDs, control options, and configuration examples.
 
+**Apple HomeKit:** See [docs/homekit.md](docs/homekit.md) for what the fan entity looks like in the Home app, how to get it bridged, and the behaviour that surprises people.
+
 ## Troubleshooting
 
 ### Integration Not Loading
@@ -194,6 +196,7 @@ These intervals balance update frequency with API rate limits. Real-time updates
 
 **Documentation:**
 
+- [Using MELCloud Home with Apple HomeKit](docs/homekit.md) - What appears in the Home app and how it behaves
 - [Architecture Overview](docs/architecture.md) - Visual system architecture with mermaid diagrams
 - [Testing Best Practices](docs/testing-best-practices.md) - Development setup and testing guidelines
 - [Architecture Decision Records](docs/README.md#architecture-decision-records-adrs) - Key architectural decisions

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The integration creates the following entities for each device:
 **Air-to-Air (ATA) Systems:**
 
 - Climate control (HVAC modes, temperature, fan speeds, swing)
+- Fan (fan speed, vane oscillation, unit power — gives HomeKit a speed slider and swing switch)
 - Sensors (room temperature, outdoor temperature, WiFi signal, energy consumption)
 - Binary sensors (error state, connection status)
 

--- a/custom_components/melcloudhome/__init__.py
+++ b/custom_components/melcloudhome/__init__.py
@@ -271,6 +271,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     platforms: list[Platform] = [
         Platform.BINARY_SENSOR,
         Platform.CLIMATE,
+        Platform.FAN,
         Platform.SENSOR,
         Platform.SWITCH,
         Platform.WATER_HEATER,
@@ -378,6 +379,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     platforms: list[Platform] = [
         Platform.BINARY_SENSOR,
         Platform.CLIMATE,
+        Platform.FAN,
         Platform.SENSOR,
         Platform.SWITCH,
         Platform.WATER_HEATER,

--- a/custom_components/melcloudhome/fan.py
+++ b/custom_components/melcloudhome/fan.py
@@ -1,0 +1,190 @@
+"""Fan platform for MELCloud Home integration.
+
+Exposes ATA fan speed, vane oscillation and unit power as a fan entity.
+The climate entity's own fan_modes and swing_modes are deliberately
+untouched; ADR-025 records why these controls live here instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.percentage import (
+    ordered_list_item_to_percentage,
+    percentage_to_ordered_list_item,
+)
+
+from .api.models import AirToAirUnit, Building
+from .const import DOMAIN
+from .const_ata import ATA_FAN_SPEEDS, ATAEntityBase, normalize_to_api
+from .coordinator import MELCloudHomeCoordinator
+from .helpers import create_device_info, with_debounced_refresh
+from .protocols import CoordinatorProtocol
+
+_LOGGER = logging.getLogger(__name__)
+
+# ATA_FAN_SPEEDS[0] is "auto", which a percentage cannot express, so it is
+# carried as the sole preset instead. The rest are the ordered speed list.
+_AUTO_PRESET = ATA_FAN_SPEEDS[0]
+_NUMBERED_SPEEDS = ATA_FAN_SPEEDS[1:]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up MELCloud Home fan entities."""
+    _LOGGER.debug("Setting up MELCloud Home fan platform")
+
+    coordinator: MELCloudHomeCoordinator = hass.data[DOMAIN][entry.entry_id][
+        "coordinator"
+    ]
+
+    entities: list[ATAFan] = []
+    for building in coordinator.data.buildings:
+        for unit in building.air_to_air_units:
+            # A unit reporting no speeds would give speed_count == 0, and
+            # FanEntity.percentage_step is 100 / speed_count, so every state
+            # update would raise ZeroDivisionError. capabilities itself is
+            # never None; from_dict defaults it.
+            if unit.capabilities.number_of_fan_speeds < 1:
+                _LOGGER.debug("Skipping fan entity for %s: no fan speeds", unit.id[-8:])
+                continue
+            entities.append(ATAFan(coordinator, unit, building, entry))
+
+    _LOGGER.debug("Created %d fan entities", len(entities))
+    async_add_entities(entities)
+
+
+class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
+    """Fan entity for an ATA unit's blower and vertical vane.
+
+    Note: type: ignore[misc] required because HA is not installed in dev
+    environment (aiohttp version conflict). Mypy sees HA base classes as 'Any'.
+    """
+
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+
+    def __init__(
+        self,
+        coordinator: CoordinatorProtocol,
+        unit: AirToAirUnit,
+        building: Building,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the fan entity."""
+        super().__init__(coordinator)
+        self._unit_id = unit.id
+        self._building_id = building.id
+        self._entry = entry
+        self._attr_unique_id = f"{unit.id}_ac_fan"
+        self._attr_preset_modes = [_AUTO_PRESET]
+
+        # Named for the air conditioner: a Home app user who did not install
+        # the integration should not read this as a room fan.
+        self._attr_name = "A/C fan"
+        self._attr_device_info = create_device_info(unit, building)
+
+        # Slider resolution comes from this. The HomeKit bridge uses
+        # 100 / speed_count as its step, giving one detent per real speed.
+        speeds = unit.capabilities.number_of_fan_speeds
+        self._ordered_speeds = _NUMBERED_SPEEDS[:speeds]
+        self._attr_speed_count = len(self._ordered_speeds)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the unit is powered on."""
+        device = self.get_device()
+        if device is None:
+            return None
+        return device.power
+
+    @property
+    def percentage(self) -> int | None:
+        """Return the commanded speed as a percentage.
+
+        None while the unit is in auto, because no numbered speed is
+        commanded then; the auto preset carries that state instead.
+        """
+        device = self.get_device()
+        if device is None or device.set_fan_speed is None:
+            return None
+        speed = device.set_fan_speed.lower()
+        if speed not in self._ordered_speeds:
+            return None
+        return ordered_list_item_to_percentage(  # type: ignore[no-any-return]
+            self._ordered_speeds, speed
+        )
+
+    @property
+    def preset_mode(self) -> str | None:
+        """Return "auto" while the unit picks its own speed."""
+        device = self.get_device()
+        if device is None or device.set_fan_speed is None:
+            return None
+        if device.set_fan_speed.lower() == _AUTO_PRESET:
+            return _AUTO_PRESET
+        return None
+
+    @with_debounced_refresh()
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the fan speed.
+
+        Implemented rather than inherited: HomeKit's slider has a zero detent,
+        and FanEntity.async_set_percentage routes zero to async_turn_off()
+        without returning, so it would power the unit down and then also send a
+        speed. Zero means unit power off here, and nothing else.
+        """
+        if percentage == 0:
+            await self.coordinator.async_set_power(self._unit_id, False)
+            return
+        speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
+        await self.coordinator.async_set_fan_speed(
+            self._unit_id, normalize_to_api(speed)
+        )
+
+    @with_debounced_refresh()
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Hand speed selection back to the unit."""
+        await self.coordinator.async_set_fan_speed(
+            self._unit_id, normalize_to_api(preset_mode)
+        )
+
+    @with_debounced_refresh()
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Power the unit on, optionally at a given speed."""
+        await self.coordinator.async_set_power(self._unit_id, True)
+        if preset_mode is not None:
+            await self.coordinator.async_set_fan_speed(
+                self._unit_id, normalize_to_api(preset_mode)
+            )
+        elif percentage:
+            speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
+            await self.coordinator.async_set_fan_speed(
+                self._unit_id, normalize_to_api(speed)
+            )
+
+    @with_debounced_refresh()
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Power the unit off.
+
+        An air conditioner has no "fan off, unit running" state, so this is the
+        only thing off can mean. ADR-025 records that this is deliberate, and
+        that HomeKit shows the button whether or not the feature is declared.
+        """
+        await self.coordinator.async_set_power(self._unit_id, False)

--- a/custom_components/melcloudhome/fan.py
+++ b/custom_components/melcloudhome/fan.py
@@ -82,6 +82,7 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         | FanEntityFeature.TURN_ON
         | FanEntityFeature.TURN_OFF
     )
+    _attr_translation_key = "melcloudhome"  # For preset mode translations
 
     def __init__(
         self,

--- a/custom_components/melcloudhome/fan.py
+++ b/custom_components/melcloudhome/fan.py
@@ -76,12 +76,6 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
     environment (aiohttp version conflict). Mypy sees HA base classes as 'Any'.
     """
 
-    _attr_supported_features = (
-        FanEntityFeature.SET_SPEED
-        | FanEntityFeature.OSCILLATE
-        | FanEntityFeature.TURN_ON
-        | FanEntityFeature.TURN_OFF
-    )
     _attr_translation_key = "melcloudhome"  # For preset mode translations
 
     def __init__(
@@ -109,6 +103,17 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         speeds = unit.capabilities.number_of_fan_speeds
         self._ordered_speeds = _NUMBERED_SPEEDS[:speeds]
         self._attr_speed_count = len(self._ordered_speeds)
+
+        # Oscillation writes vaneVerticalDirection, so only offer it where the
+        # hardware has a vane. Same gate the climate entity puts on SWING_MODE.
+        features = (
+            FanEntityFeature.SET_SPEED
+            | FanEntityFeature.TURN_ON
+            | FanEntityFeature.TURN_OFF
+        )
+        if unit.capabilities.has_swing or unit.capabilities.has_air_direction:
+            features |= FanEntityFeature.OSCILLATE
+        self._attr_supported_features = features
 
     @property
     def is_on(self) -> bool | None:
@@ -160,6 +165,40 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
             self._unit_id, _VANE_SWING if oscillating else _VANE_AUTO
         )
 
+    async def _async_power_on(self) -> None:
+        """Power the unit on without disturbing its operation mode.
+
+        A bare power write sends operationMode=null, which can trigger a
+        mode-conflict fault on multi-zone outdoor units. The mode is only
+        omitted when the device reports none to preserve.
+        """
+        device = self.get_device()
+        if device and device.operation_mode:
+            await self.coordinator.async_set_power_and_mode(
+                self._unit_id, True, device.operation_mode
+            )
+        else:
+            await self.coordinator.async_set_power(self._unit_id, True)
+
+    async def _async_apply_percentage(self, percentage: int) -> None:
+        """Apply a slider position: zero powers off, anything else sets a speed.
+
+        The unit is powered on as well as sped up, because the HomeKit bridge
+        sends Active=1 and RotationSpeed in one write when the slider is dragged
+        up on an off tile, and then deliberately skips fan.turn_on on the
+        assumption that a SET_SPEED fan powers itself on. The control client
+        skips a write the device already satisfies, so on an already-running
+        unit this costs no extra API call.
+        """
+        if percentage == 0:
+            await self.coordinator.async_set_power(self._unit_id, False)
+            return
+        await self._async_power_on()
+        speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
+        await self.coordinator.async_set_fan_speed(
+            self._unit_id, normalize_to_api(speed)
+        )
+
     @with_debounced_refresh()
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the fan speed.
@@ -169,13 +208,7 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         without returning, so it would power the unit down and then also send a
         speed. Zero means unit power off here, and nothing else.
         """
-        if percentage == 0:
-            await self.coordinator.async_set_power(self._unit_id, False)
-            return
-        speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
-        await self.coordinator.async_set_fan_speed(
-            self._unit_id, normalize_to_api(speed)
-        )
+        await self._async_apply_percentage(percentage)
 
     @with_debounced_refresh()
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -191,17 +224,20 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
-        """Power the unit on, optionally at a given speed."""
-        await self.coordinator.async_set_power(self._unit_id, True)
+        """Power the unit on, optionally at a given speed or preset.
+
+        percentage=0 is permitted by the service schema and means the same here
+        as it does to fan.set_percentage: power off.
+        """
         if preset_mode is not None:
+            await self._async_power_on()
             await self.coordinator.async_set_fan_speed(
                 self._unit_id, normalize_to_api(preset_mode)
             )
-        elif percentage:
-            speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
-            await self.coordinator.async_set_fan_speed(
-                self._unit_id, normalize_to_api(speed)
-            )
+        elif percentage is not None:
+            await self._async_apply_percentage(percentage)
+        else:
+            await self._async_power_on()
 
     @with_debounced_refresh()
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/custom_components/melcloudhome/fan.py
+++ b/custom_components/melcloudhome/fan.py
@@ -137,6 +137,21 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         self._ordered_speeds = _NUMBERED_SPEEDS[:speeds]
         self._attr_speed_count = len(self._ordered_speeds)
 
+        # Percentage of the last numbered speed seen, so that while the unit
+        # is in auto, percentage (below) can report it instead of None. See
+        # _handle_coordinator_update and percentage. Seeded from the unit this
+        # entity was constructed with -- itself the coordinator's first fetch,
+        # not a write of ours -- so a unit that starts on a numbered speed and
+        # is switched straight to auto on the very next update still has
+        # something to resume. Stays None if the unit starts in auto: nothing
+        # has been seen yet, so percentage keeps returning None (ADR-025).
+        self._last_numbered_percentage: int | None = None
+        initial_speed = (unit.set_fan_speed or "").lower()
+        if initial_speed in self._ordered_speeds:
+            self._last_numbered_percentage = ordered_list_item_to_percentage(
+                self._ordered_speeds, initial_speed
+            )
+
         # Oscillation writes vaneVerticalDirection, so only offer it where the
         # hardware has a vane. Same gate the climate entity puts on SWING_MODE.
         features = (
@@ -160,13 +175,19 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
     def percentage(self) -> int | None:
         """Return the commanded speed as a percentage.
 
-        None while the unit is in auto, because no numbered speed is
-        commanded then; the auto preset carries that state instead.
+        While the unit is in auto, no numbered speed is commanded -- the auto
+        preset carries that state instead -- so this reports the percentage of
+        the last numbered speed seen (see _handle_coordinator_update), letting
+        HomeKit's Manual/Auto toggle resume the speed the user was actually on
+        instead of falling back to its own hard-coded 50%. None only if no
+        numbered speed has ever been seen.
         """
         device = self.get_device()
         if device is None or device.set_fan_speed is None:
             return None
         speed = device.set_fan_speed.lower()
+        if speed == _AUTO_PRESET:
+            return self._last_numbered_percentage
         if speed not in self._ordered_speeds:
             return None
         return ordered_list_item_to_percentage(  # type: ignore[no-any-return]
@@ -182,6 +203,26 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         if device.set_fan_speed.lower() == _AUTO_PRESET:
             return _AUTO_PRESET
         return None
+
+    def _handle_coordinator_update(self) -> None:
+        """Remember the last numbered speed seen, then update entity state.
+
+        The commanded speed can change from the climate entity's fan_mode
+        dropdown, the vendor's own app, or a service call -- none of which are
+        calls into this entity, so they all arrive here rather than through a
+        write this class made itself. ATAEntityBase (CoordinatorEntity) does
+        not override this hook, so this is the only place that sees every one
+        of those paths; super() below reaches CoordinatorEntity's default
+        implementation directly and still writes the state.
+        """
+        device = self.get_device()
+        if device is not None and device.set_fan_speed is not None:
+            speed = device.set_fan_speed.lower()
+            if speed in self._ordered_speeds:
+                self._last_numbered_percentage = ordered_list_item_to_percentage(
+                    self._ordered_speeds, speed
+                )
+        super()._handle_coordinator_update()
 
     @property
     def oscillating(self) -> bool | None:

--- a/custom_components/melcloudhome/fan.py
+++ b/custom_components/melcloudhome/fan.py
@@ -47,12 +47,13 @@ _VANE_AUTO = "Auto"
 # intermediate position), each preceded by a power-on write. The shared
 # write-dedup in control_client_ata compares against coordinator data, which
 # stays stale for the whole debounced-refresh window, so it cannot suppress
-# these. with_debounced_refresh() defaults to a 2.0s delay; this guard window
-# needs to be at least that long to bridge the gap until a refresh lands, plus
-# headroom for scheduling and network jitter within the burst itself. The speed
-# write is deferred by _SPEED_DEBOUNCE_WINDOW before its refresh is even
-# requested, so the stale window is the sum of the two and still fits inside
-# this guard.
+# these. with_debounced_refresh() defaults to a 2.0s delay, and that timer is
+# shared with the control client and restarted by every WebSocket delta, so the
+# stale window has no fixed upper bound -- during a busy drag it can outlast
+# this guard. Three seconds covers the ordinary case (one refresh delay plus the
+# deferred speed write, with headroom for scheduling and network jitter) without
+# claiming to cover every case: when it is outlasted, the only consequence is
+# one redundant power-on write, which the API accepts on a running unit.
 _POWER_ON_GUARD_WINDOW = 3.0
 
 # How long a slider position must stand still before it is written. Overlapping
@@ -253,6 +254,14 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         fan.turn_on -- called with guard left False -- always powers on: the
         guard exists to tame set_percentage's drag burst, not to make the
         documented service unreliable.
+
+        The deadline is armed before the write is awaited, not after. HomeKit's
+        bridge dispatches each service call as its own un-awaited task and HA
+        takes no per-entity lock, so calls genuinely interleave at the await
+        below; arming afterwards lets every call that arrives while the first
+        power-on is in flight past the check and issue its own. Arming first
+        would, on its own, make a *failed* power-on suppress the retry that
+        follows it, so the deadline is put back if the write raises.
         """
         if (
             guard
@@ -262,13 +271,17 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
             return
 
         device = self.get_device()
-        if device and device.operation_mode:
-            await self.coordinator.async_set_power_and_mode(
-                self._unit_id, True, device.operation_mode
-            )
-        else:
-            await self.coordinator.async_set_power(self._unit_id, True)
         self._power_on_guard_until = time.monotonic() + _POWER_ON_GUARD_WINDOW
+        try:
+            if device and device.operation_mode:
+                await self.coordinator.async_set_power_and_mode(
+                    self._unit_id, True, device.operation_mode
+                )
+            else:
+                await self.coordinator.async_set_power(self._unit_id, True)
+        except Exception:
+            self._power_on_guard_until = None
+            raise
 
     async def _async_apply_percentage(
         self, percentage: int, *, guard: bool = False
@@ -284,6 +297,9 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         _async_power_on; see that method and async_set_percentage.
         """
         if percentage == 0:
+            # Dragging to the zero detent is an explicit power-off, which
+            # invalidates the guard's premise; see async_turn_off.
+            self._power_on_guard_until = None
             await self.coordinator.async_set_power(self._unit_id, False)
             return
         await self._async_power_on(guard=guard)
@@ -306,14 +322,22 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         debounced) timer when the *service call* returns, which is before this
         write has even been issued. Requesting it after the write keeps the poll
         downstream of the thing it is meant to observe.
+
+        The refresh runs even when the write raises: this is a timer callback,
+        so there is no service call left to report the failure to, and without a
+        refresh the tile would keep showing the speed that was never written
+        until the next poll. The exception still propagates and is logged by the
+        job that runs this callback.
         """
         self._cancel_speed_write = None
         percentage = self._pending_percentage
         if percentage is None:
             return
         self._pending_percentage = None
-        await self._async_apply_percentage(percentage, guard=True)
-        await self.coordinator.async_request_refresh_debounced()
+        try:
+            await self._async_apply_percentage(percentage, guard=True)
+        finally:
+            await self.coordinator.async_request_refresh_debounced()
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the fan speed.
@@ -333,14 +357,23 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         dedup can't catch the repeats because it reads coordinator data that
         stays stale for the whole debounced-refresh window. fan.turn_on does
         not set guard, so it always powers on regardless of a recent drag.
+
+        The pending value and its timer are taken before the power-on is
+        awaited. HomeKit's bridge dispatches each call as its own un-awaited
+        task and HA takes no per-entity lock, so a call that suspends on the
+        power-on request resumes after a newer one has already run: writing the
+        pending value afterwards would let the older slider position overwrite
+        the newer one and win the timer, which is exactly the #318 symptom.
+        Claiming it first means the last call to *enter* this method owns the
+        write, whatever order the awaits finish in.
         """
-        if percentage > 0:
-            await self._async_power_on(guard=True)
         self._pending_percentage = percentage
         self._cancel_pending_speed_write()
         self._cancel_speed_write = async_call_later(
             self.hass, _SPEED_DEBOUNCE_WINDOW, self._async_write_pending_percentage
         )
+        if percentage > 0:
+            await self._async_power_on(guard=True)
 
     async def async_will_remove_from_hass(self) -> None:
         """Cancel a pending speed write so nothing fires after removal."""
@@ -390,6 +423,18 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         An air conditioner has no "fan off, unit running" state, so this is the
         only thing off can mean. ADR-025 records that this is deliberate, and
         that HomeKit shows the button whether or not the feature is declared.
+
+        The power-on guard is dropped here. It is armed whenever a guarded
+        power-on runs, including when the shared write-dedup skipped the API
+        call because the unit was already on -- so a slider drag on a running
+        unit leaves it armed for three seconds without any power write having
+        happened. Turning the unit off inside that window and dragging the
+        slider straight back up would then hit set_percentage alone (the bridge
+        sends Active and RotationSpeed together and skips fan.turn_on), the
+        guard would suppress the power-on, and the unit would stay off with a
+        speed write landing on it. An explicit power-off invalidates the
+        premise the guard rests on, so it stops applying.
         """
         self._cancel_pending_speed_write()
+        self._power_on_guard_until = None
         await self.coordinator.async_set_power(self._unit_id, False)

--- a/custom_components/melcloudhome/fan.py
+++ b/custom_components/melcloudhome/fan.py
@@ -8,6 +8,7 @@ untouched; ADR-025 records why these controls live here instead.
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
@@ -39,6 +40,15 @@ _NUMBERED_SPEEDS = ATA_FAN_SPEEDS[1:]
 # is true of the hardware.
 _VANE_SWING = "Swing"
 _VANE_AUTO = "Auto"
+
+# HomeKit streams several set_percentage calls per slider drag (one per
+# intermediate position), each preceded by a power-on write. The shared
+# write-dedup in control_client_ata compares against coordinator data, which
+# stays stale for the whole debounced-refresh window, so it cannot suppress
+# these. with_debounced_refresh() defaults to a 2.0s delay; this guard window
+# needs to be at least that long to bridge the gap until a refresh lands, plus
+# headroom for scheduling and network jitter within the burst itself.
+_POWER_ON_GUARD_WINDOW = 3.0
 
 
 async def async_setup_entry(
@@ -92,6 +102,10 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         self._entry = entry
         self._attr_unique_id = f"{unit.id}_ac_fan"
         self._attr_preset_modes = [_AUTO_PRESET]
+
+        # monotonic() deadline until which a *guarded* power-on is suppressed;
+        # see _POWER_ON_GUARD_WINDOW and _async_power_on.
+        self._power_on_guard_until: float | None = None
 
         # Named for the air conditioner: a Home app user who did not install
         # the integration should not read this as a room fan.
@@ -165,13 +179,28 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
             self._unit_id, _VANE_SWING if oscillating else _VANE_AUTO
         )
 
-    async def _async_power_on(self) -> None:
+    async def _async_power_on(self, *, guard: bool = False) -> None:
         """Power the unit on without disturbing its operation mode.
 
         A bare power write sends operationMode=null, which can trigger a
         mode-conflict fault on multi-zone outdoor units. The mode is only
         omitted when the device reports none to preserve.
+
+        guard=True suppresses the write entirely while a previous guarded (or
+        unguarded) power-on is still within _POWER_ON_GUARD_WINDOW, to collapse
+        the repeated power-on writes a HomeKit slider drag issues. It is opt-in
+        per call site rather than a blanket check inside this method, so
+        fan.turn_on -- called with guard left False -- always powers on: the
+        guard exists to tame set_percentage's drag burst, not to make the
+        documented service unreliable.
         """
+        if (
+            guard
+            and self._power_on_guard_until is not None
+            and time.monotonic() < self._power_on_guard_until
+        ):
+            return
+
         device = self.get_device()
         if device and device.operation_mode:
             await self.coordinator.async_set_power_and_mode(
@@ -179,8 +208,11 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
             )
         else:
             await self.coordinator.async_set_power(self._unit_id, True)
+        self._power_on_guard_until = time.monotonic() + _POWER_ON_GUARD_WINDOW
 
-    async def _async_apply_percentage(self, percentage: int) -> None:
+    async def _async_apply_percentage(
+        self, percentage: int, *, guard: bool = False
+    ) -> None:
         """Apply a slider position: zero powers off, anything else sets a speed.
 
         The unit is powered on as well as sped up, because the HomeKit bridge
@@ -188,12 +220,13 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         up on an off tile, and then deliberately skips fan.turn_on on the
         assumption that a SET_SPEED fan powers itself on. The control client
         skips a write the device already satisfies, so on an already-running
-        unit this costs no extra API call.
+        unit this costs no extra API call. guard is forwarded to
+        _async_power_on; see that method and async_set_percentage.
         """
         if percentage == 0:
             await self.coordinator.async_set_power(self._unit_id, False)
             return
-        await self._async_power_on()
+        await self._async_power_on(guard=guard)
         speed = percentage_to_ordered_list_item(self._ordered_speeds, percentage)
         await self.coordinator.async_set_fan_speed(
             self._unit_id, normalize_to_api(speed)
@@ -207,8 +240,14 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         and FanEntity.async_set_percentage routes zero to async_turn_off()
         without returning, so it would power the unit down and then also send a
         speed. Zero means unit power off here, and nothing else.
+
+        guard=True here (and only here): a slider drag calls this repeatedly in
+        quick succession, each preceded by a power-on, and the shared write-
+        dedup can't catch the repeats because it reads coordinator data that
+        stays stale for the whole debounced-refresh window. fan.turn_on does
+        not set guard, so it always powers on regardless of a recent drag.
         """
-        await self._async_apply_percentage(percentage)
+        await self._async_apply_percentage(percentage, guard=True)
 
     @with_debounced_refresh()
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/custom_components/melcloudhome/fan.py
+++ b/custom_components/melcloudhome/fan.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util.percentage import (
     ordered_list_item_to_percentage,
     percentage_to_ordered_list_item,
@@ -47,8 +49,21 @@ _VANE_AUTO = "Auto"
 # stays stale for the whole debounced-refresh window, so it cannot suppress
 # these. with_debounced_refresh() defaults to a 2.0s delay; this guard window
 # needs to be at least that long to bridge the gap until a refresh lands, plus
-# headroom for scheduling and network jitter within the burst itself.
+# headroom for scheduling and network jitter within the burst itself. The speed
+# write is deferred by _SPEED_DEBOUNCE_WINDOW before its refresh is even
+# requested, so the stale window is the sum of the two and still fits inside
+# this guard.
 _POWER_ON_GUARD_WINDOW = 3.0
+
+# How long a slider position must stand still before it is written. Overlapping
+# speed writes are applied by the server in arrival order, not issue order, so a
+# burst can land on an earlier value than the one the user released on (#318):
+# a drag ending on Three wrote Two, Three, Three, Three and settled on Two.
+# Sending only the final position makes that race impossible. The writes in that
+# production log were ~260ms apart, so the window has to be comfortably wider
+# than that or the timer fires mid-drag and the burst is back; 0.5s is roughly
+# double the measured gap and still reads as immediate at the tile.
+_SPEED_DEBOUNCE_WINDOW = 0.5
 
 
 async def async_setup_entry(
@@ -106,6 +121,10 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         # monotonic() deadline until which a *guarded* power-on is suppressed;
         # see _POWER_ON_GUARD_WINDOW and _async_power_on.
         self._power_on_guard_until: float | None = None
+
+        # Pending debounced speed write; see _SPEED_DEBOUNCE_WINDOW.
+        self._cancel_speed_write: CALLBACK_TYPE | None = None
+        self._pending_percentage: int | None = None
 
         # Named for the air conditioner: a Home app user who did not install
         # the integration should not read this as a room fan.
@@ -232,7 +251,29 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
             self._unit_id, normalize_to_api(speed)
         )
 
-    @with_debounced_refresh()
+    def _cancel_pending_speed_write(self) -> None:
+        """Drop any speed write still waiting on the debounce timer."""
+        if self._cancel_speed_write is not None:
+            self._cancel_speed_write()
+            self._cancel_speed_write = None
+
+    async def _async_write_pending_percentage(self, _now: datetime) -> None:
+        """Write the slider position the user actually settled on.
+
+        The refresh is requested here rather than by @with_debounced_refresh on
+        async_set_percentage, because that decorator starts its own (separately
+        debounced) timer when the *service call* returns, which is before this
+        write has even been issued. Requesting it after the write keeps the poll
+        downstream of the thing it is meant to observe.
+        """
+        self._cancel_speed_write = None
+        percentage = self._pending_percentage
+        if percentage is None:
+            return
+        self._pending_percentage = None
+        await self._async_apply_percentage(percentage, guard=True)
+        await self.coordinator.async_request_refresh_debounced()
+
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the fan speed.
 
@@ -241,17 +282,34 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         without returning, so it would power the unit down and then also send a
         speed. Zero means unit power off here, and nothing else.
 
+        Only the speed write is debounced; the power-on stays immediate so the
+        unit starts the moment a drag begins rather than half a second later.
+        Deferring zero along with the rest is deliberate: dragging *through* the
+        zero detent on the way up no longer powers the unit off en route.
+
         guard=True here (and only here): a slider drag calls this repeatedly in
         quick succession, each preceded by a power-on, and the shared write-
         dedup can't catch the repeats because it reads coordinator data that
         stays stale for the whole debounced-refresh window. fan.turn_on does
         not set guard, so it always powers on regardless of a recent drag.
         """
-        await self._async_apply_percentage(percentage, guard=True)
+        if percentage > 0:
+            await self._async_power_on(guard=True)
+        self._pending_percentage = percentage
+        self._cancel_pending_speed_write()
+        self._cancel_speed_write = async_call_later(
+            self.hass, _SPEED_DEBOUNCE_WINDOW, self._async_write_pending_percentage
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel a pending speed write so nothing fires after removal."""
+        self._cancel_pending_speed_write()
+        await super().async_will_remove_from_hass()
 
     @with_debounced_refresh()
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Hand speed selection back to the unit."""
+        self._cancel_pending_speed_write()
         await self.coordinator.async_set_fan_speed(
             self._unit_id, normalize_to_api(preset_mode)
         )
@@ -267,7 +325,13 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
 
         percentage=0 is permitted by the service schema and means the same here
         as it does to fan.set_percentage: power off.
+
+        Applied immediately, not debounced: an explicit service call is a
+        deliberate single command, not a drag. Same reasoning that has turn_on
+        bypass the power-on guard. It does supersede a pending drag write, which
+        would otherwise land afterwards and undo it.
         """
+        self._cancel_pending_speed_write()
         if preset_mode is not None:
             await self._async_power_on()
             await self.coordinator.async_set_fan_speed(
@@ -286,4 +350,5 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         only thing off can mean. ADR-025 records that this is deliberate, and
         that HomeKit shows the button whether or not the feature is declared.
         """
+        self._cancel_pending_speed_write()
         await self.coordinator.async_set_power(self._unit_id, False)

--- a/custom_components/melcloudhome/fan.py
+++ b/custom_components/melcloudhome/fan.py
@@ -33,6 +33,13 @@ _LOGGER = logging.getLogger(__name__)
 _AUTO_PRESET = ATA_FAN_SPEEDS[0]
 _NUMBERED_SPEEDS = ATA_FAN_SPEEDS[1:]
 
+# The vane values oscillation maps onto. "Swing" sweeps; "Auto" is a fixed
+# angle chosen by operating mode, which the Mitsubishi MSZ-LN instructions and
+# the MELCloud Home manual both document, so reporting Auto as not oscillating
+# is true of the hardware.
+_VANE_SWING = "Swing"
+_VANE_AUTO = "Auto"
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -71,6 +78,7 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
 
     _attr_supported_features = (
         FanEntityFeature.SET_SPEED
+        | FanEntityFeature.OSCILLATE
         | FanEntityFeature.TURN_ON
         | FanEntityFeature.TURN_OFF
     )
@@ -135,6 +143,21 @@ class ATAFan(ATAEntityBase, FanEntity):  # type: ignore[misc]
         if device.set_fan_speed.lower() == _AUTO_PRESET:
             return _AUTO_PRESET
         return None
+
+    @property
+    def oscillating(self) -> bool | None:
+        """Return true while the vane is sweeping."""
+        device = self.get_device()
+        if device is None or device.vane_vertical_direction is None:
+            return None
+        return device.vane_vertical_direction == _VANE_SWING
+
+    @with_debounced_refresh()
+    async def async_oscillate(self, oscillating: bool) -> None:
+        """Start or stop the vane sweeping."""
+        await self.coordinator.async_set_vane_vertical(
+            self._unit_id, _VANE_SWING if oscillating else _VANE_AUTO
+        )
 
     @with_debounced_refresh()
     async def async_set_percentage(self, percentage: int) -> None:

--- a/custom_components/melcloudhome/translations/de.json
+++ b/custom_components/melcloudhome/translations/de.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Urlaubsmodus"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatisch"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/el.json
+++ b/custom_components/melcloudhome/translations/el.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Λειτουργία διακοπών"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Αυτόματο"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/en.json
+++ b/custom_components/melcloudhome/translations/en.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Holiday mode"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/es.json
+++ b/custom_components/melcloudhome/translations/es.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Modo vacaciones"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/fi.json
+++ b/custom_components/melcloudhome/translations/fi.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Lomatila"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/fr.json
+++ b/custom_components/melcloudhome/translations/fr.json
@@ -209,6 +209,17 @@
       "cop": {
         "name": "Coefficient de performance"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automatique"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/it.json
+++ b/custom_components/melcloudhome/translations/it.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Modalità vacanza"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/nb.json
+++ b/custom_components/melcloudhome/translations/nb.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Feriemodus"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/nl.json
+++ b/custom_components/melcloudhome/translations/nl.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Vakantiemodus"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/pt.json
+++ b/custom_components/melcloudhome/translations/pt.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Modo férias"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Automático"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/sv.json
+++ b/custom_components/melcloudhome/translations/sv.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Semesterläge"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Auto"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/th.json
+++ b/custom_components/melcloudhome/translations/th.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "โหมดวันหยุด"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "อัตโนมัติ"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/tr.json
+++ b/custom_components/melcloudhome/translations/tr.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Tatil modu"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Oto"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/custom_components/melcloudhome/translations/vi.json
+++ b/custom_components/melcloudhome/translations/vi.json
@@ -209,6 +209,17 @@
       "holiday_mode": {
         "name": "Chế độ nghỉ lễ"
       }
+    },
+    "fan": {
+      "melcloudhome": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "auto": "Tự động"
+            }
+          }
+        }
+      }
     }
   },
   "services": {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -14,6 +14,11 @@ services:
     networks:
       - ha-dev
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # Home Assistant with auto-setup
   homeassistant:
@@ -37,6 +42,11 @@ services:
     depends_on:
       - melcloud-mock
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,13 @@
 # containers (see docker-compose.test.yml).
 name: melcloudhome-dev
 
+# Shared by every service below; Compose ignores top-level x-* keys.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   # Mock MELCloud API Server
   melcloud-mock:
@@ -14,11 +21,7 @@ services:
     networks:
       - ha-dev
     restart: unless-stopped
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
 
   # Home Assistant with auto-setup
   homeassistant:
@@ -42,11 +45,7 @@ services:
     depends_on:
       - melcloud-mock
     restart: unless-stopped
-    logging:
-      driver: json-file
-      options:
-        max-size: "10m"
-        max-file: "3"
+    logging: *default-logging
     entrypoint: ["/bin/bash", "-c"]
     command:
       - |

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,9 @@ Key architectural decisions for the MELCloud Home integration:
 - [ADR-020: Report `unknown`, Not `unavailable`, for Missing Readings](decisions/020-unknown-for-missing-readings.md) - `available_fn` removed from all entity descriptions (amends ADR-006, ADR-008)
 - [ADR-021: Deferred Startup Fetch](decisions/021-deferred-startup-fetch.md) - The first energy/telemetry fetch runs in a background task instead of blocking entity creation
 - [ADR-022: A Reading Is a Value Plus the Time the Unit Recorded It](decisions/022-reading-provenance.md) - `Reading` + `reading_fn` + the `last_reading` attribute for slow-cadence sensors (amends ADR-006)
+- [ADR-023: ATW Water Temperatures Come From the Internal Temperatures Report](decisions/023-atw-water-temperatures-from-report.md) - flow and return temperatures read from the report endpoint rather than the device payload
+- [ADR-024: Energy Storage Is Scoped Per Account](decisions/024-entry-scoped-energy-storage.md) - energy totals keyed by config entry so two accounts cannot overwrite each other
+- [ADR-025: Exposing Fan Speed and Vane to HomeKit](decisions/025-homekit-fan-entity.md) - a `fan` entity per ATA unit, because the HomeKit bridge cannot expose either control from the climate entity
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,6 +210,7 @@ All entities use UUID-based device names for stable entity IDs (format: `melclou
 **ATA (Air-to-Air) Entities:**
 
 - `climate.melcloudhome_{short_id}_climate` - Main climate control
+- `fan.melcloudhome_{short_id}_a_c_fan` - Fan speed, vane oscillation and unit power ([ADR-025](decisions/025-homekit-fan-entity.md))
 - `sensor.melcloudhome_{short_id}_room_temperature` - Current temperature
 - `sensor.melcloudhome_{short_id}_energy_*` - Energy consumption (daily/weekly/monthly)
 - `binary_sensor.melcloudhome_{short_id}_error` - Error state

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -198,8 +198,7 @@ plain YAML and bridge that instead. It is rejected as the answer because it asks
 every affected user to write and maintain the same mapping by hand, in a project
 whose users are Home Assistant owners rather than developers, and it still
 creates a second entity, so it carries this decision's main cost without its
-convenience. It remains a reasonable interim workaround to offer anyone who wants
-the controls before this ships.
+convenience.
 
 **Doing nothing** is core's position and is defensible: the developer
 documentation explicitly permits custom fan modes, and in

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -285,10 +285,11 @@ users nothing.
   position would mean holding state the coordinator does not keep, which is not
   worth it for a binary control, so the loss is accepted.
 - Units whose capabilities report no vane get no oscillation control at all.
-  That is common rather than exceptional: three of the six units in the
-  installation this was verified against report none, so without the capability
-  gate half of them would have carried a swing switch wired to hardware that
-  cannot swing.
+  Such units are real rather than hypothetical: several were found in the
+  installation this was verified against, and without the capability gate each
+  would have carried a swing switch wired to hardware that cannot swing. How
+  common they are across the fleet is not known, and the gate does not depend
+  on it.
 - `percentage` reports the commanded speed and the `auto` preset carries the
   auto state. Leaving `auto` returns the unit to the speed the user last chose
   rather than to a bridge default, and the percentage is unknown only before any

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -268,8 +268,10 @@ users nothing.
   rejected vocabulary change and a manual accessory-type change besides.
 - The fan entity reaches every voice assistant, not only HomeKit. A `fan`
   domain entity appears in Google Home and Alexa as a fan with a power switch,
-  for every user, whether or not they bridge to HomeKit. Anyone asking Google or
-  Alexa to turn that fan off switches the air conditioner off.
+  for every user, whether or not they bridge to HomeKit, so anyone asking Google
+  or Alexa to turn that fan off switches the air conditioner off. This follows
+  from the entity being an ordinary `fan` and has not been exercised on either
+  assistant; only HomeKit has been tested.
 - Fan speed becomes settable from two places in HA, the climate entity's
   `fan_mode` dropdown and the new entity's percentage, visible on the device page
   and in both more-info dialogs but not on the dashboard thermostat card unless

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-09-11
 **Relates to:** [ADR-013](013-automatic-friendly-device-names.md) (the device
-naming these entities inherit),
+naming this entity inherits),
 [ADR-018](018-out-of-band-state-sync-limitation.md) (the deduplication that
 applies to these writes)
 **Decision Makers:** @andrew-blake
@@ -32,48 +32,34 @@ There is no `B6` SwingMode characteristic and no `B7` Fanv2 service.
 
 ### Why both controls are missing
 
-The bridge builds each control only when the entity's vocabulary intersects a
-fixed set, and neither integration vocabulary does.
+The bridge builds each control only when the climate entity's vocabulary
+intersects a fixed set, and neither integration vocabulary does. Fan speed needs
+`fan_modes` to intersect `{low, middle, medium, high}`; `ATA_FAN_SPEEDS` is
+`["auto", "one", ..., "five"]`. The vane needs `swing_modes` to contain one of
+`{on, both, horizontal, vertical}` and, from 2026.8.0, also `off`;
+`ATA_VANE_POSITIONS` is `["auto", "swing", "one", ..., "five"]`.
+`swing_horizontal_modes` is never consulted at all.
 
-Fan speed needs `fan_modes` to intersect `PRE_DEFINED_FAN_MODES`, which is
-`{low, middle, medium, high}`. `ATA_FAN_SPEEDS` is
-`["auto", "one", ..., "five"]`, sliced per device to `auto` plus
-`capabilities.number_of_fan_speeds` entries, so `ordered_fan_speeds` stays empty
-and no speed characteristic is added. `CHAR_TARGET_FAN_STATE` needs `auto` plus
-either `on` or a non-empty `ordered_fan_speeds`, so it is skipped too, leaving
-`fan_chars` empty and no fan service built at all.
+A second gate applies to both and constrains any fix made on the climate entity:
+the **reported** value must itself be one of the recognised names, not merely
+present in the advertised list. `climate_util.fan_mode_to_speed` returns `None`
+unless the reported mode lowercases into `ordered_fan_speeds`, and
+`climate_util.is_swing_on` tests the reported `swing_mode` against the predefined
+set. Advertising standard names while continuing to report `"three"` or
+`"swing"` leaves the corresponding control permanently stale.
 
-The vane needs `swing_modes` to contain one of `PRE_DEFINED_SWING_MODES` (`on`,
-`both`, `horizontal`, `vertical`) and, from 2026.8.0, also `off`.
-`ATA_VANE_POSITIONS` is `["auto", "swing", "one", ..., "five"]`, which satisfies
-neither. `swing_horizontal_modes` is never consulted by the bridge.
-
-The **reported** value must itself be one of the recognised names, not merely
-present in the advertised list, which constrains any fix:
-
-```python
-if (CHAR_ROTATION_SPEED in self.fan_chars
-        and fan_mode_lower in self.ordered_fan_speeds):
-    self.char_speed.set_value(
-        ordered_list_item_to_percentage(self.ordered_fan_speeds, fan_mode_lower))
-```
-
-So adding standard names as extra selectable values while `fan_mode` continues
-to report `"three"` would leave the slider permanently stale. The vane read-back
-has no such gate: an unrecognised value simply reads as not oscillating.
-
-### Accessory types available
+### The accessory type is mostly out of reach
 
 From 2026.8.0 the bridge can publish a climate entity as `HeaterCooler`
-(`type_heater_coolers.py`) rather than `Thermostat`. `HeaterCooler` is HAP's
-air-conditioner service: it is categorised `CATEGORY_AIR_CONDITIONER`, and it
-carries `CHAR_ROTATION_SPEED` and `CHAR_SWING_MODE` on the accessory itself
-rather than on a linked fan service. It is the correct representation of an air
-conditioner in the Home app.
+(`type_heater_coolers.py`), HAP's air-conditioner service, which carries speed
+and swing on the accessory itself. Qualifying for it needs
+`climate_supports_heater_cooler`, which a standard swing pair alone satisfies.
 
-Routing to it requires `climate_supports_heater_cooler`, which passes on
-**either** two or more standard fan names **or** a standard swing pair. The
-swing route is therefore reachable without touching fan speed.
+`_async_resolve_climate_type` auto-routes only when `stored_type is None and allow_auto and not
+aid_storage.entity_is_allocated(entity_id)`, so an entity that is already bridged
+keeps its Thermostat until a user changes the accessory type by hand in the
+bridge options. Every install affected by this problem today is in exactly that
+position.
 
 ### How many installs this affects
 
@@ -84,8 +70,8 @@ installs bridge to HomeKit, and the direct evidence is a single issue report, so
 this record claims no measured population.
 
 HomeKit, and Siri with it, is often the interface used by people in a household
-who never open Home Assistant, so a control missing there is missing entirely
-for those users rather than merely inconvenient.
+who never open Home Assistant, so a control missing there is missing entirely for
+those users rather than merely inconvenient.
 
 Reported as [issue #318](https://github.com/andrew-blake/melcloudhome/issues/318),
 which identified the vane gate correctly and proposed renaming the vane values.
@@ -93,121 +79,132 @@ The fan gap was found while verifying that report against hardware.
 
 ## Decision
 
-Three changes, none of them a rename or a removal:
+A `fan` platform is added for ATA units, carrying fan speed, vane oscillation and
+unit power. The climate vocabulary is left alone: `ATA_FAN_SPEEDS`,
+`ATA_VANE_POSITIONS` and `ClimateEntityFeature.FAN_MODE` all stay as they are, so
+the climate entity keeps its own dropdowns and the new entity is an additional
+surface rather than a replacement.
 
-1. `ATA_VANE_POSITIONS` gains `off` and `vertical`, keeping `auto`, `swing` and
-   `one`..`five`.
-2. A `fan` entity is added per ATA unit, carrying speed and unit power.
-3. `ATA_FAN_SPEEDS` and `ClimateEntityFeature.FAN_MODE` are left as they are, so
-   the climate entity keeps its own fan dropdown and the new entity is an
-   additional surface rather than a replacement.
+Precedent for one unit carrying both a climate and a fan entity is
+`home_connect`, which does this for an air conditioner. `smartthings` is the
+counter-precedent, declining a fan entity for anything with a cooling setpoint on
+the reasoning that the climate entity already carries the control; that reasoning
+does not apply here, because on this integration the climate entity demonstrably
+cannot carry it through the bridge.
 
-### Why the vane goes on the climate entity
+### Why a fan entity rather than the climate entity
 
-A standard swing pair is what qualifies the climate entity for `HeaterCooler` on
-2026.8.0 and later. Declaring `OSCILLATE` on the fan entity would expose the
-vane just as well but would leave the air conditioner publishing as a
-Thermostat, never classified correctly.
+`type_fans` builds its speed slider from `FanEntityFeature.SET_SPEED` and its
+swing switch from `FanEntityFeature.OSCILLATE`, with no fixed name set involved,
+so a fan entity has no vocabulary gate and both controls work from values the
+integration computes directly.
 
-Adding the values rather than renaming `auto` and `swing` keeps every existing
-automation working, and core already ships translations for both. Mapping `off`
-to API `Auto` is true of the hardware, not a convenience: Mitsubishi's MSZ-LN
-instructions describe `AUTO` as "the most efficient airflow direction.
-COOL/DRY/FAN: horizontal position. HEAT: position (4)" and reserve "moves up and
-down intermittently" for `Swing`.
+`FanEntity.percentage_step` is `100 / speed_count`,
+which the bridge passes as `PROP_MIN_STEP`, so setting `speed_count` from
+`capabilities.number_of_fan_speeds` puts one slider detent on each real speed.
+Every speed stays reachable only while `speed_count` tracks that capability;
+hard-code it and the slider's detents stop matching the hardware.
 
-### Why fan speed needs its own entity
+`oscillating` is a boolean the integration derives from
+`vane_vertical_direction == "Swing"`, so the vane round-trips without any
+vocabulary or reported-value change. The seven real vane positions remain on the
+climate entity's `swing_mode`, since HomeKit's control is binary and cannot
+express them.
 
-Exposing speed on the climate entity would require the reported `fan_mode` to
-become a standard name, which silently breaks any template comparing against
-`"three"`. A fan entity has no vocabulary gate, and
-its slider resolution comes from the unit's own speed count, so all five speeds
-stay reachable instead of three. It carries no `OSCILLATE`, so one vane has one
-switch.
+### How `auto` is represented
 
-Precedent is `home_connect`, which ships a climate and a fan entity for one air
-conditioner; `smartthings` is the counter-precedent, declining a fan entity for
-anything with a cooling setpoint.
+`auto` goes in `preset_modes`, alone, because a percentage cannot express it.
+With exactly one preset, `type_fans.create_services` appends
+`CHAR_TARGET_FAN_STATE`, so it surfaces as HomeKit's Auto toggle rather than a
+stray switch, and turning it off restores the previous percentage. This is a
+decision rather than an implementation detail, because the single-preset case is
+what produces that behaviour and adding a second preset would silently change it.
 
-### Why the fan entity controls unit power
+### Power maps to the unit
 
-An air conditioner has no "fan off, unit running" state, so power here can only
-mean unit power. Withholding the features does not avoid that: `CHAR_ACTIVE` is
-mandatory on the Fanv2 service and wired straight to `fan.turn_off`, so the Home
-app shows the button either way and leaving it undeclared merely makes it fail.
-Given a button that cannot be removed, one that works is preferred to one that
-does nothing, so "turn off the A/C fan" switching the unit off is accepted
-knowingly.
-
-### Version behaviour
-
-`hacs.json` keeps its 2025.8.0 minimum, and the code branches on no HA version.
-Older installs get a less tidy accessory layout, described under Consequences,
-and keep every control the newer ones have.
+`TURN_ON` and `TURN_OFF` are declared and mapped to unit power. An air
+conditioner has no "fan off, unit running" state, so power here can only mean
+unit power. Withholding the features does not avoid the question: `CHAR_ACTIVE`
+is mandatory on the Fanv2 service and wired straight to `fan.turn_off`, so the
+Home app shows the button either way, and leaving it undeclared merely makes it
+fail and spring back. Given a button that cannot be removed, one that works is
+preferred to one that does nothing, so "turn off the A/C fan" switching the unit
+off is accepted knowingly.
 
 ## Alternatives Considered
 
-**Renaming `fan_modes`** has the most precedent in core: `midea`, `gree`,
-`sensibo` and `lg_thinq` all map vendor speeds onto standard names, and `midea`
-shows it need not cost HA anything, keeping five speeds by using standard names
-in the middle and custom `silent` and `full` at the extremes. It is rejected
-because of the read-back gate: the reported `fan_mode` would have to change
-from `"three"` to `"medium"`, which silently breaks any template or condition
-comparing against the numbered values. HomeKit would also reach only three of
-five speeds, and `geoffdavis/esphome-mitsubishiheatpump` ran this experiment on
-the same hardware; its [issue #135](https://github.com/geoffdavis/esphome-mitsubishiheatpump/issues/135) is a user asking to be put back on numbers because
-`medium` and `middle` are indistinguishable. It would further destroy the
-case-fold symmetry of `normalize_to_api`, currently a pure round trip against
-the API's own vocabulary, requiring a bidirectional map maintained in the list,
-the read property and the write path. Putting speed on the `HeaterCooler`
-accessory would be the tidiest outcome of all, one correctly-classified tile
-carrying everything, but it is unreachable without this rename and so falls
-with it.
+**Adding `off` and `vertical` to `swing_modes`** is what #318 proposed, and this
+record previously adopted it. It is rejected on three counts, each verified in
+core source.
 
-**`OSCILLATE` on the fan entity** would expose the vane with no vocabulary
-change at all. It is rejected because it leaves the climate entity failing
-`climate_supports_heater_cooler`, so the air conditioner keeps publishing as a
-Thermostat and the Home app never classifies it correctly.
+For the swing toggle to read correctly, `is_swing_on` requires the *reported*
+`swing_mode` to be `vertical` rather than `swing`, so the change is not additive
+despite appearing so: that value would have to change, and any template comparing
+against `"swing"` would break silently. That is the same breaking class this record
+refuses for `fan_mode`, so the apparent asymmetry between the two vocabularies
+does not exist.
 
-**Both swing routes** would place two identical oscillation switches in the Home
-app for one vane. They could not disagree, since both read
-`vane_vertical_direction` through the one coordinator, but the duplication buys
-nothing.
+Setting `swing_on_mode` also makes `fan_chars` non-empty, which builds a linked
+Fanv2 on the Thermostat with `CHAR_ACTIVE` configured unconditionally, and
+`_set_fan_active` rejects every write to it because `ATA_FAN_SPEEDS` contains no
+`off`. That ships a dead control: a power button on the new tile that visibly
+does nothing.
+
+The justification for accepting all that was promotion to `HeaterCooler`, which
+per the Context section requires a manual accessory-type change on every
+already-bridged entity, so the payoff mostly does not arrive.
+
+**Renaming `fan_modes` to standard names** has the most precedent in core:
+`midea`, `gree`, `sensibo` and `lg_thinq` all map vendor speeds onto standard
+names, and `midea` shows it need not cost HA anything, keeping five speeds by
+using standard names in the middle and custom `silent` and `full` at the
+extremes. It is rejected because of the read-back gate, which would force the
+reported `fan_mode` from `"three"` to `"medium"` and silently break templates,
+because HomeKit would reach only three of five speeds, and because
+`geoffdavis/esphome-mitsubishiheatpump` ran this experiment on the same hardware;
+its
+[issue #135](https://github.com/geoffdavis/esphome-mitsubishiheatpump/issues/135)
+is a user asking to be put back on numbers because `medium` and `middle` are
+indistinguishable. It would also destroy the case-fold symmetry of
+`normalize_to_api`, currently a pure round trip against the API's own vocabulary.
+Putting speed on the `HeaterCooler` accessory would be the tidiest outcome of
+all, but it is unreachable without this rename and so falls with it.
 
 **Doing nothing** is core's position and is defensible: the developer
 documentation explicitly permits custom fan modes, and in
 [architecture discussion #553](https://github.com/home-assistant/architecture/discussions/553)
-a maintainer rejected expanding the built-in sets on the grounds that the
-options are vendor-specific. It is rejected because the complaints are being
-filed here.
+a maintainer rejected expanding the built-in sets on the grounds that the options
+are vendor-specific. HA core's own `melcloud_home` integration has the same gap
+for the same hardware. It is rejected because the complaints are being filed
+here.
 
 ## Consequences
 
-- On 2026.8.0 and later, HomeKit shows an air-conditioner tile with temperature,
-  mode and swing, plus a second tile, for example "Living Room A/C fan",
-  carrying the speed slider. On earlier versions the first tile is a thermostat
-  instead.
-- Airflow is split across two tiles: swing on the air conditioner, speed on the
-  fan. Each control is where its own concept belongs, but they are not adjacent
-  as they would be on a physical remote.
-- The fan tile's power button switches the air conditioner off, and so does
-  dragging the slider to zero. Deliberate, and the least-bad option given
-  `CHAR_ACTIVE` cannot be suppressed.
-- The vane dropdown in HA gains two entries that duplicate `auto` and `swing` in
-  effect. That is the price of the standard vocabulary, and it is why the
-  original names are kept rather than replaced.
+- HomeKit gains a second tile per unit, for example "Living Room A/C fan",
+  carrying the speed slider, the swing switch and power. The climate accessory is
+  untouched and continues to publish temperature and mode only.
+- The air conditioner keeps publishing as a Thermostat rather than as an air
+  conditioner. Correct classification needs `HeaterCooler`, which needs the
+  rejected vocabulary change and a manual accessory-type change besides.
+- **The fan entity reaches every voice assistant, not only HomeKit.** A `fan`
+  domain entity appears in Google Home and Alexa as a fan with a power switch,
+  for every user, whether or not they bridge to HomeKit. Anyone asking Google or
+  Alexa to turn that fan off switches the air conditioner off.
 - Fan speed becomes settable from two places in HA, the climate entity's
-  `fan_mode` dropdown and the new entity's percentage, visible on the device
-  page and in both more-info dialogs but not on the dashboard thermostat card
-  unless the user opted into the `climate-fan-modes` card feature. The overlap
-  is accepted, because suppressing the dropdown would mean dropping
+  `fan_mode` dropdown and the new entity's percentage, visible on the device page
+  and in both more-info dialogs but not on the dashboard thermostat card unless
+  the user opted into the `climate-fan-modes` card feature. The overlap is
+  accepted, because suppressing the dropdown would mean dropping
   `ClimateEntityFeature.FAN_MODE` and breaking every existing
   `climate.set_fan_mode` call.
+- The vane is binary through HomeKit. Positions one to five stay reachable from
+  Home Assistant only.
 - `percentage` reports the commanded speed, so in `auto` the slider shows the
-  setpoint rather than the speed the fan is running. Reporting
-  `actual_fan_speed` (#285) would be more informative but makes reads and writes
-  reference different API fields, so it is deferred rather than adopted
-  silently.
+  setpoint rather than the speed the fan is running. Reporting `actual_fan_speed`
+  (#285) would be more informative but makes reads and writes reference different
+  API fields, so it is deferred rather than adopted silently.
+- Existing automations, templates and service calls keep working unchanged,
+  because every advertised list and every reported value stays as it is.
 
 ## Open Questions
 
@@ -218,24 +215,24 @@ filed here.
 
 ### Conditions for Revisiting
 
-- **If the duplicated fan speed control draws support traffic**,
-  `home_connect`'s shape is the one to migrate towards: `fan_modes` becomes
-  `["auto", "manual"]` and speed lives only on the fan entity, at the same
-  migration cost as renaming.
-- **If the two-tile layout proves confusing in practice**, the rename becomes
-  worth its cost, because it is the only route to a single correctly-classified
-  tile carrying both controls. That trade is three of five speeds in HomeKit and
-  a breaking change to the reported `fan_mode`, against one tile instead of two.
+- **If core ever auto-routes already-bridged entities to `HeaterCooler`**, or if
+  changing the accessory type by hand becomes normal, the swing vocabulary
+  question reopens, since correct classification would then be purchasable for
+  the cost of one breaking reported-value change.
+- **If the duplicated fan speed control draws support traffic**, `home_connect`'s
+  shape is the one to migrate towards: `fan_modes` becomes `["auto", "manual"]`
+  and speed lives only on the fan entity, at the same migration cost as renaming.
 - **If [architecture#1468](https://github.com/home-assistant/architecture/discussions/1468)
   reaches the HomeKit bridge.** It proposes mapping climate `fan_modes` to a
-  positional `1..N` range for Alexa. Applied to HomeKit, the fan entity would
-  become redundant. That discussion had no replies when this was written, so it
-  is not a reason to wait.
+  positional `1..N` range for Alexa. Applied to HomeKit, this entity would become
+  redundant. That discussion had no replies when this was written, so it is not a
+  reason to wait.
 
 ## References
 
-- `homekit/type_thermostats.py`, `type_heater_coolers.py`, `type_fans.py`,
-  `climate_base.py`, `climate_util.py` in HA core
+- `homekit/type_fans.py`, `type_thermostats.py`, `type_heater_coolers.py`,
+  `climate_base.py`, `climate_util.py`, `accessories.py` and `aidmanager.py` in
+  HA core, read from the 2026.9.1 wheel and diffed against 2026.8.0
 - [Climate entity developer docs](https://developers.home-assistant.io/docs/core/entity/climate/#fan-modes),
   which permit custom fan modes
 - [issue #318](https://github.com/andrew-blake/melcloudhome/issues/318)

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -221,7 +221,11 @@ users nothing.
   `ClimateEntityFeature.FAN_MODE` and breaking every existing
   `climate.set_fan_mode` call.
 - The vane is binary through HomeKit. Positions one to five stay reachable from
-  Home Assistant only.
+  Home Assistant only, and switching oscillation off returns the vane to `Auto`
+  rather than to the position it held before. A unit set to position three, then
+  swung and unswung from the Home app, ends on `Auto`. Restoring the prior
+  position would mean holding state the coordinator does not keep, which is not
+  worth it for a binary control, so the loss is accepted.
 - `percentage` reports the commanded speed, so in `auto` the slider shows the
   setpoint rather than the speed the fan is running. Reporting `actual_fan_speed`
   (#285) would be more informative but makes reads and writes reference different

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -108,7 +108,9 @@ hard-code it and the slider's detents stop matching the hardware.
 `vane_vertical_direction == "Swing"`, so the vane round-trips without any
 vocabulary or reported-value change. The seven real vane positions remain on the
 climate entity's `swing_mode`, since HomeKit's control is binary and cannot
-express them.
+express them. `OSCILLATE` is declared only where `capabilities.has_swing` or
+`has_air_direction` is set, the gate the climate entity already puts on
+`SWING_MODE`, so a unit without a vane gets no switch rather than a dead one.
 
 ### How `auto` is represented
 
@@ -127,6 +129,13 @@ Home app shows the button either way, and leaving it undeclared merely makes it
 fail and spring back. Given a button that cannot be removed, one that works is
 preferred to one that does nothing, so "turn off the A/C fan" switching the unit
 off is accepted knowingly.
+
+Setting a non-zero speed powers the unit on as well as commanding the speed. The
+bridge sends `Active=1` and `RotationSpeed` together when the slider is dragged
+up on an inactive tile, then deliberately skips `fan.turn_on` on the documented
+assumption that a `SET_SPEED` fan powers itself on. Every power-on carries the
+device's current `operation_mode`, because a bare power write sends
+`operationMode=null`, which can fault a multi-zone outdoor unit.
 
 ## Alternatives Considered
 
@@ -203,9 +212,11 @@ users nothing.
 
 ## Consequences
 
-- HomeKit gains a second tile per unit, for example "Living Room A/C fan",
-  carrying the speed slider, the swing switch and power. The climate accessory is
-  untouched and continues to publish temperature and mode only.
+- HomeKit gains a second tile per unit, for example "Living Room A-C fan",
+  carrying the speed slider, the swing switch and power. The Home app shows a
+  hyphen because the bridge substitutes one for the slash in the entity name. The
+  climate accessory is untouched and continues to publish temperature and mode
+  only.
 - The air conditioner keeps publishing as a Thermostat rather than as an air
   conditioner. Correct classification needs `HeaterCooler`, which needs the
   rejected vocabulary change and a manual accessory-type change besides.
@@ -226,8 +237,10 @@ users nothing.
   swung and unswung from the Home app, ends on `Auto`. Restoring the prior
   position would mean holding state the coordinator does not keep, which is not
   worth it for a binary control, so the loss is accepted.
-- `percentage` reports the commanded speed, so in `auto` the slider shows the
-  setpoint rather than the speed the fan is running. Reporting `actual_fan_speed`
+- `percentage` reports the commanded speed, and is unknown in `auto` because no
+  numbered speed is commanded then; the `auto` preset carries that state instead.
+  The bridge skips the characteristic update while percentage is unknown, so the
+  HomeKit slider holds whatever it last showed. Reporting `actual_fan_speed`
   (#285) would be more informative but makes reads and writes reference different
   API fields, so it is deferred rather than adopted silently.
 - Existing automations, templates and service calls keep working unchanged,

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -98,26 +98,46 @@ swing switch from `FanEntityFeature.OSCILLATE`, with no fixed name set involved,
 so a fan entity has no vocabulary gate and both controls work from values the
 integration computes directly.
 
-`FanEntity.percentage_step` is `100 / speed_count`,
-which the bridge passes as `PROP_MIN_STEP`, so setting `speed_count` from
+`FanEntity.percentage_step` is `100 / speed_count`, which the bridge passes as
+`PROP_MIN_STEP`, so setting `speed_count` from
 `capabilities.number_of_fan_speeds` puts one slider detent on each real speed.
 Every speed stays reachable only while `speed_count` tracks that capability;
-hard-code it and the slider's detents stop matching the hardware.
+hard-code it and the slider's detents stop matching the hardware. That same
+division is why a unit reporting no fan speeds at all gets no fan entity: a
+`speed_count` of zero would make every state update raise.
 
 `oscillating` is a boolean the integration derives from
 `vane_vertical_direction == "Swing"`, so the vane round-trips without any
-vocabulary or reported-value change. The seven real vane positions remain on the
-climate entity's `swing_mode`, since HomeKit's control is binary and cannot
-express them. `OSCILLATE` is declared only where `capabilities.has_swing` or
+vocabulary or reported-value change. `Swing` sweeps and `Auto` is a fixed angle
+chosen by operating mode, so reporting `Auto` as not oscillating is true of the
+hardware. The seven real vane positions remain on the climate entity's
+`swing_mode`, since HomeKit's control is binary and cannot express them.
+`OSCILLATE` is declared only where `capabilities.has_swing` or
 `has_air_direction` is set, the gate the climate entity already puts on
 `SWING_MODE`, so a unit without a vane gets no switch rather than a dead one.
+
+Oscillating writes the vane and nothing else, so switching it on does not start
+a stopped unit. It sets the vane for the next time the unit runs.
 
 ### How `auto` is represented
 
 `auto` goes in `preset_modes`, alone, because a percentage cannot express it.
 Being alone is the decision rather than an accident: with exactly one preset the
 bridge appends `CHAR_TARGET_FAN_STATE`, giving HomeKit's proper Auto toggle,
-whereas a second preset would silently turn both into stray switches.
+whereas a second preset would silently turn both into stray switches. The cost
+is borne inside Home Assistant, where the fan dialog renders no preset selector
+for a single preset, so `auto` is chosen from the climate entity's `fan_mode`
+dropdown or a service call rather than from this entity.
+
+While `auto` is selected, `percentage` keeps reporting the last numbered speed
+the unit has been seen on rather than going blank, and is unknown only before
+any numbered speed has been seen at all. That matches HAP's own model, in which
+`RotationSpeed` is the manual setpoint that persists while `TargetFanState` is
+Auto rather than a value that goes blank when Auto is selected. It also matters
+for the Manual/Auto toggle specifically: `type_fans.set_single_preset_mode`
+reads that percentage back when the user leaves Auto and falls back to a
+hard-coded 50% if it finds `None`, moving the unit to whatever speed that maps
+to instead of the one the user was actually on.
 
 ### Power maps to the unit
 
@@ -133,16 +153,39 @@ off is accepted knowingly.
 Setting a non-zero speed powers the unit on as well as commanding the speed. The
 bridge sends `Active=1` and `RotationSpeed` together when the slider is dragged
 up on an inactive tile, then deliberately skips `fan.turn_on` on the documented
-assumption that a `SET_SPEED` fan powers itself on. Every power-on carries the
+assumption that a `SET_SPEED` fan powers itself on. A power-on carries the
 device's current `operation_mode`, because a bare power write sends
-`operationMode=null`, which can fault a multi-zone outdoor unit.
+`operationMode=null`, which can fault a multi-zone outdoor unit; the mode is
+omitted only when the device reports none to preserve. Powering off carries
+nothing, since there is no mode to keep on the way down.
+
+### One write per slider drag
+
+A HomeKit slider drag is not one command. The bridge sends every intermediate
+position the finger passes through, so one gesture arrives as a burst of speed
+writes. Those writes overlap in flight and the server applies them in the order
+they arrive rather than the order they were issued, so the position the user
+released on can lose to an earlier one: a drag ending on speed three settled the
+unit on speed two.
+
+Only the final position is written, half a second after the slider stops moving.
+One write per gesture makes the ordering race impossible. The window has to be
+wider than the gap between intermediate positions, which is around a quarter of
+a second, and short enough that deliberate steps a few seconds apart are each
+treated as their own settled position rather than swallowed.
+
+The power-on is not deferred, so the unit starts the moment a drag begins. It is
+suppressed for a few seconds after one succeeds instead, because the shared
+write-deduplication compares against coordinator data that stays stale until the
+next refresh and so cannot recognise the repeats itself. An explicit
+`fan.turn_on` is never suppressed: the suppression exists to tame the drag
+burst, not to make the documented service unreliable.
 
 ## Alternatives Considered
 
-**Adding `off` and `vertical` to `swing_modes`** is what #318 proposed, and it
-was the assumed path until review found the three problems below, each verified
-in core source. It is recorded at this length because it looks additive and safe,
-and is neither.
+**Adding `off` and `vertical` to `swing_modes`** is what #318 proposed. It is
+recorded at this length because it looks additive and safe, and is neither; each
+of the three problems below is verified in core source.
 
 For the swing toggle to read correctly, `is_swing_on` requires the *reported*
 `swing_mode` to be `vertical` rather than `swing`, so the change is not additive
@@ -182,6 +225,7 @@ installed a template component to undo the renaming from outside.
 
 Renaming would also destroy the case-fold symmetry of `normalize_to_api`,
 currently a pure round trip against the API's own vocabulary.
+
 Putting speed on the `HeaterCooler` accessory would be the tidiest outcome of
 all, but it is unreachable without this rename and so falls with it. Note that
 it would not have been the better outcome for resolution: `HeaterCooler` derives
@@ -211,11 +255,14 @@ users nothing.
 
 ## Consequences
 
-- HomeKit gains a second tile per unit, for example "Living Room A-C fan",
-  carrying the speed slider, the swing switch and power. The Home app shows a
-  hyphen because the bridge substitutes one for the slash in the entity name. The
-  climate accessory is untouched and continues to publish temperature and mode
-  only.
+- HomeKit gains a second tile per unit, for example "Living Room A-C fan". The
+  Home app shows a hyphen because the bridge substitutes one for the slash in
+  the entity name; the name stays as it is, since "A-C fan" still reads as an
+  air conditioner rather than a room fan. The tile carries power and the speed
+  slider, with Oscillate and the Manual/Auto toggle on the accessory page behind
+  it. That placement is the Home app's own layout for a fan service and is not
+  something the integration chooses. The climate accessory is untouched and
+  continues to publish temperature and mode only.
 - The air conditioner keeps publishing as a Thermostat rather than as an air
   conditioner. Correct classification needs `HeaterCooler`, which needs the
   rejected vocabulary change and a manual accessory-type change besides.
@@ -226,41 +273,39 @@ users nothing.
 - Fan speed becomes settable from two places in HA, the climate entity's
   `fan_mode` dropdown and the new entity's percentage, visible on the device page
   and in both more-info dialogs but not on the dashboard thermostat card unless
-  the user opted into the `climate-fan-modes` card feature. The overlap is
-  accepted, because suppressing the dropdown would mean dropping
-  `ClimateEntityFeature.FAN_MODE` and breaking every existing
-  `climate.set_fan_mode` call.
+  the user opted into the `climate-fan-modes` card feature. The two surfaces
+  cannot disagree, since both read the same coordinator field, and either one
+  reflects a change made from the other. The overlap is accepted, because
+  suppressing the dropdown would mean dropping `ClimateEntityFeature.FAN_MODE`
+  and breaking every existing `climate.set_fan_mode` call.
 - The vane is binary through HomeKit. Positions one to five stay reachable from
   Home Assistant only, and switching oscillation off returns the vane to `Auto`
   rather than to the position it held before. A unit set to position three, then
   swung and unswung from the Home app, ends on `Auto`. Restoring the prior
   position would mean holding state the coordinator does not keep, which is not
   worth it for a binary control, so the loss is accepted.
-- `percentage` reports the commanded speed; the `auto` preset carries the auto
-  state, since a percentage cannot express it. While the unit is in `auto`,
-  `percentage` reports the last numbered speed commanded rather than `None`,
-  and is unknown only before any numbered speed has ever been seen. This
-  matches HAP's own model: `RotationSpeed` is the manual setpoint that persists
-  while `TargetFanState` is Auto, not a value that goes blank when Auto is
-  selected. It also matters for HomeKit's Manual/Auto toggle specifically:
-  `type_fans.set_single_preset_mode` reads back our `percentage` when the user
-  switches out of Auto, and falls back to a hard-coded 50% if it finds `None`,
-  moving the unit to whatever speed that percentage maps to rather than the one
-  the user was actually on. Reporting the remembered speed closes that gap.
-  Reporting `actual_fan_speed` (#285) would be more informative but makes reads
-  and writes reference different API fields, so it remains deferred rather than
-  adopted here.
+- Units whose capabilities report no vane get no oscillation control at all.
+  That is common rather than exceptional: three of the six units in the
+  installation this was verified against report none, so without the capability
+  gate half of them would have carried a swing switch wired to hardware that
+  cannot swing.
+- `percentage` reports the commanded speed and the `auto` preset carries the
+  auto state. Leaving `auto` returns the unit to the speed the user last chose
+  rather than to a bridge default, and the percentage is unknown only before any
+  numbered speed has been seen.
 - **In `auto`, the Home app's title misreports the running speed, and this is
   accepted.** Its accessory page renders `RotationSpeed` as "N% Speed"
   regardless of `TargetFanState`, so in `auto` it shows the speed the unit will
   resume, not the one it is running. Observed on hardware: the title read
-  "100% Speed" while the unit modulated itself down to speed two. The bridge
-  reads the same `percentage` for both the title and the Manual fallback, so
-  the two cannot be answered differently. Reporting `actual_fan_speed` would
-  make the title honest at the cost of putting that field's several-minute lag
-  behind the manual slider, where the position would visibly spring back after
-  a drag and look like the control rejecting input. Between a title that
-  misinforms and a control that appears broken, the title is preferred.
+  "100% Speed" while the unit modulated itself down to speed two, audibly. The
+  bridge reads the same `percentage` for both the title and the Manual fallback,
+  so the two cannot be answered differently. Reporting `actual_fan_speed` (#285)
+  would make the title honest, but it makes reads and writes reference different
+  API fields, and that field lags by several minutes, so the manual slider would
+  visibly spring back after a drag and look like the control rejecting input.
+  Between a title that misinforms and a control that appears broken, the title
+  is preferred, and #285 stays deferred. The running speed remains visible in
+  the Actual Fan Speed sensor, which under `auto` is the only place it appears.
 - Existing automations, templates and service calls keep working unchanged,
   because every advertised list and every reported value stays as it is.
 

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -1,0 +1,244 @@
+# ADR-025: Exposing Fan Speed and Vane to HomeKit
+
+**Status:** Accepted
+**Date:** 2026-09-11
+**Relates to:** [ADR-013](013-automatic-friendly-device-names.md) (the device
+naming these entities inherit),
+[ADR-018](018-out-of-band-state-sync-limitation.md) (the deduplication that
+applies to these writes)
+**Decision Makers:** @andrew-blake
+
+---
+
+## Context
+
+An ATA unit bridged to HomeKit appears as a bare thermostat. Temperature and
+operating mode are controllable, and fan speed and the vane are not reachable at
+all, from the Home app or from Siri. Both are fully controllable inside Home
+Assistant, so the capability exists and stops at the bridge.
+
+### Evidence
+
+An ATA unit was bridged to HomeKit on HA 2026.7.4 and paired to an iOS client.
+The published accessory contains two services and nothing else, read from
+`.storage/homekit.<entry>.iids` for that accessory's aid:
+
+- `3E` AccessoryInformation
+- `4A` Thermostat, with `0F` CurrentHeatingCoolingState, `33`
+  TargetHeatingCoolingState, `11` CurrentTemperature, `35` TargetTemperature,
+  `36` TemperatureDisplayUnits
+
+There is no `B6` SwingMode characteristic and no `B7` Fanv2 service.
+
+### Why both controls are missing
+
+The bridge builds each control only when the entity's vocabulary intersects a
+fixed set, and neither integration vocabulary does.
+
+Fan speed needs `fan_modes` to intersect `PRE_DEFINED_FAN_MODES`, which is
+`{low, middle, medium, high}`. `ATA_FAN_SPEEDS` is
+`["auto", "one", ..., "five"]`, sliced per device to `auto` plus
+`capabilities.number_of_fan_speeds` entries, so `ordered_fan_speeds` stays empty
+and no speed characteristic is added. `CHAR_TARGET_FAN_STATE` needs `auto` plus
+either `on` or a non-empty `ordered_fan_speeds`, so it is skipped too, leaving
+`fan_chars` empty and no fan service built at all.
+
+The vane needs `swing_modes` to contain one of `PRE_DEFINED_SWING_MODES` (`on`,
+`both`, `horizontal`, `vertical`) and, from 2026.8.0, also `off`.
+`ATA_VANE_POSITIONS` is `["auto", "swing", "one", ..., "five"]`, which satisfies
+neither. `swing_horizontal_modes` is never consulted by the bridge.
+
+The **reported** value must itself be one of the recognised names, not merely
+present in the advertised list, which constrains any fix:
+
+```python
+if (CHAR_ROTATION_SPEED in self.fan_chars
+        and fan_mode_lower in self.ordered_fan_speeds):
+    self.char_speed.set_value(
+        ordered_list_item_to_percentage(self.ordered_fan_speeds, fan_mode_lower))
+```
+
+So adding standard names as extra selectable values while `fan_mode` continues
+to report `"three"` would leave the slider permanently stale. The vane read-back
+has no such gate: an unrecognised value simply reads as not oscillating.
+
+### Accessory types available
+
+From 2026.8.0 the bridge can publish a climate entity as `HeaterCooler`
+(`type_heater_coolers.py`) rather than `Thermostat`. `HeaterCooler` is HAP's
+air-conditioner service: it is categorised `CATEGORY_AIR_CONDITIONER`, and it
+carries `CHAR_ROTATION_SPEED` and `CHAR_SWING_MODE` on the accessory itself
+rather than on a linked fan service. It is the correct representation of an air
+conditioner in the Home app.
+
+Routing to it requires `climate_supports_heater_cooler`, which passes on
+**either** two or more standard fan names **or** a standard swing pair. The
+swing route is therefore reachable without touching fan speed.
+
+### How many installs this affects
+
+Both controls are missing for anyone bridging ATA units to HomeKit, and the gap
+is structural rather than intermittent, so it affects every such install rather
+than some. How many that is remains unknown: there is no telemetry on how many
+installs bridge to HomeKit, and the direct evidence is a single issue report, so
+this record claims no measured population.
+
+HomeKit, and Siri with it, is often the interface used by people in a household
+who never open Home Assistant, so a control missing there is missing entirely
+for those users rather than merely inconvenient.
+
+Reported as [issue #318](https://github.com/andrew-blake/melcloudhome/issues/318),
+which identified the vane gate correctly and proposed renaming the vane values.
+The fan gap was found while verifying that report against hardware.
+
+## Decision
+
+Three changes, none of them a rename or a removal:
+
+1. `ATA_VANE_POSITIONS` gains `off` and `vertical`, keeping `auto`, `swing` and
+   `one`..`five`.
+2. A `fan` entity is added per ATA unit, carrying speed and unit power.
+3. `ATA_FAN_SPEEDS` and `ClimateEntityFeature.FAN_MODE` are left as they are, so
+   the climate entity keeps its own fan dropdown and the new entity is an
+   additional surface rather than a replacement.
+
+### Why the vane goes on the climate entity
+
+A standard swing pair is what qualifies the climate entity for `HeaterCooler` on
+2026.8.0 and later. Declaring `OSCILLATE` on the fan entity would expose the
+vane just as well but would leave the air conditioner publishing as a
+Thermostat, never classified correctly.
+
+Adding the values rather than renaming `auto` and `swing` keeps every existing
+automation working, and core already ships translations for both. Mapping `off`
+to API `Auto` is true of the hardware, not a convenience: Mitsubishi's MSZ-LN
+instructions describe `AUTO` as "the most efficient airflow direction.
+COOL/DRY/FAN: horizontal position. HEAT: position (4)" and reserve "moves up and
+down intermittently" for `Swing`.
+
+### Why fan speed needs its own entity
+
+Exposing speed on the climate entity would require the reported `fan_mode` to
+become a standard name, which silently breaks any template comparing against
+`"three"`. A fan entity has no vocabulary gate, and
+its slider resolution comes from the unit's own speed count, so all five speeds
+stay reachable instead of three. It carries no `OSCILLATE`, so one vane has one
+switch.
+
+Precedent is `home_connect`, which ships a climate and a fan entity for one air
+conditioner; `smartthings` is the counter-precedent, declining a fan entity for
+anything with a cooling setpoint.
+
+### Why the fan entity controls unit power
+
+An air conditioner has no "fan off, unit running" state, so power here can only
+mean unit power. Withholding the features does not avoid that: `CHAR_ACTIVE` is
+mandatory on the Fanv2 service and wired straight to `fan.turn_off`, so the Home
+app shows the button either way and leaving it undeclared merely makes it fail.
+Given a button that cannot be removed, one that works is preferred to one that
+does nothing, so "turn off the A/C fan" switching the unit off is accepted
+knowingly.
+
+### Version behaviour
+
+`hacs.json` keeps its 2025.8.0 minimum, and the code branches on no HA version.
+Older installs get a less tidy accessory layout, described under Consequences,
+and keep every control the newer ones have.
+
+## Alternatives Considered
+
+**Renaming `fan_modes`** has the most precedent in core: `midea`, `gree`,
+`sensibo` and `lg_thinq` all map vendor speeds onto standard names, and `midea`
+shows it need not cost HA anything, keeping five speeds by using standard names
+in the middle and custom `silent` and `full` at the extremes. It is rejected
+because of the read-back gate: the reported `fan_mode` would have to change
+from `"three"` to `"medium"`, which silently breaks any template or condition
+comparing against the numbered values. HomeKit would also reach only three of
+five speeds, and `geoffdavis/esphome-mitsubishiheatpump` ran this experiment on
+the same hardware; its [issue #135](https://github.com/geoffdavis/esphome-mitsubishiheatpump/issues/135) is a user asking to be put back on numbers because
+`medium` and `middle` are indistinguishable. It would further destroy the
+case-fold symmetry of `normalize_to_api`, currently a pure round trip against
+the API's own vocabulary, requiring a bidirectional map maintained in the list,
+the read property and the write path. Putting speed on the `HeaterCooler`
+accessory would be the tidiest outcome of all, one correctly-classified tile
+carrying everything, but it is unreachable without this rename and so falls
+with it.
+
+**`OSCILLATE` on the fan entity** would expose the vane with no vocabulary
+change at all. It is rejected because it leaves the climate entity failing
+`climate_supports_heater_cooler`, so the air conditioner keeps publishing as a
+Thermostat and the Home app never classifies it correctly.
+
+**Both swing routes** would place two identical oscillation switches in the Home
+app for one vane. They could not disagree, since both read
+`vane_vertical_direction` through the one coordinator, but the duplication buys
+nothing.
+
+**Doing nothing** is core's position and is defensible: the developer
+documentation explicitly permits custom fan modes, and in
+[architecture discussion #553](https://github.com/home-assistant/architecture/discussions/553)
+a maintainer rejected expanding the built-in sets on the grounds that the
+options are vendor-specific. It is rejected because the complaints are being
+filed here.
+
+## Consequences
+
+- On 2026.8.0 and later, HomeKit shows an air-conditioner tile with temperature,
+  mode and swing, plus a second tile, for example "Living Room A/C fan",
+  carrying the speed slider. On earlier versions the first tile is a thermostat
+  instead.
+- Airflow is split across two tiles: swing on the air conditioner, speed on the
+  fan. Each control is where its own concept belongs, but they are not adjacent
+  as they would be on a physical remote.
+- The fan tile's power button switches the air conditioner off, and so does
+  dragging the slider to zero. Deliberate, and the least-bad option given
+  `CHAR_ACTIVE` cannot be suppressed.
+- The vane dropdown in HA gains two entries that duplicate `auto` and `swing` in
+  effect. That is the price of the standard vocabulary, and it is why the
+  original names are kept rather than replaced.
+- Fan speed becomes settable from two places in HA, the climate entity's
+  `fan_mode` dropdown and the new entity's percentage, visible on the device
+  page and in both more-info dialogs but not on the dashboard thermostat card
+  unless the user opted into the `climate-fan-modes` card feature. The overlap
+  is accepted, because suppressing the dropdown would mean dropping
+  `ClimateEntityFeature.FAN_MODE` and breaking every existing
+  `climate.set_fan_mode` call.
+- `percentage` reports the commanded speed, so in `auto` the slider shows the
+  setpoint rather than the speed the fan is running. Reporting
+  `actual_fan_speed` (#285) would be more informative but makes reads and writes
+  reference different API fields, so it is deferred rather than adopted
+  silently.
+
+## Open Questions
+
+- Entity creation is gated on a stable capability, `number_of_fan_speeds > 0`.
+  The behaviour when `unit.capabilities` is `None` is unresolved: `ATAClimate`
+  falls back to all five speeds in that case, and whether the fan entity should
+  follow that fallback or skip creation needs deciding during implementation.
+
+### Conditions for Revisiting
+
+- **If the duplicated fan speed control draws support traffic**,
+  `home_connect`'s shape is the one to migrate towards: `fan_modes` becomes
+  `["auto", "manual"]` and speed lives only on the fan entity, at the same
+  migration cost as renaming.
+- **If the two-tile layout proves confusing in practice**, the rename becomes
+  worth its cost, because it is the only route to a single correctly-classified
+  tile carrying both controls. That trade is three of five speeds in HomeKit and
+  a breaking change to the reported `fan_mode`, against one tile instead of two.
+- **If [architecture#1468](https://github.com/home-assistant/architecture/discussions/1468)
+  reaches the HomeKit bridge.** It proposes mapping climate `fan_modes` to a
+  positional `1..N` range for Alexa. Applied to HomeKit, the fan entity would
+  become redundant. That discussion had no replies when this was written, so it
+  is not a reason to wait.
+
+## References
+
+- `homekit/type_thermostats.py`, `type_heater_coolers.py`, `type_fans.py`,
+  `climate_base.py`, `climate_util.py` in HA core
+- [Climate entity developer docs](https://developers.home-assistant.io/docs/core/entity/climate/#fan-modes),
+  which permit custom fan modes
+- [issue #318](https://github.com/andrew-blake/melcloudhome/issues/318)
+- [architecture#553](https://github.com/home-assistant/architecture/discussions/553)
+- Mitsubishi MSZ-LN VG operating instructions; MELCloud Home user manual,
+  "Vane (Horizontal and Vertical)"

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -251,6 +251,17 @@ users nothing.
   Reporting `actual_fan_speed` (#285) would be more informative but makes reads
   and writes reference different API fields, so it remains deferred rather than
   adopted here.
+- **In `auto`, the Home app's title misreports the running speed, and this is
+  accepted.** Its accessory page renders `RotationSpeed` as "N% Speed"
+  regardless of `TargetFanState`, so in `auto` it shows the speed the unit will
+  resume, not the one it is running. Observed on hardware: the title read
+  "100% Speed" while the unit modulated itself down to speed two. The bridge
+  reads the same `percentage` for both the title and the Manual fallback, so
+  the two cannot be answered differently. Reporting `actual_fan_speed` would
+  make the title honest at the cost of putting that field's several-minute lag
+  behind the manual slider, where the position would visibly spring back after
+  a drag and look like the control rejecting input. Between a title that
+  misinforms and a control that appears broken, the title is preferred.
 - Existing automations, templates and service calls keep working unchanged,
   because every advertised list and every reported value stays as it is.
 

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -12,10 +12,9 @@ applies to these writes)
 
 ## Context
 
-An ATA unit bridged to HomeKit appears as a bare thermostat. Temperature and
-operating mode are controllable, and fan speed and the vane are not reachable at
-all, from the Home app or from Siri. Both are fully controllable inside Home
-Assistant, so the capability exists and stops at the bridge.
+An ATA unit bridged to HomeKit appears as a bare thermostat. Whilst temperature
+and operating mode are exposed to HomeKit, the fan speed and the vane are not,
+even though they are fully controllable inside Home Assistant.
 
 ### Evidence
 

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -14,20 +14,17 @@ applies to these writes)
 
 An ATA unit bridged to HomeKit appears as a bare thermostat. Whilst temperature
 and operating mode are exposed to HomeKit, the fan speed and the vane are not,
-even though they are fully controllable inside Home Assistant.
+even though they are fully controllable inside Home Assistant. Reported as
+[issue #318](https://github.com/andrew-blake/melcloudhome/issues/318), which
+identified the vane gate correctly and proposed renaming the vane values; the fan
+gap was found while verifying that report against hardware.
 
 ### Evidence
 
 An ATA unit was bridged to HomeKit on HA 2026.7.4 and paired to an iOS client.
-The published accessory contains two services and nothing else, read from
-`.storage/homekit.<entry>.iids` for that accessory's aid:
-
-- `3E` AccessoryInformation
-- `4A` Thermostat, with `0F` CurrentHeatingCoolingState, `33`
-  TargetHeatingCoolingState, `11` CurrentTemperature, `35` TargetTemperature,
-  `36` TemperatureDisplayUnits
-
-There is no `B6` SwingMode characteristic and no `B7` Fanv2 service.
+Reading `.storage/homekit.<entry>.iids` for that accessory's aid shows two
+services and nothing else: `3E` AccessoryInformation and `4A` Thermostat. There
+is no `B6` SwingMode characteristic and no `B7` Fanv2 service.
 
 ### Why both controls are missing
 
@@ -47,34 +44,39 @@ unless the reported mode lowercases into `ordered_fan_speeds`, and
 set. Advertising standard names while continuing to report `"three"` or
 `"swing"` leaves the corresponding control permanently stale.
 
-### The accessory type is mostly out of reach
+### The Heater Cooler accessory type
 
-From 2026.8.0 the bridge can publish a climate entity as `HeaterCooler`
-(`type_heater_coolers.py`), HAP's air-conditioner service, which carries speed
-and swing on the accessory itself. Qualifying for it needs
-`climate_supports_heater_cooler`, which a standard swing pair alone satisfies.
+From 2026.8.0 the bridge can publish a climate entity as a Heater Cooler rather
+than a Thermostat. That is HAP's air-conditioner service, and it puts mode,
+temperature, fan speed and swing on a single tile, which is how the device
+actually works. The HomeKit Bridge documentation says which entities get it:
 
-`_async_resolve_climate_type` auto-routes only when `stored_type is None and allow_auto and not
-aid_storage.entity_is_allocated(entity_id)`, so an entity that is already bridged
-keeps its Thermostat until a user changes the accessory type by hand in the
-bridge options. Every install affected by this problem today is in exactly that
-position.
+> Air conditioners and heat pumps that offer two or more fan speeds or a swing
+> mode that can be turned off.
 
-### How many installs this affects
+The fan speeds here are numbered rather than named, and the vane has no `off`, so
+these units meet neither condition and do not qualify.
 
-Both controls are missing for anyone bridging ATA units to HomeKit, and the gap
-is structural rather than intermittent, so it affects every such install rather
-than some. How many that is remains unknown: there is no telemetry on how many
-installs bridge to HomeKit, and the direct evidence is a single issue report, so
-this record claims no measured population.
+More importantly, qualifying does not bring fan speed with it. An entity that
+qualifies on its swing values alone still advertises no standard fan names, so
+its tile would gain a swing switch and no speed slider. Reaching both controls on
+one tile means changing both vocabularies.
+
+One smaller limit, which shrinks over time rather than persisting: the
+documentation also says entities "already exposed before this feature was
+introduced keep their Thermostat accessory", so anyone who has already bridged a
+unit must change the accessory type by hand. Issue #318 is the first time HomeKit
+has come up for this integration, so that is a handful of people, and anyone
+bridging later would get the Heater Cooler automatically.
+
+### Who this affects
+
+Both controls are missing for anyone bridging ATA units to HomeKit, so it affects
+every such install rather than some.
 
 HomeKit, and Siri with it, is often the interface used by people in a household
 who never open Home Assistant, so a control missing there is missing entirely for
 those users rather than merely inconvenient.
-
-Reported as [issue #318](https://github.com/andrew-blake/melcloudhome/issues/318),
-which identified the vane gate correctly and proposed renaming the vane values.
-The fan gap was found while verifying that report against hardware.
 
 ## Decision
 
@@ -84,12 +86,10 @@ unit power. The climate vocabulary is left alone: `ATA_FAN_SPEEDS`,
 the climate entity keeps its own dropdowns and the new entity is an additional
 surface rather than a replacement.
 
-Precedent for one unit carrying both a climate and a fan entity is
-`home_connect`, which does this for an air conditioner. `smartthings` is the
-counter-precedent, declining a fan entity for anything with a cooling setpoint on
-the reasoning that the climate entity already carries the control; that reasoning
-does not apply here, because on this integration the climate entity demonstrably
-cannot carry it through the bridge.
+`home_connect` is the precedent, shipping both a climate and a fan entity for one
+air conditioner. `smartthings` is the counter-precedent, refusing a fan entity
+for anything with a cooling setpoint because the climate entity already carries
+the control, which is the one thing that is not true here.
 
 ### Why a fan entity rather than the climate entity
 
@@ -113,11 +113,9 @@ express them.
 ### How `auto` is represented
 
 `auto` goes in `preset_modes`, alone, because a percentage cannot express it.
-With exactly one preset, `type_fans.create_services` appends
-`CHAR_TARGET_FAN_STATE`, so it surfaces as HomeKit's Auto toggle rather than a
-stray switch, and turning it off restores the previous percentage. This is a
-decision rather than an implementation detail, because the single-preset case is
-what produces that behaviour and adding a second preset would silently change it.
+Being alone is the decision rather than an accident: with exactly one preset the
+bridge appends `CHAR_TARGET_FAN_STATE`, giving HomeKit's proper Auto toggle,
+whereas a second preset would silently turn both into stray switches.
 
 ### Power maps to the unit
 
@@ -132,9 +130,10 @@ off is accepted knowingly.
 
 ## Alternatives Considered
 
-**Adding `off` and `vertical` to `swing_modes`** is what #318 proposed, and this
-record previously adopted it. It is rejected on three counts, each verified in
-core source.
+**Adding `off` and `vertical` to `swing_modes`** is what #318 proposed, and it
+was the assumed path until review found the three problems below, each verified
+in core source. It is recorded at this length because it looks additive and safe,
+and is neither.
 
 For the swing toggle to read correctly, `is_swing_on` requires the *reported*
 `swing_mode` to be `vertical` rather than `swing`, so the change is not additive
@@ -149,9 +148,11 @@ Fanv2 on the Thermostat with `CHAR_ACTIVE` configured unconditionally, and
 `off`. That ships a dead control: a power button on the new tile that visibly
 does nothing.
 
-The justification for accepting all that was promotion to `HeaterCooler`, which
-per the Context section requires a manual accessory-type change on every
-already-bridged entity, so the payoff mostly does not arrive.
+The justification for accepting all that was promotion to the Heater Cooler
+accessory. That payoff is real for anyone bridging later, and delayed for anyone
+already bridged, who must change the accessory type by hand. What it would not
+deliver is fan speed, which needs the rename below as well, so the swing change
+alone buys a better-looking tile and leaves half the reported problem in place.
 
 **Renaming `fan_modes` to standard names** has the most precedent in core:
 `midea`, `gree`, `sensibo` and `lg_thinq` all map vendor speeds onto standard
@@ -159,23 +160,46 @@ names, and `midea` shows it need not cost HA anything, keeping five speeds by
 using standard names in the middle and custom `silent` and `full` at the
 extremes. It is rejected because of the read-back gate, which would force the
 reported `fan_mode` from `"three"` to `"medium"` and silently break templates,
-because HomeKit would reach only three of five speeds, and because
-`geoffdavis/esphome-mitsubishiheatpump` ran this experiment on the same hardware;
-its
+because HomeKit would reach only three of five speeds, and because the same
+renaming has already been tried on this hardware and rejected by its users.
+
+`geoffdavis/esphome-mitsubishiheatpump` drives the same hardware through a library
+whose fan map is numbered, then had to invent a mapping onto `low`, `medium`,
+`high` and `middle` because ESPHome forces a fixed set of names. Its
 [issue #135](https://github.com/geoffdavis/esphome-mitsubishiheatpump/issues/135)
-is a user asking to be put back on numbers because `medium` and `middle` are
-indistinguishable. It would also destroy the case-fold symmetry of
-`normalize_to_api`, currently a pure round trip against the API's own vocabulary.
+is three users asking for numbers back, one keeping a lookup table to remember
+which of `medium` and `middle` is which, and it was closed when the reporter
+installed a template component to undo the renaming from outside.
+
+Renaming would also destroy the case-fold symmetry of `normalize_to_api`,
+currently a pure round trip against the API's own vocabulary.
 Putting speed on the `HeaterCooler` accessory would be the tidiest outcome of
-all, but it is unreachable without this rename and so falls with it.
+all, but it is unreachable without this rename and so falls with it. Note that
+it would not have been the better outcome for resolution: `HeaterCooler` derives
+its slider step from `100 / len(ordered_fan_speeds)` exactly as the Thermostat's
+linked fan service does, so it too would reach three of five speeds. The fan
+entity gives five.
+
+**Documenting a template recipe instead of shipping a platform** would work, and
+it is what the ESPHome users fell back on. Core's template integration has no
+climate platform, which is why they needed a third-party component from HACS, but
+it does have a template fan supporting `speed_count`, `percentage`,
+`preset_modes` and `oscillating`, so a user could wrap the climate entity in
+plain YAML and bridge that instead. It is rejected as the answer because it asks
+every affected user to write and maintain the same mapping by hand, in a project
+whose users are Home Assistant owners rather than developers, and it still
+creates a second entity, so it carries this decision's main cost without its
+convenience. It remains a reasonable interim workaround to offer anyone who wants
+the controls before this ships.
 
 **Doing nothing** is core's position and is defensible: the developer
 documentation explicitly permits custom fan modes, and in
 [architecture discussion #553](https://github.com/home-assistant/architecture/discussions/553)
 a maintainer rejected expanding the built-in sets on the grounds that the options
 are vendor-specific. HA core's own `melcloud_home` integration has the same gap
-for the same hardware. It is rejected because the complaints are being filed
-here.
+for the same hardware. Doing nothing is the right answer when a fix costs more
+than the problem, and it is rejected here because the fan entity costs existing
+users nothing.
 
 ## Consequences
 
@@ -185,7 +209,7 @@ here.
 - The air conditioner keeps publishing as a Thermostat rather than as an air
   conditioner. Correct classification needs `HeaterCooler`, which needs the
   rejected vocabulary change and a manual accessory-type change besides.
-- **The fan entity reaches every voice assistant, not only HomeKit.** A `fan`
+- The fan entity reaches every voice assistant, not only HomeKit. A `fan`
   domain entity appears in Google Home and Alexa as a fan with a power switch,
   for every user, whether or not they bridge to HomeKit. Anyone asking Google or
   Alexa to turn that fan off switches the air conditioner off.
@@ -205,14 +229,7 @@ here.
 - Existing automations, templates and service calls keep working unchanged,
   because every advertised list and every reported value stays as it is.
 
-## Open Questions
-
-- Entity creation is gated on a stable capability, `number_of_fan_speeds > 0`.
-  The behaviour when `unit.capabilities` is `None` is unresolved: `ATAClimate`
-  falls back to all five speeds in that case, and whether the fan entity should
-  follow that fallback or skip creation needs deciding during implementation.
-
-### Conditions for Revisiting
+## Conditions for Revisiting
 
 - **If core ever auto-routes already-bridged entities to `HeaterCooler`**, or if
   changing the accessory type by hand becomes normal, the swing vocabulary
@@ -232,6 +249,8 @@ here.
 - `homekit/type_fans.py`, `type_thermostats.py`, `type_heater_coolers.py`,
   `climate_base.py`, `climate_util.py`, `accessories.py` and `aidmanager.py` in
   HA core, read from the 2026.9.1 wheel and diffed against 2026.8.0
+- [HomeKit Bridge documentation](https://www.home-assistant.io/integrations/homekit/),
+  which is the source of both quotations above
 - [Climate entity developer docs](https://developers.home-assistant.io/docs/core/entity/climate/#fan-modes),
   which permit custom fan modes
 - [issue #318](https://github.com/andrew-blake/melcloudhome/issues/318)

--- a/docs/decisions/025-homekit-fan-entity.md
+++ b/docs/decisions/025-homekit-fan-entity.md
@@ -237,12 +237,20 @@ users nothing.
   swung and unswung from the Home app, ends on `Auto`. Restoring the prior
   position would mean holding state the coordinator does not keep, which is not
   worth it for a binary control, so the loss is accepted.
-- `percentage` reports the commanded speed, and is unknown in `auto` because no
-  numbered speed is commanded then; the `auto` preset carries that state instead.
-  The bridge skips the characteristic update while percentage is unknown, so the
-  HomeKit slider holds whatever it last showed. Reporting `actual_fan_speed`
-  (#285) would be more informative but makes reads and writes reference different
-  API fields, so it is deferred rather than adopted silently.
+- `percentage` reports the commanded speed; the `auto` preset carries the auto
+  state, since a percentage cannot express it. While the unit is in `auto`,
+  `percentage` reports the last numbered speed commanded rather than `None`,
+  and is unknown only before any numbered speed has ever been seen. This
+  matches HAP's own model: `RotationSpeed` is the manual setpoint that persists
+  while `TargetFanState` is Auto, not a value that goes blank when Auto is
+  selected. It also matters for HomeKit's Manual/Auto toggle specifically:
+  `type_fans.set_single_preset_mode` reads back our `percentage` when the user
+  switches out of Auto, and falls back to a hard-coded 50% if it finds `None`,
+  moving the unit to whatever speed that percentage maps to rather than the one
+  the user was actually on. Reporting the remembered speed closes that gap.
+  Reporting `actual_fan_speed` (#285) would be more informative but makes reads
+  and writes reference different API fields, so it remains deferred rather than
+  adopted here.
 - Existing automations, templates and service calls keep working unchanged,
   because every advertised list and every reported value stays as it is.
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -53,14 +53,13 @@ and Alexa as well as to HomeKit.
 Oscillation is only offered on units that report a vane, so a unit with neither
 swing nor air direction gets the speed slider and power without it.
 
-If your HomeKit Bridge is configured with a filter such as
-`include_domains: [climate]`, add `fan` to it, otherwise this entity is not
-bridged and the new tile never appears.
+Under `auto` the percentage keeps the last speed you chose and the unit picks
+its own, so the speed it is actually running is in the Actual Fan Speed sensor
+below.
 
-In auto, the speed slider keeps the last speed you chose and the unit picks its
-own. The Home app's title still reads that percentage, so it shows the speed the
-unit will go back to rather than the one it is running now. The speed it is
-actually running is in the Actual Fan Speed sensor below.
+**Using this in Apple Home?** See [the HomeKit guide](homekit.md), which covers
+adding the fan to your bridge, what the tile does, and the behaviour that
+surprises people.
 
 ### Sensors
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -50,6 +50,13 @@ Turning this entity off powers the air conditioner down, because an air
 conditioner has no "fan off, unit running" state. That applies to Google Home
 and Alexa as well as to HomeKit.
 
+Oscillation is only offered on units that report a vane, so a unit with neither
+swing nor air direction gets the speed slider and power without it.
+
+If your HomeKit Bridge is configured with a filter such as
+`include_domains: [climate]`, add `fan` to it, otherwise this entity is not
+bridged and the new tile never appears.
+
 ### Sensors
 
 - **Room Temperature**: `sensor.melcloudhome_{short_id}_room_temperature`

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -32,6 +32,24 @@ For each air conditioning unit, the following entities are created:
 - **Features**: Power on/off, temperature control, HVAC modes, fan speeds, swing modes
 - **HVAC Action**: Real-time heating/cooling/idle status
 
+### Fan Entity
+
+- **Entity ID**: `fan.melcloudhome_{short_id}_a_c_fan`
+- **Name**: `<device> A/C fan`
+- **Created when**: The unit reports `number_of_fan_speeds` of 1 or more
+
+Carries fan speed as a percentage, the vertical vane as oscillation, and unit
+power. It exists because Home Assistant's HomeKit bridge cannot expose either
+control from the climate entity; see ADR-025.
+
+Fan speed is settable from both this entity and the climate entity's fan mode
+dropdown. Both control the same unit and cannot disagree, since both read one
+coordinator field.
+
+Turning this entity off powers the air conditioner down, because an air
+conditioner has no "fan off, unit running" state. That applies to Google Home
+and Alexa as well as to HomeKit.
+
 ### Sensors
 
 - **Room Temperature**: `sensor.melcloudhome_{short_id}_room_temperature`

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -57,6 +57,11 @@ If your HomeKit Bridge is configured with a filter such as
 `include_domains: [climate]`, add `fan` to it, otherwise this entity is not
 bridged and the new tile never appears.
 
+In auto, the speed slider keeps the last speed you chose and the unit picks its
+own. The Home app's title still reads that percentage, so it shows the speed the
+unit will go back to rather than the one it is running now. The speed it is
+actually running is in the Actual Fan Speed sensor below.
+
 ### Sensors
 
 - **Room Temperature**: `sensor.melcloudhome_{short_id}_room_temperature`

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -47,8 +47,9 @@ dropdown. Both control the same unit and cannot disagree, since both read one
 coordinator field.
 
 Turning this entity off powers the air conditioner down, because an air
-conditioner has no "fan off, unit running" state. That applies to Google Home
-and Alexa as well as to HomeKit.
+conditioner has no "fan off, unit running" state. The same should apply anywhere
+else the entity is exposed, such as Google Home or Alexa, though only HomeKit
+has been tested.
 
 Oscillation is only offered on units that report a vane, so a unit with neither
 swing nor air direction gets the speed slider and power without it.

--- a/docs/homekit.md
+++ b/docs/homekit.md
@@ -38,10 +38,9 @@ Take care at the entity selection step: leaving the fan selection empty means
 the whole domain, so every unit in your home gets bridged. Pick the ones you
 want explicitly if you only want some of them.
 
-Home Assistant reloads the bridge when you save. If the new tile has not
-appeared in the Home app after a minute or two, restart Home Assistant. New
-accessories arrive in whichever room the Home app puts them in by default, so
-you may want to move them into the right room afterwards.
+Home Assistant rebuilds the bridge when you save, so the new tile appears
+without restarting anything. It arrives in whichever room the Home app chooses
+by default, so you may want to move it into the right room afterwards.
 
 ## Tapping the icon and tapping the label
 
@@ -107,8 +106,8 @@ watch the unit modulating in Auto, watch it there.
 ## Units that report no vane
 
 Some units report no vane to the MELCloud Home service, and those get no
-Oscillate control. There is nothing missing and nothing to configure. It is not
-unusual either: in one six-unit household, three of the units report none.
+Oscillate control. There is nothing missing and nothing to configure, and it is
+not unusual for a unit to report no vane.
 
 The alternative would be an Oscillate switch that did nothing at all, which is
 worse than no switch.

--- a/docs/homekit.md
+++ b/docs/homekit.md
@@ -1,0 +1,150 @@
+# Using MELCloud Home with Apple HomeKit
+
+How your air conditioning units appear in the Apple Home app, and the handful of
+things about them that catch people out.
+
+**Last Updated:** 2026-09-12
+
+---
+
+## What you will see
+
+Each air conditioning unit gives you two tiles in the Home app rather than one.
+
+The thermostat tile is the one you already have. It carries the temperature and
+the heating or cooling mode.
+
+The fan tile is the new one. It carries the fan speed, the vane and the unit's
+power. It takes its name from the unit, so a unit called Living Room gives you a
+tile called "Living Room A-C fan".
+
+Both tiles are the same air conditioner. A change made on one shows up on the
+other, and neither can get out of step with the unit itself.
+
+Heat pumps are unaffected. This applies to air conditioning units only.
+
+## Adding the fan to your bridge
+
+The fan is a new entity, so your HomeKit Bridge will not pick it up on its own.
+In Home Assistant go to **Settings** → **Devices & Services** → **HomeKit
+Bridge** → **Configure**, and add the fan entities you want to the list the
+bridge exposes.
+
+If your bridge is filtered to climate entities only, for example with
+`include_domains: [climate]`, the fan will never appear however long you wait.
+Add `fan` to the filter.
+
+Take care at the entity selection step: leaving the fan selection empty means
+the whole domain, so every unit in your home gets bridged. Pick the ones you
+want explicitly if you only want some of them.
+
+Home Assistant reloads the bridge when you save. If the new tile has not
+appeared in the Home app after a minute or two, restart Home Assistant. New
+accessories arrive in whichever room the Home app puts them in by default, so
+you may want to move them into the right room afterwards.
+
+## Tapping the icon and tapping the label
+
+On the tile itself, the icon and the name do different things.
+
+Tapping the **icon** switches the unit on or off. Tapping the **label** opens
+the controls.
+
+This is easy to miss. If you are hunting for a power button, it is the icon.
+
+## The controls behind the label
+
+Open the fan tile and you get three controls: **Oscillate**, **Fan Mode**
+(Manual or Auto) and **Fan Speed**.
+
+Only the speed slider and the power are on the tile itself. Apple decides which
+fan controls sit on a tile and which sit on the page behind it, and the
+integration has no say in that.
+
+## Turning the fan off turns the air conditioner off
+
+This is the one that surprises everyone, so it is worth reading twice.
+
+An air conditioner has no "fan off, unit still running" state. The fan is the
+air conditioner. So turning the fan tile off, or dragging its speed slider down
+to zero, switches the whole unit off. Turning it back on starts the air
+conditioner again, in the mode it was last using.
+
+The same applies to Google Home and Alexa, where the unit also appears as a fan.
+Asking a voice assistant to turn off the living room A/C fan stops the air
+conditioning in that room.
+
+If what you actually want is the unit running quietly, set the lowest speed
+rather than turning the fan off.
+
+## Oscillate does not start the unit
+
+Switching Oscillate on sets the vertical vane sweeping. It does not power the
+unit on. If the unit is off, nothing visible happens straight away and the
+setting applies the next time it runs. That is deliberate, not a fault.
+
+Switching Oscillate off returns the vane to Auto, which is a fixed angle the
+unit chooses to suit what it is doing. It does not go back to a numbered vane
+position you might have set in Home Assistant earlier.
+
+## Auto fan speed
+
+Fan Mode has two settings. On **Manual** you choose the speed. On **Auto** the
+unit chooses it, and will change it by itself as the room warms or cools.
+
+While you are in Auto, the speed slider keeps the last speed you chose. So the
+percentage at the top of the page is the speed the unit will go back to, not the
+speed it is running at that moment. The Home app has no way to show those two
+things separately, and a slider that remembers your choice is more useful than
+one that drifts about on its own.
+
+Switching back to Manual returns the unit to the speed you last chose.
+
+The speed the unit is genuinely running is in Home Assistant, in the **Actual
+Fan Speed** sensor. That one does not reach HomeKit at all, so if you want to
+watch the unit modulating in Auto, watch it there.
+
+## Units that report no vane
+
+Some units report no vane to the MELCloud Home service, and those get no
+Oscillate control. There is nothing missing and nothing to configure. It is not
+unusual either: in one six-unit household, three of the units report none.
+
+The alternative would be an Oscillate switch that did nothing at all, which is
+worse than no switch.
+
+If a unit has a vane you can move from the official MELCloud Home app and still
+gets no Oscillate control here, that is worth
+[raising as an issue](https://github.com/andrew-blake/melcloudhome/issues).
+
+## Two things that look wrong and are not
+
+**The name reads "A-C fan".** The entity is called "A/C fan". HomeKit does not
+allow a slash in an accessory name and puts a hyphen in its place, so the Home
+app shows "A-C fan". Nothing has gone wrong, and you can rename the accessory in
+the Home app if it bothers you.
+
+**"Not certified to work with HomeKit".** This banner appears when you pair, and
+it appears for everything Home Assistant bridges, not just these fans. Home
+Assistant's bridge is not part of Apple's certification programme. It is normal
+and it is not a problem.
+
+## Why the thermostat tile stays a plain thermostat
+
+It would be tidier to have one tile with the temperature, the speed and the vane
+all on it. Apple does have an accessory type that does exactly that, but a unit
+only qualifies for it if its fan speeds carry Apple's own names, which would
+mean renaming five numbered speeds onto low, medium and high. That would reach
+three of your five speeds instead of all five, and it would break existing
+automations and templates that refer to the current names.
+
+A separate fan tile keeps every speed reachable and changes nothing you already
+have. [ADR-025](decisions/025-homekit-fan-entity.md) records the full reasoning
+for anyone who wants it.
+
+## See also
+
+- [Entity Reference](entities.md) for the fan entity and the Actual Fan Speed
+  sensor as they appear inside Home Assistant
+- [HomeKit Bridge documentation](https://www.home-assistant.io/integrations/homekit/)
+  for bridge setup in general

--- a/docs/homekit.md
+++ b/docs/homekit.md
@@ -50,7 +50,7 @@ On the tile itself, the icon and the name do different things.
 Tapping the **icon** switches the unit on or off. Tapping the **label** opens
 the speed slider.
 
-This is easy to miss. If you are hunting for a power button, it is the icon.
+If you are looking for a power button, the icon is it.
 
 ## Finding Oscillate and Fan Mode
 
@@ -59,22 +59,21 @@ power button in that view: the slider is the power control, and setting it to
 anything above zero starts the unit. **Oscillate** and **Fan Mode** (Manual or
 Auto) are one level further in, behind the cog icon in the corner.
 
-They are easy to miss, because nothing on the slider view hints that there is
-more behind the cog. Apple decides which fan controls sit on the tile and which
-sit on the settings page, and the integration has no say in it.
+Nothing on the slider view hints that there is more behind the cog. Apple
+decides which fan controls sit on the tile and which sit on the settings page,
+and the integration has no say in it.
 
 ## Turning the fan off turns the air conditioner off
-
-This is the one that surprises everyone, so it is worth reading twice.
 
 An air conditioner has no "fan off, unit still running" state. The fan is the
 air conditioner. So turning the fan tile off, or dragging its speed slider down
 to zero, switches the whole unit off. Turning it back on starts the air
 conditioner again, in the mode it was last using.
 
-The same applies to Google Home and Alexa, where the unit also appears as a fan.
-Asking a voice assistant to turn off the living room A/C fan stops the air
-conditioning in that room.
+We have only checked this through HomeKit. The entity is an ordinary Home
+Assistant fan though, so if you also expose your entities to Google Home or
+Alexa it will appear there as a fan too, and asking either of them to turn that
+fan off should stop the air conditioning in the same way.
 
 If what you actually want is the unit running quietly, set the lowest speed
 rather than turning the fan off.
@@ -109,27 +108,10 @@ watch the unit modulating in Auto, watch it there.
 ## Units that report no vane
 
 Some units report no vane to the MELCloud Home service, and those get no
-Oscillate control. There is nothing missing and nothing to configure, and it is
-not unusual for a unit to report no vane.
+Oscillate control. There is nothing missing and nothing to configure.
 
-The alternative would be an Oscillate switch that did nothing at all, which is
-worse than no switch.
-
-If a unit has a vane you can move from the official MELCloud Home app and still
-gets no Oscillate control here, that is worth
-[raising as an issue](https://github.com/andrew-blake/melcloudhome/issues).
-
-## Two things that look wrong and are not
-
-**The name reads "A-C fan".** The entity is called "A/C fan". HomeKit does not
-allow a slash in an accessory name and puts a hyphen in its place, so the Home
-app shows "A-C fan". Nothing has gone wrong, and you can rename the accessory in
-the Home app if it bothers you.
-
-**"Not certified to work with HomeKit".** This banner appears when you pair, and
-it appears for everything Home Assistant bridges, not just these fans. Home
-Assistant's bridge is not part of Apple's certification programme. It is normal
-and it is not a problem.
+If you think one of your units has a vane but gets no Oscillate control, please
+[raise an issue](https://github.com/andrew-blake/melcloudhome/issues).
 
 ## Why the thermostat tile stays a plain thermostat
 

--- a/docs/homekit.md
+++ b/docs/homekit.md
@@ -31,8 +31,9 @@ Bridge** → **Configure**, and add the fan entities you want to the list the
 bridge exposes.
 
 If your bridge is filtered to climate entities only, for example with
-`include_domains: [climate]`, the fan will never appear however long you wait.
-Add `fan` to the filter.
+`include_domains: [climate]`, add `fan` to the filter as well. Without it the
+fan entities are not offered to HomeKit at all, so the new tile will not show
+up.
 
 Take care at the entity selection step: leaving the fan selection empty means
 the whole domain, so every unit in your home gets bridged. Pick the ones you
@@ -47,18 +48,20 @@ by default, so you may want to move it into the right room afterwards.
 On the tile itself, the icon and the name do different things.
 
 Tapping the **icon** switches the unit on or off. Tapping the **label** opens
-the controls.
+the speed slider.
 
 This is easy to miss. If you are hunting for a power button, it is the icon.
 
-## The controls behind the label
+## Finding Oscillate and Fan Mode
 
-Open the fan tile and you get three controls: **Oscillate**, **Fan Mode**
-(Manual or Auto) and **Fan Speed**.
+Opening the tile gives you the speed slider and nothing else. There is no
+power button in that view: the slider is the power control, and setting it to
+anything above zero starts the unit. **Oscillate** and **Fan Mode** (Manual or
+Auto) are one level further in, behind the cog icon in the corner.
 
-Only the speed slider and the power are on the tile itself. Apple decides which
-fan controls sit on a tile and which sit on the page behind it, and the
-integration has no say in that.
+They are easy to miss, because nothing on the slider view hints that there is
+more behind the cog. Apple decides which fan controls sit on the tile and which
+sit on the settings page, and the integration has no say in it.
 
 ## Turning the fan off turns the air conditioner off
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -358,6 +358,8 @@ def create_mock_ata_unit(
     overheat_protection: "ProtectionModeState | None" = None,
     holiday_mode: "ProtectionModeState | None" = None,
     number_of_fan_speeds: int = 5,
+    has_swing: bool = True,
+    has_air_direction: bool = True,
 ) -> "AirToAirUnit":
     """Create a mock AirToAirUnit for testing."""
     from custom_components.melcloudhome.api.models_ata import (
@@ -384,6 +386,8 @@ def create_mock_ata_unit(
         capabilities=AirToAirCapabilities(
             has_energy_consumed_meter=has_energy_meter,
             number_of_fan_speeds=number_of_fan_speeds,
+            has_swing=has_swing,
+            has_air_direction=has_air_direction,
         ),
         energy_consumed=energy_consumed,
         has_outdoor_temp_sensor=has_outdoor_sensor,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -357,6 +357,7 @@ def create_mock_ata_unit(
     frost_protection: "ProtectionModeState | None" = None,
     overheat_protection: "ProtectionModeState | None" = None,
     holiday_mode: "ProtectionModeState | None" = None,
+    number_of_fan_speeds: int = 5,
 ) -> "AirToAirUnit":
     """Create a mock AirToAirUnit for testing."""
     from custom_components.melcloudhome.api.models_ata import (
@@ -380,7 +381,10 @@ def create_mock_ata_unit(
         error_code=error_code,
         rssi=rssi,
         time_zone=None,
-        capabilities=AirToAirCapabilities(has_energy_consumed_meter=has_energy_meter),
+        capabilities=AirToAirCapabilities(
+            has_energy_consumed_meter=has_energy_meter,
+            number_of_fan_speeds=number_of_fan_speeds,
+        ),
         energy_consumed=energy_consumed,
         has_outdoor_temp_sensor=has_outdoor_sensor,
         outdoor_temp_reading=outdoor_temp_reading,

--- a/tests/integration/test_climate_ata.py
+++ b/tests/integration/test_climate_ata.py
@@ -322,3 +322,38 @@ async def test_device_removal_entity_becomes_unavailable(hass: HomeAssistant) ->
 
     state = hass.states.get(_CLIMATE_ENTITY)
     assert state is None  # Entity not created when no units
+
+
+@pytest.mark.asyncio
+async def test_climate_vocabularies_are_unchanged(hass: HomeAssistant) -> None:
+    """Pin both vocabularies against a future tidy-up.
+
+    ADR-025 rejected adding HomeKit's standard names to swing_modes: doing so
+    requires swing_mode to report "vertical" instead of "swing", which breaks
+    templates silently, and it builds a linked fan service on the Thermostat
+    whose power button is rejected and visibly does nothing. The fan entity
+    carries these controls instead. Read that ADR before changing this test.
+    """
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    state = hass.states.get(_CLIMATE_ENTITY)
+    assert state.attributes["fan_modes"] == [
+        "auto",
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+    ]
+    assert state.attributes["swing_modes"] == [
+        "auto",
+        "swing",
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+    ]

--- a/tests/integration/test_fan_ata.py
+++ b/tests/integration/test_fan_ata.py
@@ -1,0 +1,183 @@
+"""Tests for the MELCloud Home ATA fan entity.
+
+Behaviour through Home Assistant core interfaces only.
+Reference: docs/testing-best-practices.md
+Run with: make test-integration
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from .conftest import (
+    create_mock_ata_building,
+    create_mock_ata_unit,
+    create_mock_ata_user_context,
+    setup_ata_integration_custom,
+)
+
+# melcloudhome_<first4><last4> from create_device_info, plus the slug of
+# _attr_name. Confirmed: slugify("melcloudhome_a1b2_9abc A/C fan", separator="_")
+# gives this, and the same call on "... Climate" gives the climate constant.
+_FAN_ENTITY = "fan.melcloudhome_a1b2_9abc_a_c_fan"
+
+
+def _configure_ata_controls(client: Any) -> None:
+    client.ata = MagicMock()
+    client.ata.set_power = AsyncMock()
+    client.ata.set_fan_speed = AsyncMock()
+    client.ata.set_vane_vertical = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_fan_entity_created_for_ata_unit(hass: HomeAssistant) -> None:
+    """A unit with fan speeds gets a fan entity."""
+    mock_context = create_mock_ata_user_context()
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    assert hass.states.get(_FAN_ENTITY) is not None
+
+
+@pytest.mark.asyncio
+async def test_percentage_reflects_commanded_speed(hass: HomeAssistant) -> None:
+    """Speed three of five reports as 60 percent."""
+    mock_unit = create_mock_ata_unit(power=True, set_fan_speed="Three")
+    mock_context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    assert hass.states.get(_FAN_ENTITY).attributes["percentage"] == 60
+
+
+@pytest.mark.asyncio
+async def test_percentage_is_none_in_auto(hass: HomeAssistant) -> None:
+    """No numbered speed is commanded in auto, so percentage is unknown."""
+    mock_unit = create_mock_ata_unit(power=True, set_fan_speed="Auto")
+    mock_context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    state = hass.states.get(_FAN_ENTITY)
+    assert state.attributes["percentage"] is None
+    assert state.attributes["preset_mode"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_set_percentage_sends_matching_speed(hass: HomeAssistant) -> None:
+    """Forty percent of five speeds is speed two."""
+    mock_context = create_mock_ata_user_context()
+    _, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {"entity_id": _FAN_ENTITY, "percentage": 40},
+        blocking=True,
+    )
+
+    mock_client.ata.set_fan_speed.assert_called_once()
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Two"
+
+
+@pytest.mark.asyncio
+async def test_set_percentage_zero_powers_the_unit_off(hass: HomeAssistant) -> None:
+    """Zero means unit power off, and sends no speed."""
+    mock_context = create_mock_ata_user_context()
+    _, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {"entity_id": _FAN_ENTITY, "percentage": 0},
+        blocking=True,
+    )
+
+    assert mock_client.ata.set_power.call_args[0][1] is False
+    mock_client.ata.set_fan_speed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_preset_mode_auto(hass: HomeAssistant) -> None:
+    """The auto preset sends the API's Auto fan speed.
+
+    The unit must start on a numbered speed: the control client skips the call
+    when the device already holds the requested value (ADR-018), and the mock
+    helper defaults to "Auto".
+    """
+    mock_unit = create_mock_ata_unit(power=True, set_fan_speed="Three")
+    mock_context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[mock_unit])]
+    )
+    _, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "set_preset_mode",
+        {"entity_id": _FAN_ENTITY, "preset_mode": "auto"},
+        blocking=True,
+    )
+
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Auto"
+
+
+@pytest.mark.asyncio
+async def test_turn_off_powers_the_unit_down(hass: HomeAssistant) -> None:
+    """An air conditioner has no fan-off state, so off means unit power off."""
+    mock_context = create_mock_ata_user_context()
+    _, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    await hass.services.async_call(
+        "fan", "turn_off", {"entity_id": _FAN_ENTITY}, blocking=True
+    )
+
+    assert mock_client.ata.set_power.call_args[0][1] is False
+
+
+@pytest.mark.asyncio
+async def test_speed_count_follows_device_capability(hass: HomeAssistant) -> None:
+    """A three-speed unit gets three steps, not five."""
+    mock_unit = create_mock_ata_unit(
+        power=True, set_fan_speed="Three", number_of_fan_speeds=3
+    )
+    mock_context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    state = hass.states.get(_FAN_ENTITY)
+    assert state.attributes["percentage_step"] == pytest.approx(100 / 3)
+    assert state.attributes["percentage"] == 100
+
+
+@pytest.mark.asyncio
+async def test_no_fan_entity_without_fan_speeds(hass: HomeAssistant) -> None:
+    """A unit reporting no speeds gets no fan entity."""
+    mock_unit = create_mock_ata_unit(number_of_fan_speeds=0)
+    mock_context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    assert hass.states.get(_FAN_ENTITY) is None

--- a/tests/integration/test_fan_ata.py
+++ b/tests/integration/test_fan_ata.py
@@ -14,6 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
+from custom_components.melcloudhome.const import DOMAIN
+
 from .conftest import (
     create_mock_ata_building,
     create_mock_ata_unit,
@@ -81,12 +83,48 @@ async def test_percentage_reflects_commanded_speed(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.asyncio
-async def test_percentage_is_none_in_auto(hass: HomeAssistant) -> None:
-    """No numbered speed is commanded in auto, so percentage is unknown."""
+async def test_percentage_is_none_before_any_numbered_speed_seen(
+    hass: HomeAssistant,
+) -> None:
+    """Auto with nothing remembered yet leaves percentage unknown.
+
+    The unit starts in auto, so there is no numbered speed to resume; today's
+    behaviour (the HomeKit bridge falling back to its own hard-coded 50%) is
+    the correct graceful degradation here. See
+    test_percentage_reports_last_numbered_speed_in_auto for the case where a
+    speed *has* been seen.
+    """
     await _setup(hass, power=True, set_fan_speed="Auto")
 
     state = hass.states.get(_FAN_ENTITY)
     assert state.attributes["percentage"] is None
+    assert state.attributes["preset_mode"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_percentage_reports_last_numbered_speed_in_auto(
+    hass: HomeAssistant,
+) -> None:
+    """Switching to auto from a numbered speed keeps reporting that speed.
+
+    Regression test for #318: HomeKit's bridge reads back our percentage when
+    the user leaves Auto for Manual, and falls back to a hard-coded 50% if it
+    finds None -- moving the unit to a speed the user never chose. Reporting
+    the last numbered speed we saw instead of None lets leaving auto resume
+    it.
+    """
+    _, mock_client = await _setup(hass, power=True, set_fan_speed="Three")
+
+    updated_unit = create_mock_ata_unit(power=True, set_fan_speed="Auto")
+    updated_context = create_mock_ata_user_context(
+        [create_mock_ata_building(units=[updated_unit])]
+    )
+    mock_client.get_user_context = AsyncMock(return_value=updated_context)
+    await hass.services.async_call(DOMAIN, "force_refresh", {}, blocking=True)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(_FAN_ENTITY)
+    assert state.attributes["percentage"] == 60
     assert state.attributes["preset_mode"] == "auto"
 
 

--- a/tests/integration/test_fan_ata.py
+++ b/tests/integration/test_fan_ata.py
@@ -181,3 +181,78 @@ async def test_no_fan_entity_without_fan_speeds(hass: HomeAssistant) -> None:
     )
 
     assert hass.states.get(_FAN_ENTITY) is None
+
+
+@pytest.mark.asyncio
+async def test_oscillating_true_when_vane_swinging(hass: HomeAssistant) -> None:
+    """The API's Swing is the only vane value that oscillates."""
+    mock_unit = create_mock_ata_unit(power=True, vane_vertical="Swing")
+    mock_context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    assert hass.states.get(_FAN_ENTITY).attributes["oscillating"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("vane", ["Auto", "One", "Five"])
+async def test_oscillating_false_for_fixed_positions(
+    hass: HomeAssistant, vane: str
+) -> None:
+    """Auto is a fixed mode-dependent angle, not a sweep, per the vendor manual."""
+    mock_unit = create_mock_ata_unit(power=True, vane_vertical=vane)
+    mock_context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[mock_unit])]
+    )
+    await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    assert hass.states.get(_FAN_ENTITY).attributes["oscillating"] is False
+
+
+@pytest.mark.asyncio
+async def test_oscillate_on_sends_swing(hass: HomeAssistant) -> None:
+    """Turning oscillation on sets the vane to Swing."""
+    mock_context = create_mock_ata_user_context()
+    _, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "oscillate",
+        {"entity_id": _FAN_ENTITY, "oscillating": True},
+        blocking=True,
+    )
+
+    assert mock_client.ata.set_vane_vertical.call_args[0][1] == "Swing"
+
+
+@pytest.mark.asyncio
+async def test_oscillate_off_sends_auto(hass: HomeAssistant) -> None:
+    """Turning it off returns the vane to the unit's own positioning.
+
+    The vane must start on "Swing", both because that is the only state you
+    would switch oscillation off from, and because the control client skips a
+    write matching the device's current value (ADR-018).
+    """
+    mock_unit = create_mock_ata_unit(power=True, vane_vertical="Swing")
+    mock_context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[mock_unit])]
+    )
+    _, mock_client = await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "oscillate",
+        {"entity_id": _FAN_ENTITY, "oscillating": False},
+        blocking=True,
+    )
+
+    assert mock_client.ata.set_vane_vertical.call_args[0][1] == "Auto"

--- a/tests/integration/test_fan_ata.py
+++ b/tests/integration/test_fan_ata.py
@@ -27,6 +27,7 @@ _FAN_ENTITY = "fan.melcloudhome_a1b2_9abc_a_c_fan"
 def _configure_ata_controls(client: Any) -> None:
     client.ata = MagicMock()
     client.ata.set_power = AsyncMock()
+    client.ata.set_power_and_mode = AsyncMock()
     client.ata.set_fan_speed = AsyncMock()
     client.ata.set_vane_vertical = AsyncMock()
 
@@ -256,3 +257,102 @@ async def test_oscillate_off_sends_auto(hass: HomeAssistant) -> None:
     )
 
     assert mock_client.ata.set_vane_vertical.call_args[0][1] == "Auto"
+
+
+async def _setup_one_unit(hass: HomeAssistant, **unit_kwargs: Any) -> Any:
+    """Set up the integration with a single ATA unit built from unit_kwargs."""
+    mock_context = create_mock_ata_user_context(
+        buildings=[
+            create_mock_ata_building(units=[create_mock_ata_unit(**unit_kwargs)])
+        ]
+    )
+    return await setup_ata_integration_custom(
+        hass, mock_context, configure_client=_configure_ata_controls
+    )
+
+
+@pytest.mark.asyncio
+async def test_turn_on_preserves_the_operation_mode(hass: HomeAssistant) -> None:
+    """Power-on carries the mode, so no operationMode=null reaches the API.
+
+    A bare power write can fault a multi-zone outdoor unit. The unit starts off
+    because the control client skips a write the device already satisfies.
+    """
+    _, mock_client = await _setup_one_unit(hass, power=False, operation_mode="Heat")
+
+    await hass.services.async_call(
+        "fan", "turn_on", {"entity_id": _FAN_ENTITY}, blocking=True
+    )
+
+    assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
+    mock_client.ata.set_power.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_turn_on_with_percentage_sets_power_and_speed(
+    hass: HomeAssistant,
+) -> None:
+    """turn_on(percentage=40) powers on and commands speed two of five."""
+    _, mock_client = await _setup_one_unit(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "turn_on",
+        {"entity_id": _FAN_ENTITY, "percentage": 40},
+        blocking=True,
+    )
+
+    assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Two"
+
+
+@pytest.mark.asyncio
+async def test_turn_on_with_auto_preset_sets_power_and_speed(
+    hass: HomeAssistant,
+) -> None:
+    """HomeKit's Auto toggle routes through turn_on, so it must power on too."""
+    _, mock_client = await _setup_one_unit(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Three"
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "turn_on",
+        {"entity_id": _FAN_ENTITY, "preset_mode": "auto"},
+        blocking=True,
+    )
+
+    assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Auto"
+
+
+@pytest.mark.asyncio
+async def test_set_percentage_powers_on_an_off_unit(hass: HomeAssistant) -> None:
+    """Dragging the HomeKit slider up on an off tile must start the unit.
+
+    The bridge sends Active=1 and RotationSpeed in one write and then skips
+    fan.turn_on, so set_percentage alone has to power the unit on.
+    """
+    _, mock_client = await _setup_one_unit(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {"entity_id": _FAN_ENTITY, "percentage": 60},
+        blocking=True,
+    )
+
+    assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Three"
+
+
+@pytest.mark.asyncio
+async def test_no_oscillation_without_a_vane(hass: HomeAssistant) -> None:
+    """A unit with neither swing nor air direction gets no oscillate control."""
+    await _setup_one_unit(hass, power=True, has_swing=False, has_air_direction=False)
+
+    assert "oscillating" not in hass.states.get(_FAN_ENTITY).attributes

--- a/tests/integration/test_fan_ata.py
+++ b/tests/integration/test_fan_ata.py
@@ -32,13 +32,20 @@ def _configure_ata_controls(client: Any) -> None:
     client.ata.set_vane_vertical = AsyncMock()
 
 
+async def _setup(hass: HomeAssistant, **unit_kw: Any) -> tuple[Any, Any]:
+    """Set up the integration with one ATA unit, returning (entry, mock_client)."""
+    context = create_mock_ata_user_context(
+        buildings=[create_mock_ata_building(units=[create_mock_ata_unit(**unit_kw)])]
+    )
+    return await setup_ata_integration_custom(
+        hass, context, configure_client=_configure_ata_controls
+    )
+
+
 @pytest.mark.asyncio
 async def test_fan_entity_created_for_ata_unit(hass: HomeAssistant) -> None:
     """A unit with fan speeds gets a fan entity."""
-    mock_context = create_mock_ata_user_context()
-    await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    await _setup(hass)
 
     assert hass.states.get(_FAN_ENTITY) is not None
 
@@ -46,13 +53,7 @@ async def test_fan_entity_created_for_ata_unit(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_percentage_reflects_commanded_speed(hass: HomeAssistant) -> None:
     """Speed three of five reports as 60 percent."""
-    mock_unit = create_mock_ata_unit(power=True, set_fan_speed="Three")
-    mock_context = create_mock_ata_user_context(
-        buildings=[create_mock_ata_building(units=[mock_unit])]
-    )
-    await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    await _setup(hass, power=True, set_fan_speed="Three")
 
     assert hass.states.get(_FAN_ENTITY).attributes["percentage"] == 60
 
@@ -60,13 +61,7 @@ async def test_percentage_reflects_commanded_speed(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_percentage_is_none_in_auto(hass: HomeAssistant) -> None:
     """No numbered speed is commanded in auto, so percentage is unknown."""
-    mock_unit = create_mock_ata_unit(power=True, set_fan_speed="Auto")
-    mock_context = create_mock_ata_user_context(
-        buildings=[create_mock_ata_building(units=[mock_unit])]
-    )
-    await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    await _setup(hass, power=True, set_fan_speed="Auto")
 
     state = hass.states.get(_FAN_ENTITY)
     assert state.attributes["percentage"] is None
@@ -76,10 +71,7 @@ async def test_percentage_is_none_in_auto(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_set_percentage_sends_matching_speed(hass: HomeAssistant) -> None:
     """Forty percent of five speeds is speed two."""
-    mock_context = create_mock_ata_user_context()
-    _, mock_client = await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    _, mock_client = await _setup(hass)
 
     await hass.services.async_call(
         "fan",
@@ -95,10 +87,7 @@ async def test_set_percentage_sends_matching_speed(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_set_percentage_zero_powers_the_unit_off(hass: HomeAssistant) -> None:
     """Zero means unit power off, and sends no speed."""
-    mock_context = create_mock_ata_user_context()
-    _, mock_client = await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    _, mock_client = await _setup(hass)
 
     await hass.services.async_call(
         "fan",
@@ -119,13 +108,7 @@ async def test_set_preset_mode_auto(hass: HomeAssistant) -> None:
     when the device already holds the requested value (ADR-018), and the mock
     helper defaults to "Auto".
     """
-    mock_unit = create_mock_ata_unit(power=True, set_fan_speed="Three")
-    mock_context = create_mock_ata_user_context(
-        buildings=[create_mock_ata_building(units=[mock_unit])]
-    )
-    _, mock_client = await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    _, mock_client = await _setup(hass, power=True, set_fan_speed="Three")
 
     await hass.services.async_call(
         "fan",
@@ -140,10 +123,7 @@ async def test_set_preset_mode_auto(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_turn_off_powers_the_unit_down(hass: HomeAssistant) -> None:
     """An air conditioner has no fan-off state, so off means unit power off."""
-    mock_context = create_mock_ata_user_context()
-    _, mock_client = await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    _, mock_client = await _setup(hass)
 
     await hass.services.async_call(
         "fan", "turn_off", {"entity_id": _FAN_ENTITY}, blocking=True
@@ -155,15 +135,7 @@ async def test_turn_off_powers_the_unit_down(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_speed_count_follows_device_capability(hass: HomeAssistant) -> None:
     """A three-speed unit gets three steps, not five."""
-    mock_unit = create_mock_ata_unit(
-        power=True, set_fan_speed="Three", number_of_fan_speeds=3
-    )
-    mock_context = create_mock_ata_user_context(
-        buildings=[create_mock_ata_building(units=[mock_unit])]
-    )
-    await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    await _setup(hass, power=True, set_fan_speed="Three", number_of_fan_speeds=3)
 
     state = hass.states.get(_FAN_ENTITY)
     assert state.attributes["percentage_step"] == pytest.approx(100 / 3)
@@ -173,13 +145,7 @@ async def test_speed_count_follows_device_capability(hass: HomeAssistant) -> Non
 @pytest.mark.asyncio
 async def test_no_fan_entity_without_fan_speeds(hass: HomeAssistant) -> None:
     """A unit reporting no speeds gets no fan entity."""
-    mock_unit = create_mock_ata_unit(number_of_fan_speeds=0)
-    mock_context = create_mock_ata_user_context(
-        buildings=[create_mock_ata_building(units=[mock_unit])]
-    )
-    await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    await _setup(hass, number_of_fan_speeds=0)
 
     assert hass.states.get(_FAN_ENTITY) is None
 
@@ -187,13 +153,7 @@ async def test_no_fan_entity_without_fan_speeds(hass: HomeAssistant) -> None:
 @pytest.mark.asyncio
 async def test_oscillating_true_when_vane_swinging(hass: HomeAssistant) -> None:
     """The API's Swing is the only vane value that oscillates."""
-    mock_unit = create_mock_ata_unit(power=True, vane_vertical="Swing")
-    mock_context = create_mock_ata_user_context(
-        buildings=[create_mock_ata_building(units=[mock_unit])]
-    )
-    await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    await _setup(hass, power=True, vane_vertical="Swing")
 
     assert hass.states.get(_FAN_ENTITY).attributes["oscillating"] is True
 
@@ -204,13 +164,7 @@ async def test_oscillating_false_for_fixed_positions(
     hass: HomeAssistant, vane: str
 ) -> None:
     """Auto is a fixed mode-dependent angle, not a sweep, per the vendor manual."""
-    mock_unit = create_mock_ata_unit(power=True, vane_vertical=vane)
-    mock_context = create_mock_ata_user_context(
-        buildings=[create_mock_ata_building(units=[mock_unit])]
-    )
-    await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    await _setup(hass, power=True, vane_vertical=vane)
 
     assert hass.states.get(_FAN_ENTITY).attributes["oscillating"] is False
 
@@ -218,10 +172,7 @@ async def test_oscillating_false_for_fixed_positions(
 @pytest.mark.asyncio
 async def test_oscillate_on_sends_swing(hass: HomeAssistant) -> None:
     """Turning oscillation on sets the vane to Swing."""
-    mock_context = create_mock_ata_user_context()
-    _, mock_client = await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    _, mock_client = await _setup(hass)
 
     await hass.services.async_call(
         "fan",
@@ -241,13 +192,7 @@ async def test_oscillate_off_sends_auto(hass: HomeAssistant) -> None:
     would switch oscillation off from, and because the control client skips a
     write matching the device's current value (ADR-018).
     """
-    mock_unit = create_mock_ata_unit(power=True, vane_vertical="Swing")
-    mock_context = create_mock_ata_user_context(
-        buildings=[create_mock_ata_building(units=[mock_unit])]
-    )
-    _, mock_client = await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
+    _, mock_client = await _setup(hass, power=True, vane_vertical="Swing")
 
     await hass.services.async_call(
         "fan",
@@ -259,18 +204,6 @@ async def test_oscillate_off_sends_auto(hass: HomeAssistant) -> None:
     assert mock_client.ata.set_vane_vertical.call_args[0][1] == "Auto"
 
 
-async def _setup_one_unit(hass: HomeAssistant, **unit_kwargs: Any) -> Any:
-    """Set up the integration with a single ATA unit built from unit_kwargs."""
-    mock_context = create_mock_ata_user_context(
-        buildings=[
-            create_mock_ata_building(units=[create_mock_ata_unit(**unit_kwargs)])
-        ]
-    )
-    return await setup_ata_integration_custom(
-        hass, mock_context, configure_client=_configure_ata_controls
-    )
-
-
 @pytest.mark.asyncio
 async def test_turn_on_preserves_the_operation_mode(hass: HomeAssistant) -> None:
     """Power-on carries the mode, so no operationMode=null reaches the API.
@@ -278,7 +211,7 @@ async def test_turn_on_preserves_the_operation_mode(hass: HomeAssistant) -> None
     A bare power write can fault a multi-zone outdoor unit. The unit starts off
     because the control client skips a write the device already satisfies.
     """
-    _, mock_client = await _setup_one_unit(hass, power=False, operation_mode="Heat")
+    _, mock_client = await _setup(hass, power=False, operation_mode="Heat")
 
     await hass.services.async_call(
         "fan", "turn_on", {"entity_id": _FAN_ENTITY}, blocking=True
@@ -293,7 +226,7 @@ async def test_turn_on_with_percentage_sets_power_and_speed(
     hass: HomeAssistant,
 ) -> None:
     """turn_on(percentage=40) powers on and commands speed two of five."""
-    _, mock_client = await _setup_one_unit(
+    _, mock_client = await _setup(
         hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
     )
 
@@ -313,7 +246,7 @@ async def test_turn_on_with_auto_preset_sets_power_and_speed(
     hass: HomeAssistant,
 ) -> None:
     """HomeKit's Auto toggle routes through turn_on, so it must power on too."""
-    _, mock_client = await _setup_one_unit(
+    _, mock_client = await _setup(
         hass, power=False, operation_mode="Heat", set_fan_speed="Three"
     )
 
@@ -335,7 +268,7 @@ async def test_set_percentage_powers_on_an_off_unit(hass: HomeAssistant) -> None
     The bridge sends Active=1 and RotationSpeed in one write and then skips
     fan.turn_on, so set_percentage alone has to power the unit on.
     """
-    _, mock_client = await _setup_one_unit(
+    _, mock_client = await _setup(
         hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
     )
 
@@ -353,6 +286,6 @@ async def test_set_percentage_powers_on_an_off_unit(hass: HomeAssistant) -> None
 @pytest.mark.asyncio
 async def test_no_oscillation_without_a_vane(hass: HomeAssistant) -> None:
     """A unit with neither swing nor air direction gets no oscillate control."""
-    await _setup_one_unit(hass, power=True, has_swing=False, has_air_direction=False)
+    await _setup(hass, power=True, has_swing=False, has_air_direction=False)
 
     assert "oscillating" not in hass.states.get(_FAN_ENTITY).attributes

--- a/tests/integration/test_fan_ata.py
+++ b/tests/integration/test_fan_ata.py
@@ -5,11 +5,14 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
+from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
 from .conftest import (
     create_mock_ata_building,
@@ -40,6 +43,25 @@ async def _setup(hass: HomeAssistant, **unit_kw: Any) -> tuple[Any, Any]:
     return await setup_ata_integration_custom(
         hass, context, configure_client=_configure_ata_controls
     )
+
+
+async def _set_percentage(hass: HomeAssistant, percentage: int) -> None:
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {"entity_id": _FAN_ENTITY, "percentage": percentage},
+        blocking=True,
+    )
+
+
+async def _let_the_speed_write_land(hass: HomeAssistant) -> None:
+    """Advance HA's clock past the fan's speed debounce window.
+
+    The write is scheduled with async_call_later, so firing the loop's timers is
+    enough - no real time passes and nothing here is timing-dependent.
+    """
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+    await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio
@@ -73,12 +95,8 @@ async def test_set_percentage_sends_matching_speed(hass: HomeAssistant) -> None:
     """Forty percent of five speeds is speed two."""
     _, mock_client = await _setup(hass)
 
-    await hass.services.async_call(
-        "fan",
-        "set_percentage",
-        {"entity_id": _FAN_ENTITY, "percentage": 40},
-        blocking=True,
-    )
+    await _set_percentage(hass, 40)
+    await _let_the_speed_write_land(hass)
 
     mock_client.ata.set_fan_speed.assert_called_once()
     assert mock_client.ata.set_fan_speed.call_args[0][1] == "Two"
@@ -89,12 +107,8 @@ async def test_set_percentage_zero_powers_the_unit_off(hass: HomeAssistant) -> N
     """Zero means unit power off, and sends no speed."""
     _, mock_client = await _setup(hass)
 
-    await hass.services.async_call(
-        "fan",
-        "set_percentage",
-        {"entity_id": _FAN_ENTITY, "percentage": 0},
-        blocking=True,
-    )
+    await _set_percentage(hass, 0)
+    await _let_the_speed_write_land(hass)
 
     assert mock_client.ata.set_power.call_args[0][1] is False
     mock_client.ata.set_fan_speed.assert_not_called()
@@ -222,6 +236,35 @@ async def test_turn_on_preserves_the_operation_mode(hass: HomeAssistant) -> None
 
 
 @pytest.mark.asyncio
+async def test_turn_on_with_percentage_supersedes_a_pending_drag_write(
+    hass: HomeAssistant,
+) -> None:
+    """An explicit turn_on is a single deliberate command, not a drag.
+
+    It writes without waiting on the debounce window, and the pending write from
+    the drag it interrupted must not land afterwards and undo it.
+    """
+    _, mock_client = await _setup(
+        hass, power=True, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    await _set_percentage(hass, 20)
+    await hass.services.async_call(
+        "fan",
+        "turn_on",
+        {"entity_id": _FAN_ENTITY, "percentage": 100},
+        blocking=True,
+    )
+
+    mock_client.ata.set_fan_speed.assert_called_once()
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Five"
+
+    await _let_the_speed_write_land(hass)
+
+    mock_client.ata.set_fan_speed.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_turn_on_with_percentage_sets_power_and_speed(
     hass: HomeAssistant,
 ) -> None:
@@ -272,47 +315,98 @@ async def test_set_percentage_powers_on_an_off_unit(hass: HomeAssistant) -> None
         hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
     )
 
-    await hass.services.async_call(
-        "fan",
-        "set_percentage",
-        {"entity_id": _FAN_ENTITY, "percentage": 60},
-        blocking=True,
-    )
+    await _set_percentage(hass, 60)
+    await _let_the_speed_write_land(hass)
 
     assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
     assert mock_client.ata.set_fan_speed.call_args[0][1] == "Three"
 
 
 @pytest.mark.asyncio
-async def test_set_percentage_burst_powers_on_exactly_once(
+async def test_set_percentage_burst_writes_only_the_final_speed(
     hass: HomeAssistant,
 ) -> None:
-    """A HomeKit slider drag issues several set_percentage calls in quick
-    succession, each preceded by a power-on. The shared write-dedup can't
-    suppress the repeats (it reads coordinator data that stays stale for the
-    whole debounced-refresh window), so fan.py's own guard must collapse them
-    to a single power write, while each distinct speed still gets sent.
+    """Regression test for #318.
+
+    A HomeKit slider drag issues several set_percentage calls in quick
+    succession. Issuing a write per intermediate position let them overlap in
+    flight, and the server applies overlapping writes in arrival order rather
+    than issue order: a drag ending on Three was observed writing Two, Three,
+    Three, Three and settling on Two. Only the position the user released on may
+    reach the API, which also collapses the power-on burst to a single write.
     """
     _, mock_client = await _setup(
         hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
     )
 
     for percentage in (20, 40, 60):
-        await hass.services.async_call(
-            "fan",
-            "set_percentage",
-            {"entity_id": _FAN_ENTITY, "percentage": percentage},
-            blocking=True,
-        )
+        await _set_percentage(hass, percentage)
+    await _let_the_speed_write_land(hass)
 
     assert mock_client.ata.set_power_and_mode.call_count == 1
     assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
-    assert mock_client.ata.set_fan_speed.call_count == 3
-    assert [c[0][1] for c in mock_client.ata.set_fan_speed.call_args_list] == [
-        "One",
-        "Two",
-        "Three",
-    ]
+    mock_client.ata.set_fan_speed.assert_called_once()
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Three"
+
+
+@pytest.mark.asyncio
+async def test_set_percentage_burst_powers_on_immediately(
+    hass: HomeAssistant,
+) -> None:
+    """The power-on is not debounced along with the speed.
+
+    Verified on hardware: the unit must start the moment the drag begins, not
+    half a second after it ends. So before the clock advances, the power write
+    has already gone and the speed write has not.
+    """
+    _, mock_client = await _setup(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    for percentage in (20, 40, 60):
+        await _set_percentage(hass, percentage)
+
+    assert mock_client.ata.set_power_and_mode.call_count == 1
+    mock_client.ata.set_fan_speed.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dragging_through_zero_does_not_power_off(
+    hass: HomeAssistant,
+) -> None:
+    """Passing the zero detent mid-drag must not stop the unit.
+
+    Only the released position counts, so a drag from low through zero and back
+    up sends one speed and no power-off. The unit starts on, so a power-off
+    write would really be issued rather than skipped by the write-dedup.
+    """
+    _, mock_client = await _setup(
+        hass, power=True, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    for percentage in (40, 0, 80):
+        await _set_percentage(hass, percentage)
+    await _let_the_speed_write_land(hass)
+
+    mock_client.ata.set_power.assert_not_called()
+    mock_client.ata.set_fan_speed.assert_called_once()
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Four"
+
+
+@pytest.mark.asyncio
+async def test_pending_speed_write_is_dropped_when_the_entity_goes_away(
+    hass: HomeAssistant,
+) -> None:
+    """Unloading the entry must leave no write scheduled behind it."""
+    entry, mock_client = await _setup(
+        hass, power=True, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    await _set_percentage(hass, 60)
+    await hass.config_entries.async_unload(entry.entry_id)
+    await _let_the_speed_write_land(hass)
+
+    mock_client.ata.set_fan_speed.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -327,12 +421,7 @@ async def test_turn_on_still_powers_on_after_a_set_percentage_burst(
         hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
     )
 
-    await hass.services.async_call(
-        "fan",
-        "set_percentage",
-        {"entity_id": _FAN_ENTITY, "percentage": 20},
-        blocking=True,
-    )
+    await _set_percentage(hass, 20)
     await hass.services.async_call(
         "fan", "turn_on", {"entity_id": _FAN_ENTITY}, blocking=True
     )

--- a/tests/integration/test_fan_ata.py
+++ b/tests/integration/test_fan_ata.py
@@ -5,15 +5,19 @@ Reference: docs/testing-best-practices.md
 Run with: make test-integration
 """
 
+import asyncio
 from datetime import timedelta
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
+from custom_components.melcloudhome import fan as fan_module
+from custom_components.melcloudhome.api.exceptions import ApiError
 from custom_components.melcloudhome.const import DOMAIN
 
 from .conftest import (
@@ -23,18 +27,14 @@ from .conftest import (
     setup_ata_integration_custom,
 )
 
+# The climate tests already mock every ATA control this platform can reach, and
+# then some; a second copy here would only drift out of step with it.
+from .test_climate_ata import _configure_ata_controls
+
 # melcloudhome_<first4><last4> from create_device_info, plus the slug of
 # _attr_name. Confirmed: slugify("melcloudhome_a1b2_9abc A/C fan", separator="_")
 # gives this, and the same call on "... Climate" gives the climate constant.
 _FAN_ENTITY = "fan.melcloudhome_a1b2_9abc_a_c_fan"
-
-
-def _configure_ata_controls(client: Any) -> None:
-    client.ata = MagicMock()
-    client.ata.set_power = AsyncMock()
-    client.ata.set_power_and_mode = AsyncMock()
-    client.ata.set_fan_speed = AsyncMock()
-    client.ata.set_vane_vertical = AsyncMock()
 
 
 async def _setup(hass: HomeAssistant, **unit_kw: Any) -> tuple[Any, Any]:
@@ -64,6 +64,31 @@ async def _let_the_speed_write_land(hass: HomeAssistant) -> None:
     """
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
     await hass.async_block_till_done()
+
+
+async def _let_tasks_run() -> None:
+    """Give already-created tasks room to reach their next suspension point.
+
+    Yields to the event loop a fixed number of times. Nothing sleeps and no real
+    time passes, so this stays deterministic: every mock in play completes
+    without awaiting anything real, so the only thing that can still be holding a
+    task afterwards is the test's own gate.
+    """
+    for _ in range(20):
+        await asyncio.sleep(0)
+
+
+async def _power_off_via_service(hass: HomeAssistant) -> None:
+    """Tap the tile off."""
+    await hass.services.async_call(
+        "fan", "turn_off", {"entity_id": _FAN_ENTITY}, blocking=True
+    )
+
+
+async def _power_off_via_slider(hass: HomeAssistant) -> None:
+    """Drag to the zero detent and leave it there, so the write actually lands."""
+    await _set_percentage(hass, 0)
+    await _let_the_speed_write_land(hass)
 
 
 @pytest.mark.asyncio
@@ -372,30 +397,10 @@ async def test_set_percentage_burst_writes_only_the_final_speed(
     than issue order: a drag ending on Three was observed writing Two, Three,
     Three, Three and settling on Two. Only the position the user released on may
     reach the API, which also collapses the power-on burst to a single write.
-    """
-    _, mock_client = await _setup(
-        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
-    )
 
-    for percentage in (20, 40, 60):
-        await _set_percentage(hass, percentage)
-    await _let_the_speed_write_land(hass)
-
-    assert mock_client.ata.set_power_and_mode.call_count == 1
-    assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
-    mock_client.ata.set_fan_speed.assert_called_once()
-    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Three"
-
-
-@pytest.mark.asyncio
-async def test_set_percentage_burst_powers_on_immediately(
-    hass: HomeAssistant,
-) -> None:
-    """The power-on is not debounced along with the speed.
-
-    Verified on hardware: the unit must start the moment the drag begins, not
-    half a second after it ends. So before the clock advances, the power write
-    has already gone and the speed write has not.
+    The power-on is not deferred with the speed. Verified on hardware: the unit
+    must start the moment the drag begins, not half a second after it ends,
+    hence the assertions before the clock is advanced as well as after.
     """
     _, mock_client = await _setup(
         hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
@@ -406,6 +411,142 @@ async def test_set_percentage_burst_powers_on_immediately(
 
     assert mock_client.ata.set_power_and_mode.call_count == 1
     mock_client.ata.set_fan_speed.assert_not_called()
+
+    await _let_the_speed_write_land(hass)
+
+    assert mock_client.ata.set_power_and_mode.call_count == 1
+    assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
+    mock_client.ata.set_fan_speed.assert_called_once()
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Three"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_set_percentage_calls_write_the_last_position(
+    hass: HomeAssistant,
+) -> None:
+    """Overlapping set_percentage calls must still write the released position.
+
+    The test above awaits each call to completion, which is the one dispatch
+    pattern the HomeKit bridge never uses: it fires each service call as its own
+    un-awaited task, and Home Assistant takes no per-entity lock, so a drag's
+    calls really do interleave at every await. Here the power-on request is held
+    open so they do, and the later calls arrive while the first is still in
+    flight.
+
+    Two things are asserted, matching the two ordering defects this guards:
+    the pending position and its timer are claimed on entry, so the last call to
+    arrive wins whatever order the requests finish in; and the guard deadline is
+    armed before the request rather than after, so the calls arriving during it
+    are collapsed into the single power-on it exists to produce.
+    """
+    _, mock_client = await _setup(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    gates: list[asyncio.Event] = []
+
+    async def _hold_the_power_on(*_args: Any, **_kwargs: Any) -> None:
+        gate = asyncio.Event()
+        gates.append(gate)
+        await gate.wait()
+
+    mock_client.ata.set_power_and_mode.side_effect = _hold_the_power_on
+
+    tasks = []
+    for percentage in (20, 40, 60):
+        tasks.append(
+            asyncio.create_task(
+                hass.services.async_call(
+                    "fan",
+                    "set_percentage",
+                    {"entity_id": _FAN_ENTITY, "percentage": percentage},
+                    blocking=True,
+                )
+            )
+        )
+        await _let_tasks_run()
+
+    # Only the first call reached the API; the rest found the guard already
+    # armed and returned without a power write of their own.
+    assert len(gates) == 1
+    assert mock_client.ata.set_power_and_mode.call_count == 1
+
+    for gate in reversed(gates):
+        gate.set()
+        await _let_tasks_run()
+    await asyncio.gather(*tasks)
+    await _let_the_speed_write_land(hass)
+
+    mock_client.ata.set_fan_speed.assert_called_once()
+    assert mock_client.ata.set_fan_speed.call_args[0][1] == "Three"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_power_on_does_not_suppress_the_retry(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Arming the guard before the request must not make a failure stick.
+
+    The deadline goes up before the write is awaited so that a drag's
+    overlapping calls collapse into one power-on rather than one each. If that
+    write then fails the unit is still off, so the deadline has to come back
+    down and let the next call try again.
+
+    The guard window is widened out of the way for the same reason as in
+    test_power_off_disarms_the_power_on_guard: it is measured on the real clock.
+    """
+    monkeypatch.setattr(fan_module, "_POWER_ON_GUARD_WINDOW", 3600.0)
+    _, mock_client = await _setup(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    mock_client.ata.set_power_and_mode.side_effect = ApiError("upstream said no")
+    with pytest.raises(HomeAssistantError):
+        await _set_percentage(hass, 40)
+
+    mock_client.ata.set_power_and_mode.side_effect = None
+    await _set_percentage(hass, 60)
+
+    assert mock_client.ata.set_power_and_mode.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("power_off", [_power_off_via_service, _power_off_via_slider])
+async def test_power_off_disarms_the_power_on_guard(
+    hass: HomeAssistant, power_off: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Turning the unit off must not leave a drag's guard suppressing the restart.
+
+    Reachable entirely from the Home app on a running unit: dragging the slider
+    arms the guard even when the shared write-dedup skipped the API call because
+    the unit was already on, and nothing about that write happening or not
+    clears it. Tap the tile off (or drag to the zero detent), then drag straight
+    back up: the bridge sends Active and RotationSpeed together and deliberately
+    skips fan.turn_on, so it arrives as set_percentage alone. A surviving guard
+    would suppress the power-on and leave the unit off with a speed write landing
+    on it, contradicting docs/homekit.md.
+
+    The unit is modelled as off throughout so the writes reach the API mock
+    rather than being skipped by the write-dedup (ADR-018). The guard window is
+    widened out of the way because it is measured on the real clock, which
+    async_fire_time_changed does not move: at its production three seconds the
+    result would depend on how long the test itself took to run, and the only
+    thing under test here is whether the power-off disarms the guard, not when
+    it would have expired on its own.
+    """
+    monkeypatch.setattr(fan_module, "_POWER_ON_GUARD_WINDOW", 3600.0)
+    _, mock_client = await _setup(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    await _set_percentage(hass, 40)
+    await _let_the_speed_write_land(hass)
+    assert mock_client.ata.set_power_and_mode.call_count == 1
+
+    await power_off(hass)
+    await _set_percentage(hass, 60)
+
+    assert mock_client.ata.set_power_and_mode.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_fan_ata.py
+++ b/tests/integration/test_fan_ata.py
@@ -284,6 +284,63 @@ async def test_set_percentage_powers_on_an_off_unit(hass: HomeAssistant) -> None
 
 
 @pytest.mark.asyncio
+async def test_set_percentage_burst_powers_on_exactly_once(
+    hass: HomeAssistant,
+) -> None:
+    """A HomeKit slider drag issues several set_percentage calls in quick
+    succession, each preceded by a power-on. The shared write-dedup can't
+    suppress the repeats (it reads coordinator data that stays stale for the
+    whole debounced-refresh window), so fan.py's own guard must collapse them
+    to a single power write, while each distinct speed still gets sent.
+    """
+    _, mock_client = await _setup(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    for percentage in (20, 40, 60):
+        await hass.services.async_call(
+            "fan",
+            "set_percentage",
+            {"entity_id": _FAN_ENTITY, "percentage": percentage},
+            blocking=True,
+        )
+
+    assert mock_client.ata.set_power_and_mode.call_count == 1
+    assert mock_client.ata.set_power_and_mode.call_args[0][1:] == (True, "Heat")
+    assert mock_client.ata.set_fan_speed.call_count == 3
+    assert [c[0][1] for c in mock_client.ata.set_fan_speed.call_args_list] == [
+        "One",
+        "Two",
+        "Three",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_turn_on_still_powers_on_after_a_set_percentage_burst(
+    hass: HomeAssistant,
+) -> None:
+    """The drag-burst guard must never make the documented turn_on service
+    unreliable: an explicit fan.turn_on always powers on, even immediately
+    after a set_percentage call already consumed the guard window.
+    """
+    _, mock_client = await _setup(
+        hass, power=False, operation_mode="Heat", set_fan_speed="Auto"
+    )
+
+    await hass.services.async_call(
+        "fan",
+        "set_percentage",
+        {"entity_id": _FAN_ENTITY, "percentage": 20},
+        blocking=True,
+    )
+    await hass.services.async_call(
+        "fan", "turn_on", {"entity_id": _FAN_ENTITY}, blocking=True
+    )
+
+    assert mock_client.ata.set_power_and_mode.call_count == 2
+
+
+@pytest.mark.asyncio
 async def test_no_oscillation_without_a_vane(hass: HomeAssistant) -> None:
     """A unit with neither swing nor air direction gets no oscillate control."""
     await _setup(hass, power=True, has_swing=False, has_air_direction=False)


### PR DESCRIPTION
## Summary

ATA units get a `fan` entity alongside their climate entity, carrying fan speed as a percentage, the vertical vane as oscillation, and unit power (#318). Home Assistant's HomeKit bridge builds a climate entity's speed slider and swing switch only from fixed vocabularies that `ATA_FAN_SPEEDS` and `ATA_VANE_POSITIONS` do not intersect, so a bridged air conditioner publishes as a bare thermostat carrying temperature and mode alone. A fan entity has no vocabulary gate: the bridge builds the slider from `FanEntityFeature.SET_SPEED` and the switch from `OSCILLATE`, both from values the integration computes directly. The climate vocabulary stays as it is, so every advertised list and every reported value is unchanged and existing automations, templates and service calls keep working. [ADR-025](docs/decisions/025-homekit-fan-entity.md) holds the evidence and the rejected alternatives, and [docs/homekit.md](docs/homekit.md) is the new user-facing guide.

## Key changes

- `fan.py` creates one `ATAFan` per air-to-air unit reporting at least one fan speed. A unit reporting none is skipped, because `speed_count` of zero makes `FanEntity.percentage_step` divide by zero on every state update.
- `speed_count` comes from `capabilities.number_of_fan_speeds`, which the bridge turns into the slider's step, putting one detent on each real speed.
- `auto` is the sole preset mode, because a percentage cannot express it. Being alone is deliberate: at exactly one preset the bridge appends HomeKit's Auto toggle. While `auto` is selected, `percentage` reports the last numbered speed seen, so leaving Auto resumes the speed the user chose rather than the bridge's hard-coded 50%; it is unknown only before any numbered speed has been seen.
- Only the position a slider settles on is written, half a second after it stops moving. The server applies overlapping speed writes in arrival order, so a burst of intermediate positions can settle the unit on an earlier value than the one the user released on.
- Repeat power-on writes inside one drag are suppressed for three seconds, covering the debounced refresh that leaves the shared write-dedup reading stale coordinator data. An explicit `fan.turn_on` never takes that suppression.
- Each power-on carries the device's current `operation_mode`, so the write does not send `operationMode=null` at a multi-zone outdoor unit.
- `OSCILLATE` is declared only where `capabilities.has_swing` or `has_air_direction` is set, the gate the climate entity already puts on `SWING_MODE`. Oscillation reads `vane_vertical_direction == "Swing"` and switching it off writes `Auto`, touching the vane alone, so a swing toggle leaves a stopped unit stopped.
- `async_set_percentage` is implemented rather than inherited, because the inherited one routes zero to `async_turn_off` without returning and then sends a speed as well. Zero means unit power off and nothing else.
- `test_fan_ata.py` covers the platform in 25 tests through `hass.states` and `hass.services`, and `test_climate_ata.py` pins `fan_modes` and `swing_modes` against a future tidy-up with ADR-025's reasoning in the docstring.
- The `auto` preset label is translated in all fourteen language files, `docs/homekit.md` is new, and `docs/README.md`'s ADR index now carries 023 to 025.
- `docker-compose.dev.yml` caps the dev containers' json-file logs at 10m across 3 files. Dev tooling, touching no integration code.

## What changes for users

- Every ATA unit gains a fan entity, named "A/C fan" under the device. Fan speed becomes settable from two places, this entity and the climate entity's `fan_mode` dropdown; both read one coordinator field, so they cannot disagree.
- Turning the fan entity off powers the air conditioner off, because an air conditioner has no "fan off, unit running" state. An entity in the `fan` domain is exposed to assistants like any other fan, so the same applies wherever it is exposed. Anyone who wants the unit running quietly instead can set the lowest speed, and anyone who wants none of this can exclude the `fan` domain from their assistant exposure.
- A HomeKit Bridge configured with a domain filter such as `include_domains: [climate]` needs `fan` adding to it, otherwise the entity is not bridged and the new tile never appears.
- The Home app renders the name with a hyphen, "Living Room A-C fan", because the bridge substitutes one for the slash in the entity name.
- Apple decides where it puts each fan control. Tapping the tile's icon toggles power, tapping its label opens the speed slider, and Oscillate and Fan Mode sit behind the cog in that view, with nothing on the slider to hint they are there. [docs/homekit.md](docs/homekit.md) walks through it.
- With exactly one preset mode, HA's fan more-info dialog renders no preset selector, so `auto` is reachable from the climate entity's `fan_mode` dropdown or a `fan.set_preset_mode` call.
- Through HomeKit the vane is binary. Positions one to five stay reachable from Home Assistant, and switching oscillation off returns the vane to `Auto` rather than to the position it held before.
- In `auto` the Home app's accessory title shows the speed the unit will resume rather than the speed it is running, because the bridge reads one `percentage` attribute for both that title and its Manual fallback. The speed the unit is actually running stays in the Actual Fan Speed sensor. ADR-025 records why the title is preferred over a slider that springs back.

## Risks accepted

- The power-on guard reads its deadline and arms it either side of an `await`, so two overlapping `set_percentage` tasks could both pass the check. The cost is two power writes where one would do, visible as a duplicated power write against one gesture in the API log. `PARALLEL_UPDATES = 1` in `fan.py` would serialise the platform's service calls and undo it; the integration sets that nowhere today, so it would be a new convention introduced for one platform. The shared dedup in `control_client_ata` has the same shape.
- `_async_power_on` falls back to a bare power write when the device reports no `operation_mode`, which reopens the `operationMode=null` window. `climate_ata.py` has carried the identical fallback all along, so this is a second caller of an existing shape, and tightening it would move both entities together.

## AI Disclosure

- [ ] No AI/agent tooling was used
- [x] AI/agent tooling assisted; I reviewed and ran the change myself before submitting

## Testing

- [x] `make test-api`: 409 passed, 1 skipped, 16 deselected, 1 xfailed.
- [x] `make test-integration`: 307 passed. The one warning is a `PytestCacheWarning` from the read-only `tests/` mount in `docker-compose.test.yml`, which this diff does not touch.
- [x] `make test-e2e`: 16 passed, 411 deselected.
- [x] `make pre-commit`: the full hook set passed at push time on this branch.
- The three suites above ran on a clean tree at `b7885ff`. Every commit from there to the tip touches documentation only, so no result can have moved with it.
- [x] Home app gestures against a paired bridge on real ATA units, prod, 2026-09-12, with prod's logs read back for the API writes each gesture produced: dragging the slider up from off costs one power-and-mode write plus one speed write and lands where released; dragging on a running unit costs one speed write; five deliberate steps 3.5 to 4 seconds apart each registered their own write; dragging to zero powers the unit off and retains the commanded speed; Oscillate on and off cost one write each, the vane was seen physically swinging, and Oscillate on left an off unit off; Fan Mode to Auto costs one write and the preset carries auto; Auto back to Manual returns to the speed the user chose, tested from speed five so that HomeKit's hard-coded fallback to speed three would show; powering off from the thermostat tile's own mode dropdown carries the fan entity with it, both entities still agreeing on speed; the fan tile's icon toggle powers on with no speed write and carries the operation mode.
- [x] HomeKit accessory structure on prod, read from the bridge's own iids store: both bridged fan accessories carry a Fanv2 service with Active, SwingMode, RotationSpeed and TargetFanState, and both climate accessories match their pre-change baseline. In the Home app, opening the tile gives the speed slider alone, with Oscillate and Fan Mode behind the cog in that view.
- [x] The capability gate holds at the HomeKit layer: real ATA units reporting no vane exist in the installation this was verified against, and such a unit's accessory has no SwingMode characteristic, so it gets no swing switch wired to hardware that cannot swing.
- [x] Devserver, HA 2026.7.1 against the mock server: the fan platform loads with no errors across both dev entries, `percentage_step` is 20 on five-speed units and 33.33 on three-speed ones, and `supported_features` is 51 on units reporting a vane and 49 on units reporting none, which expose no `oscillating` attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
